### PR TITLE
T1036 Masquerading

### DIFF
--- a/atomics/T1036/T1036.yaml
+++ b/atomics/T1036/T1036.yaml
@@ -1,5 +1,5 @@
 ---
-attack_technique: T1306
+attack_technique: T1036
 display_name: Masquerading
 
 atomic_tests:

--- a/atomics/T1306/T1306.yaml
+++ b/atomics/T1306/T1306.yaml
@@ -1,0 +1,30 @@
+---
+attack_technique: T1306
+display_name: Masquerading
+
+atomic_tests:
+- name: Masquerading as Windows LSASS process
+  description: |
+    Copies cmd.exe, renames it, and launches it to masquerade as an instance of lsass.exe.
+
+  supported_platforms:
+    - windows
+
+  executor:
+    name: command_prompt
+    command: |
+      cmd.exe /c copy %SystemRoot%\System32\cmd.exe %SystemRoot%\Temp\lsass.exe
+      cmd.exe /c %SystemRoot%\Temp\lsass.exe
+
+- name: Masquerading as Linux crond process.
+  description: |
+    Copies sh process, renames it as crond, and executes it to masquerade as the cron daemon.
+
+  supported_platforms:
+    - linux
+
+  executor:
+    name: sh
+    command: |
+      cp /bin/sh /tmp/crond
+      /tmp/crond


### PR DESCRIPTION
**Details:**
Reopened PR because the first one bugged out. Tests for T1306 Masquerading as authorized processes.

**Testing:**
Tested on Fedora 28 and Windows 7

**Associated Issues:**
Resolves #312 