### PR TITLE
Add test for T1112 that modifies registry keys

### DIFF
--- a/atomics/T1112/T1112.yaml
+++ b/atomics/T1112/T1112.yaml
@@ -1,0 +1,85 @@
+---
+attack_technique: T1112
+display_name: Modify Registry
+
+atomic_tests:
+- name: Modify Registry of Current User Profile - cmd
+  description: |
+    Modify the registry of the currently logged in user using reg.exe cia cmd console
+  supported_platforms:
+    - windows
+  executor:
+    name: command_prompt
+    command: |
+      reg add HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced /t REG_DWORD /v HideFileExt /d 1 /f
+      
+- name: Modify Registry of Local Machine - cmd
+  description: |
+    Modify the Local Machine registry RUN key to change Windows Defender executable that should be ran on startup.  This should only be possible when
+    CMD is ran as Administrative rights.
+  supported_platforms:
+    - windows
+  executor:
+    name: command_prompt
+    command: |
+      reg add HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Run /t REG_EXPAND_SZ /v SecurityHealth /d {some_other_executable} /f
+
+- name: Modify Registry of Another User Profile
+  description: |
+    Modify a registry key of each user profile not currently loaded on the machine using both powershell and cmd line tools.
+  supported_platforms:
+    - windows
+  executor:
+    name: powershell
+    command: |
+      # here is an example of using the same method of reg load, but without the New-PSDrive cmdlet.
+      # Here we can load all unloaded user hives and do whatever we want in the location below (comments)
+      $PatternSID = 'S-1-5-21-\d+-\d+\-\d+\-\d+$'
+      
+      Write-Verbose -Message 'Gathering Profile List and loading their registry hives'
+      # Get Username, SID, and location of ntuser.dat for all users
+
+      $ProfileList = @()
+      $ProfileList = Get-ItemProperty 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\ProfileList\*' | Where-Object { $_.PSChildName -match $PatternSID } |
+        Select  @{ name = "SID"; expression = { $_.PSChildName } },
+                @{ name = "UserHive"; expression = { "$($_.ProfileImagePath)\ntuser.dat" } },
+                @{ name = "Username"; expression = { $_.ProfileImagePath -replace '^(.*[\\\/])', '' } }
+        
+      # Get all user SIDs found in HKEY_USERS (ntuder.dat files that are loaded)
+      $LoadedHives = Get-ChildItem Registry::HKEY_USERS | ? { $_.PSChildname -match $PatternSID } | Select @{ name = "SID"; expression = { $_.PSChildName } }
+            
+      $SIDObject = @()
+        
+      foreach ($item in $LoadedHives)
+      {
+          $props = @{
+              SID = $item.SID
+          }
+
+          $TempSIDObject = New-Object -TypeName PSCustomObject -Property $props
+          $SIDObject += $TempSIDObject
+      }
+
+      # We need to use ($ProfileList | Measure-Object).count instead of just ($ProfileList).count because in PS V2
+      # if the count is less than 2 it doesn't work. :)
+      for ($p = 0; $p -lt ($ProfileList | Measure-Object).count; $p++)
+      {
+          for ($l = 0; $l -lt ($SIDObject | Measure-Object).count; $l++)
+          {
+              if (($ProfileList[$p].SID) -ne ($SIDObject[$l].SID))
+              {
+                  $UnloadedHives += $ProfileList[$p].SID
+                  Write-Verbose -Message "Loading Registry hives for $($ProfileList[$p].SID)"
+                  reg load "HKU\$($ProfileList[$p].SID)" "$($ProfileList[$p].UserHive)"
+
+                  Write-Verbose -Message 'Attempting to modify registry keys for each profile'
+                  #####################################################################
+                  reg add "HKEY_CURRENT_USER\$($ProfileList[$p].SID)\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced" /t REG_DWORD /v HideFileExt /d 1 /f
+          }
+      }
+
+      Write-Verbose 'Unloading Registry hives for all users'
+      # Unload ntuser.dat        
+      ### Garbage collection and closing of ntuser.dat ###
+      [gc]::Collect()
+      reg unload "HKU\$($ProfileList[$p].SID)"


### PR DESCRIPTION
**Details:**
<!-- Insert details about this change here. Please include as much detail as possible -->
Adding test for T1112 that modifies registry keys for the current user profile, the local machine, and any additional user profiles that are not currently loaded (logged in user).  

**Testing:**
<!-- Note any testing done, local or automated here. -->
I have tested this on a local VM running Windows 7 and Windows 10 x64.  

**Associated Issues:**
<!-- Please link any issues that this pull request impacts or fixes. -->