### PR TITLE
Add a Related section to reference other works

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -26,6 +26,7 @@
     <a href="testing" class="btn">Get Started</a>
     <a href="contributing" class="btn">Contributing</a>
     <a href="apis-execution-frameworks" class="btn">APIs &amp; Execution Frameworks</a>
+    <a href="related" class="btn">Related</a>
     <a href="{{ site.github.repository_url }}" class="btn">View on GitHub</a>
     <a href="https://slack.atomicredteam.io" class="btn">Join on Slack</a>
 </section>

--- a/docs/related.md
+++ b/docs/related.md
@@ -1,0 +1,10 @@
+---
+layout: default
+---
+
+# Related Resources
+
+Projects and resources related to Atomic Red Team.
+
+* [Atomic Red Team Simple Parser](https://github.com/AlfredoAbarca/ARTSP)
+


### PR DESCRIPTION
**Details:**
Adds a Related page to atomicredteam.io, so that we can maintain a list of projects that are directly related to Atomic Red Team but not housed here.

**Testing:**
No testing. YOLO.

**Associated Issues:**
N/A