### PR TITLE
Added T1165 Startup Items emond rules test

### DIFF
--- a/atomics/T1165/T1165.yaml
+++ b/atomics/T1165/T1165.yaml
@@ -17,7 +17,7 @@ atomic_tests:
     steps: |
       1. /Library/StartupItems/StartupParameters.plist
 
-- name: Launch Daemon (emond rule)
+- name: Startup Items (emond rule)
   description: |
     Establish persistence via a rule run by emond daemon at startup, based on https://posts.specterops.io/leveraging-emond-on-macos-for-persistence-a040a2785124
 

--- a/atomics/T1165/T1165.yaml
+++ b/atomics/T1165/T1165.yaml
@@ -16,3 +16,25 @@ atomic_tests:
     name: manual
     steps: |
       1. /Library/StartupItems/StartupParameters.plist
+
+- name: Launch Daemon (emond rule)
+  description: |
+    Establish persistence via a rule run by emond daemon at startup, based on https://posts.specterops.io/leveraging-emond-on-macos-for-persistence-a040a2785124
+
+  supported_platforms:
+    - macos
+
+  input_arguments:
+    plist:
+      description: Path to emond plist file
+      type: path
+      default: /path/to/T1165_emond.plist
+
+  executor:
+    name: sh
+    command: |
+      sudo cp "${plist}" /etc/emond.d/rules/T1165_emond.plist
+      sudo touch /private/var/db/emondClients/T1165
+      #Clean up
+      sudo rm /etc/emond.d/rules/T1165_emond.plist
+      sudo rm /private/var/db/emondClients/T1165

--- a/atomics/T1165/T1165_emond.plist
+++ b/atomics/T1165/T1165_emond.plist
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<array>
+	<dict>
+		<key>name</key>
+		<string>Atomic Red Team T1160</string>
+		<key>enabled</key>
+		<true/>
+		<key>eventTypes</key>
+		<array>
+			<string>startup</string>
+		</array>
+		<key>actions</key>
+		<array>
+			<dict>
+				<key>command</key>
+				<string>/bin/sleep</string>
+				<key>user</key>
+				<string>root</string>
+				<key>arguments</key>
+				<array>
+					<string>30</string>
+				</array>
+				<key>type</key>
+				<string>RunCommand</string>
+			</dict>
+			<dict>
+				<key>command</key>
+				<string>/usr/bin/say</string>
+				<key>user</key>
+				<string>root</string>
+				<key>arguments</key>
+				<array>
+					<string>-v</string>					
+					<string>Karen</string>
+					<string>Hello from Atomic Red Team technique T1165</string>
+				</array>
+				<key>type</key>
+				<string>RunCommand</string>
+			</dict>
+		</array>
+	</dict>
+</array>
+</plist>

--- a/atomics/T1165/T1165_emond.plist
+++ b/atomics/T1165/T1165_emond.plist
@@ -4,7 +4,7 @@
 <array>
 	<dict>
 		<key>name</key>
-		<string>Atomic Red Team T1160</string>
+		<string>Atomic Red Team T1165</string>
 		<key>enabled</key>
 		<true/>
 		<key>eventTypes</key>


### PR DESCRIPTION
Based on xorrior's research: https://posts.specterops.io/leveraging-emond-on-macos-for-persistence-a040a2785124

This test will use the macOS command `say` to speak a greeting from Atomic Red Team test T1165.