### PR TITLE
Update bitsadmin.md with powershell equivalent.

### DIFF
--- a/Windows/Execution/Bitsadmin.md
+++ b/Windows/Execution/Bitsadmin.md
@@ -1,3 +1,11 @@
+## BITS Jobs
+
+MITRE ATT&CK Technique: [T1197](https://attack.mitre.org/wiki/Technique/T1197)
+
 ### bitsadmin.exe
 
     bitsadmin.exe  /transfer /Download /priority Foreground https://raw.githubusercontent.com/redcanaryco/atomic-red-team/master/Windows/Execution/Bitsadmin.md $env:TEMP\AtomicRedTeam\bitsadmin_flag.ps1
+
+### PowerShell
+
+    Start-BitsTransfer -Priority foreground -Source https://raw.githubusercontent.com/redcanaryco/atomic-red-team/master/Windows/Execution/Bitsadmin.md -Destination $env:TEMP\AtomicRedTeam\bitsadmin_flag.ps1


### PR DESCRIPTION
- Format `Windows/Execution/bitsadmin.md` in line with other docs
- Add PowerShell equivalent of current download command

Note: `bitsadmin.exe` will be deprecated in favour of powershell and fails often with below error.

```Unable to complete job - 0x80200002
The requested action is not allowed in the current job state. The job is read-only. The job may have been canceled or completed transferring.```