### PR TITLE
Add new_atomic.rb script that creates a new atomic tests file for a t…

### DIFF
--- a/atomics/spec.yaml
+++ b/atomics/spec.yaml
@@ -22,8 +22,8 @@
 #
 # To validate your atomics, run `atomic-red-team/validate_atomics.rb`
 ---
-attack_technique: TXXXX (with a capital T, Example: 'T1123')
-display_name: Name of the technique as defined by ATT&CK. Example: 'Audio Capture'
+attack_technique: TXXXX # (with a capital T, Example: 'T1123')
+display_name: Name of the technique as defined by ATT&CK. # Example: 'Audio Capture'
 
 # `atomic_tests` is an array of distinct test cases inside this technique. A test case should
 # include ALL of the information needed to run that test (ie, this is the "atomic" - you don't
@@ -34,7 +34,7 @@ atomic_tests:
 #
 # This is the first atomic test
 #
-- name: Short name of the test that titles how it tests the technique. Example: "SourceRecorder via cmd.exe"
+- name: Short name of the test that titles how it tests the technique. # Example: "SourceRecorder via cmd.exe"
   description: |
     Long form description of the test. Markdown is supported so you can **bold** items, create
 

--- a/atomics/template.yaml
+++ b/atomics/template.yaml
@@ -1,0 +1,26 @@
+---
+attack_technique: TODO
+display_name: TODO
+
+atomic_tests:
+- name: TODO
+  description: |
+    TODO
+
+  supported_platforms:
+    - windows
+    - macos
+    - centos
+    - ubuntu
+    - linux
+
+  input_arguments:
+    output_file:
+      description: TODO
+      type: todo
+      default: TODO
+
+  executors:
+    name: TODO
+    command: |
+      TODO

--- a/new_atomic.rb
+++ b/new_atomic.rb
@@ -1,0 +1,39 @@
+#! /usr/bin/env ruby
+require 'yaml'
+require 'fileutils'
+
+def usage!
+  $stderr.puts "Usage: new_atomic.rb <technique identifier (ex: T1234)>"
+  exit 1
+end
+
+def template_technique_tests(technique_id=nil)
+  template = File.read "#{File.dirname(__FILE__)}/atomics/template.yaml"
+  template.gsub! /attack_technique: TODO/, "attack_technique: #{technique_id.upcase}" if technique_id
+  template
+end
+
+def template_technique_atomic_test
+  # hacky way to extract out everything after the "atomic_tests:" element
+  # would do this by loading the yaml except that loses any comments we put in the template
+  template_technique_tests.gsub /.*atomic_tests:\n(.*)/m, '\1'
+end
+
+technique_id = ARGV[0]
+usage! if technique_id.nil?
+
+technique_id = technique_id.downcase 
+technique_atomic_test_file = "#{File.dirname(__FILE__)}/atomics/#{technique_id}/#{technique_id}.yaml"
+
+if File.exists? technique_atomic_test_file
+  puts "Atomic tests for #{technique_id} already exist - adding a new atomic test to the end"
+  File.open(technique_atomic_test_file, 'a') { |f| f.write("\n#{template_technique_atomic_test}") }
+
+else
+  puts "Atomic tests for #{technique_id} do not already exist - creating from template"
+  FileUtils.mkdir_p File.dirname(technique_atomic_test_file)
+  File.open(technique_atomic_test_file, 'w') { |f| f.write(template_technique_tests(technique_id)) }
+end
+
+# open the file in the default editor
+exec("#{ENV.fetch('EDITOR', 'vi')} '#{technique_atomic_test_file}'")

--- a/validate_atomics.rb
+++ b/validate_atomics.rb
@@ -108,7 +108,8 @@ end
 oks = []
 fails = []
 
-Dir["#{File.dirname(__FILE__)}/atomics/t*/t*.yaml"].sort.each do |path|
+(Dir["#{File.dirname(__FILE__)}/atomics/t*/t*.yaml"] + 
+ Dir["#{File.dirname(__FILE__)}/atomics/template.yaml"]).sort.each do |path|
   begin
     print "Validating #{path}..."
     validate_is_yaml! path


### PR DESCRIPTION
This adds a script that makes it simple to add a new atomic test.

# Demo creating a new technique that has no existing tests
```
atomic-red-team bb$ ./new_atomic.rb t1234
Atomic tests for t1234 do not already exist - creating from template

atomic-red-team bb$ git status
On branch atomic-creation-script
Your branch is up to date with 'origin/atomic-creation-script'.

Untracked files:
  (use "git add <file>..." to include in what will be committed)

	atomics/t1234/

nothing added to commit but untracked files present (use "git add" to track)

atomic-red-team bb$ cat atomics/t1234/t1234.yaml 
---
attack_technique: T1234
display_name: TODO

atomic_tests:
- name: TODO
  description: |
    TODO

  supported_platforms:
    - windows
    - macos
    - centos
    - ubuntu
    - linux

  input_arguments:
    output_file:
      description: TODO
      type: todo
      default: TODO

  executors:
    name: TODO
    command: |
      TODO
```

# Demo adding a new test to an existing technique
```
atomic-red-team bb$ ./new_atomic.rb t1234
Atomic tests for t1234 already exist - adding a new atomic test to the end

atomic-red-team bb$ cat atomics/t1234/t1234.yaml 
---
attack_technique: T1234
display_name: TODO

atomic_tests:
- name: TODO
  description: |
    TODO

  supported_platforms:
    - windows
    - macos
    - centos
    - ubuntu
    - linux

  input_arguments:
    output_file:
      description: TODO
      type: todo
      default: TODO

  executors:
    name: TODO
    command: |
      TODO

- name: TODO
  description: |
    TODO

  supported_platforms:
    - windows
    - macos
    - centos
    - ubuntu
    - linux

  input_arguments:
    output_file:
      description: TODO
      type: todo
      default: TODO

  executors:
    name: TODO
    command: |
      TODO
```