### PR TITLE
Systemd Service Creation Test

### DIFF
--- a/atomics/RC13378/RC13378.yaml
+++ b/atomics/RC13378/RC13378.yaml
@@ -1,0 +1,73 @@
+---
+attack_technique: RC13378
+display_name: Systemd Service Creation
+
+atomic_tests:
+- name: Create Systemd Service
+  description: |
+    This test creates a Systemd service unit file and enables it as a service.
+
+  supported_platforms:
+    - linux
+
+  input_arguments:
+    execstart_action:
+      description: ExecStart action for Systemd service
+      type: String
+      default: /bin/touch /tmp/art-systemd-execstart-marker
+    execstartpre_action:
+      description: ExecStartPre action for Systemd service
+      type: String
+      default: /bin/touch /tmp/art-systemd-execstartpre-marker
+    execstartpost_action:
+      description: ExecStartPost action for Systemd service
+      type: String
+      default: /bin/touch /tmp/art-systemd-execstartpost-marker
+    execreload_action:
+      description: ExecReload action for Systemd service
+      type: String
+      default: /bin/touch /tmp/art-systemd-execreload-marker
+    execstop_action:
+      description: ExecStop action for Systemd service
+      type: String
+      default: /bin/touch /tmp/art-systemd-execstop-marker
+    execstoppost_action:
+      description: ExecStopPost action for Systemd service
+      type: String
+      default: /bin/touch /tmp/art-systemd-execstoppost-marker
+
+  executor:
+    name: bash
+    command: |
+      echo "[Unit]" > /etc/systemd/system/art-systemd-service.service
+      echo "Description=Atomic Red Team Systemd Service" >> /etc/systemd/system/art-systemd-service.service
+      echo "" >> /etc/systemd/system/art-systemd-service.service
+      echo "[Service]" >> /etc/systemd/system/art-systemd-service.service
+      echo "Type=simple"
+      echo "ExecStart=#{execstart_action}" >> /etc/systemd/system/art-systemd-service.service
+      echo "ExecStartPre=#{execstartpre_action}" >> /etc/systemd/system/art-systemd-service.service
+      echo "ExecStartPost=#{execstartpost_action}" >> /etc/systemd/system/art-systemd-service.service
+      echo "ExecReload=#{execreload_action}" >> /etc/systemd/system/art-systemd-service.service
+      echo "ExecStop=#{execstop_action}" >> /etc/systemd/system/art-systemd-service.service
+      echo "ExecStopPost=#{execstoppost_action}" >> /etc/systemd/system/art-systemd-service.service
+      echo "" >> /etc/systemd/system/art-systemd-service.service
+      echo "[Install]" >> /etc/systemd/system/art-systemd-service.service
+      echo "WantedBy=default.target" >> /etc/systemd/system/art-systemd-service.service
+      systemctl daemon-reload
+      systemctl enable art-systemd-service.service
+      systemctl start art-systemd-service.service
+
+- name: Cleanup Systemd Test
+  description: |
+    This cleans up the remnants of the SystemD service unit file creation test.
+
+  supported_platforms:
+    - linux
+
+  executor:
+    name: bash
+    command: |
+      systemctl stop art-systemd-service.service
+      systemctl disable art-systemd-service.service
+      rm -rf /etc/systemd/system/art-systemd-service.service
+      systemctl daemon-reload


### PR DESCRIPTION
Adding a test for a contribution submission to MITRE ATT&CK Framework, hopefully it gets added. Covers the creation of Linux Systemd service unit file creation for persistence.