### PR TITLE
Fix filenames created by ruby execution framework (go-atomic.rb)

### DIFF
--- a/execution-frameworks/ruby/.gitignore
+++ b/execution-frameworks/ruby/.gitignore
@@ -1,0 +1,3 @@
+*.yaml
+*.yml
+*.json

--- a/execution-frameworks/ruby/go-atomic.rb
+++ b/execution-frameworks/ruby/go-atomic.rb
@@ -256,7 +256,8 @@ begin
                                                    repo_org_branch: options[:repo],
                                                    input_args: input_args
 
-  output_filename = "atomic-test-executor-execution-#{Time.now.utc.iso8601}.yaml"
+  formatted_time =  Time.now.utc.iso8601.gsub(/:/, '.')
+  output_filename = "atomic-test-executor-execution-#{formatted_time}.yaml"
   puts "\n\nEXECUTION COMPLETE"
   puts "  - Writing results to #{output_filename}"
   File.write(output_filename, YAML.dump(execution_plan))


### PR DESCRIPTION
**Details:**
The original `go-atomic.rb` execution framework creates output filenames in the format:

`atomic-test-executor-execution-2018-08-29T20:55:26Z.yaml` 

While this format is valid on most POSIX systems, it's invalid to use a `:` in a filename on Windows. The `:` is used to denote an alternate data stream for NTFS in Windows (NT variants).

This change replaces `:` for `.` when we generate the filename in `go-atomic.rb`. Output files now take the form:

`atomic-test-executor-execution-2018-08-30T18.56.12Z.yaml`

**Testing:**
Changes were tested on macOS with JRuby 9 and system Ruby 2.4. On Windows, the changes were tested with MRI Ruby 2.4.4.

**Associated Issues:**
This addresses #313.