### PR TITLE
Added Cylance to T1063

### DIFF
--- a/atomics/T1063/T1063.yaml
+++ b/atomics/T1063/T1063.yaml
@@ -15,9 +15,10 @@ atomic_tests:
     command: |
       netsh.exe advfirewall firewall show all profiles
       tasklist.exe
-      tasklist.exe | findstr virus
-      tasklist.exe | findstr cb
-      tasklist.exe | findstr defender
+      tasklist.exe | findstr /i virus
+      tasklist.exe | findstr /i cb
+      tasklist.exe | findstr /i defender
+      tasklist.exe | findstr /i cylance
 
 - name: Security Software Discovery - powershell
   description: |
@@ -32,6 +33,7 @@ atomic_tests:
       powershell.exe get-process | ?{$_.Description -like "*virus*"}
       powershell.exe get-process | ?{$_.Description -like "*carbonblack*"}
       powershell.exe get-process | ?{$_.Description -like "*defender*"}
+      powershell.exe get-process | ?{$_.Description -like "*cylance*"}
 
 - name: Security Software Discovery - ps
   description: |


### PR DESCRIPTION
Added Cylance to 'Security Software Discovery' as well as added the case insensitive switch to the existing processes. Without it, the simple query of "*cylance*" would fail, I did not verify if the others would fail, but figured the most effective approach as a penetration tester would be to include the /i or know the exact case-sensitivity of the process. 