### PR TITLE
T1089 Added test to unload Sysmon filter driver

### DIFF
--- a/atomics/T1089/T1089.yaml
+++ b/atomics/T1089/T1089.yaml
@@ -95,3 +95,18 @@ atomic_tests:
     name: sh
     command: |
       sudo launchctl unload /Library/LaunchDaemons/com.opendns.osx.RoamingClientConfigUpdater.plist
+
+- name: Unload Sysmon Filter Driver
+  description: |
+    Unloads the Sysinternals Sysmon filter driver without stopping the Sysmon service. 
+  supported_platforms:
+    - windows
+  input_arguments:
+    sysmon_driver:
+      description: The name of the Sysmon filter driver (this can change from the default)
+      type: string
+      default: SysmonDrv
+  executor:
+    name: command_prompt
+    command: |
+      fltmc.exe unload #{sysmon_driver}


### PR DESCRIPTION
**Details:**
Added test to unload Sysmon filter driver without stopping Sysmon service (Thanks to @darkoperator)

**Testing:**
Tested on Windows 7

**Associated Issues:**
No associated issues