### PR TITLE
PowerShell Password Policy Query

### DIFF
--- a/atomics/T1201/T1201.md
+++ b/atomics/T1201/T1201.md
@@ -90,3 +90,16 @@ Lists the password expiration policy to console on CentOS/RHEL/Ubuntu.
 cat /etc/login.defs
 ```
 <br/>
+<br/>
+
+## Atomic Test #5 - Examine password policy - Windows
+Lists the password policy to console on Windows with Remote Server Admin Tools (RSAT) installed.
+
+**Supported Platforms:** Windows
+
+
+#### Run it with `powershell`!
+```
+Get-ADDefaultDomainPasswordPolicy
+```
+<br/>

--- a/atomics/T1201/T1201.md
+++ b/atomics/T1201/T1201.md
@@ -95,6 +95,8 @@ cat /etc/login.defs
 ## Atomic Test #5 - Examine password policy - Windows
 Lists the password policy to console on Windows with Remote Server Admin Tools (RSAT) installed.
 
+RSAT tools can be downloaded from https://www.microsoft.com/en-us/download/details.aspx?id=45520
+
 **Supported Platforms:** Windows
 
 

--- a/atomics/T1201/T1201.yaml
+++ b/atomics/T1201/T1201.yaml
@@ -52,3 +52,15 @@ atomic_tests:
     name: bash
     command: |
       cat /etc/login.defs
+      
+ - name: Examine password policy - Windows
+  description: |
+    Lists the password policy to console on Windows with Remote Server Admin Tools (RSAT) installed.
+
+  supported_platforms:
+    - windows
+
+  executor:
+    name: powershell
+    command: |
+      Get-ADDefaultDomainPasswordPolicy

--- a/atomics/T1201/T1201.yaml
+++ b/atomics/T1201/T1201.yaml
@@ -53,7 +53,7 @@ atomic_tests:
     command: |
       cat /etc/login.defs
       
- - name: Examine password policy - Windows
+- name: Examine password policy - Windows
   description: |
     Lists the password policy to console on Windows with Remote Server Admin Tools (RSAT) installed.
 


### PR DESCRIPTION
**Details:**
Added Powershell password policy query to T1201 .md and .yaml.

**Testing:**
PS C:\Users\me> Get-ADDefaultDomainPasswordPolicy


ComplexityEnabled           : True
DistinguishedName           : DC=nonya,DC=com
LockoutDuration             : 00:05:00
LockoutObservationWindow    : 00:02:00
LockoutThreshold            : 3
MaxPasswordAge              : 180.00:00:00
MinPasswordAge              : 00:00:00
MinPasswordLength           : 15
objectClass                 : {domainDNS}
objectGuid                  : 12345678-1234-1234-1234-123456789abc
PasswordHistoryCount        : 2
ReversibleEncryptionEnabled : False

**Associated Issues:**
<!-- Please link any issues that this pull request impacts or fixes. -->