### PR TITLE
Readme - Contribution link fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Join the community on Slack at [https://atomicredteam.slack.com](https://atomicr
   - Windows [Tests](atomics/windows-index.md) and [Matrix](atomics/windows-matrix.md)
   - macOS [Tests](atomics/macos-index.md) and [Matrix](atomics/macos-matrix.md)
   - Linux [Tests](atomics/linux-index.md) and [Matrix](atomics/linux-matrix.md)
-* [Fork](https://github.com/redcanaryco/atomic-red-team/fork) and [Contribute](https://atomicredteam.io/contributing/) your own modifications
+* [Fork](https://github.com/redcanaryco/atomic-red-team/fork) and [Contribute](https://atomicredteam.io/contributing) your own modifications
 * [Doing more with Atomic Red Team](#doing-more-with-atomic-red-team)
     * [Using the Atomic Red Team Ruby API](#using-the-atomic-red-team-ruby-api)
     * [Bonus APIs: Ruby ATT&CK API](#bonus-apis-ruby-attck-api)


### PR DESCRIPTION
Just removed a "/" at the end of the link which was throwing a 404 upon clicking the link.