### PR TITLE
Fixed variable sign in T1077

### DIFF
--- a/atomics/T1077/T1077.yaml
+++ b/atomics/T1077/T1077.yaml
@@ -30,4 +30,4 @@ atomic_tests:
   executor:
     name: command_prompt
     command: |
-      cmd.exe /c "net use \\#{computer_name}\${share_name} #{password} /u:#{user_name}"
+      cmd.exe /c "net use \\#{computer_name}\#{share_name} #{password} /u:#{user_name}"


### PR DESCRIPTION
Just fixed one thing... trying to pull in the YAML files for some automation and noticed that one of the variable substitutions didn't work as expected.  Seems that it should have been a # instead of a $ unless I'm missing something. 