### PR TITLE
T1117: Fix path of RegSvr32.sct

### DIFF
--- a/atomics/T1117/T1117.yaml
+++ b/atomics/T1117/T1117.yaml
@@ -11,7 +11,7 @@ atomic_tests:
    filename:
     description: Name of the local file, include path.
     type: Path
-    default: C:\AtomicRedTeam\atomics\T1117\bin\Regsvr32.sct
+    default: C:\AtomicRedTeam\atomics\T1117\RegSvr32.sct
   executor:
    name: command_prompt
    command: |


### PR DESCRIPTION
**Details:**
Fix path of `RegSvr32.sct` because `RegSvr32.sct` is not locate in the `T1117\bin` folder.

**Testing:**
local testing on win7. 

**Associated Issues:**
N/A