### PR TITLE
T1063 Discovery of Sysmon using fltmc.exe

### DIFF
--- a/atomics/T1063/T1063.yaml
+++ b/atomics/T1063/T1063.yaml
@@ -48,3 +48,15 @@ atomic_tests:
     command: |
       ps -ef | grep Little\ Snitch | grep -v grep
       ps aux | grep CbOsxSensorService
+
+- name: Security Software Discovery - Sysmon Service
+  description: |
+    Discovery of an installed Sysinternals Sysmon service using driver altitude (even if the name is changed).
+
+  supported_platforms:
+    - windows
+
+  executor:
+    name: command_prompt
+    command: |
+      fltmc.exe | findstr.exe 385201


### PR DESCRIPTION
**Details:**
Added test to discover Sysmon installation no matter the name using the altitude value of its filter driver (thanks to @darkoperator)

**Testing:**
Tested on Windows 7

**Associated Issues:**
No associated issues