### PR TITLE
Fixed Bug in Get-Atomic

### DIFF
--- a/execution-frameworks/Invoke-AtomicRedTeam/Invoke-AtomicRedTeam/Public/Get-AtomicTechnique.ps1
+++ b/execution-frameworks/Invoke-AtomicRedTeam/Invoke-AtomicRedTeam/Public/Get-AtomicTechnique.ps1
@@ -25,11 +25,12 @@ function Get-AtomicTechnique {
         [string]
         $Path
     )
-    
-    Write-Debug -Message "Getting atomic technique from $Path"
+    Begin { Write-Debug -Message "Getting atomic technique from $Path" }
 
-    Process 
+
+    Process
     {
+
         Write-Verbose -Message 'Attempting to convert files from yaml'
         foreach ($file in $Path) {
             if ($pscmdlet.ShouldProcess($file, 'Converting yaml file')) {

--- a/execution-frameworks/Invoke-AtomicRedTeam/Invoke-AtomicRedTeam/Public/Get-AtomicTechnique.ps1
+++ b/execution-frameworks/Invoke-AtomicRedTeam/Invoke-AtomicRedTeam/Public/Get-AtomicTechnique.ps1
@@ -34,7 +34,7 @@ function Get-AtomicTechnique {
         Write-Verbose -Message 'Attempting to convert files from yaml'
         foreach ($file in $Path) {
             if ($pscmdlet.ShouldProcess($file, 'Converting yaml file')) {
-                Write-Verbose -Message "Converting $file from Yaml"]
+                Write-Verbose -Message "Converting $file from Yaml"
                 $parsedYaml = ConvertFrom-Yaml (Get-Content $file -Raw)
                 Write-Output $parsedYaml
             }

--- a/execution-frameworks/Invoke-AtomicRedTeam/README.md
+++ b/execution-frameworks/Invoke-AtomicRedTeam/README.md
@@ -14,7 +14,7 @@ For Additional Details:
 #### Load PowerShell Script
 
 ```powershell
-Import-Module .\Invoke-AtomicRedTeam.psm1`  
+Import-Module .\Invoke-AtomicRedTeam.psm1  
 ```
 
 #### Execute Single Test
@@ -77,7 +77,7 @@ $AtomicFilePath = 'C:\AtomicRedTeam\atomics\'
 Get-ChildItem $AtomicFilePath -Recurse -Filter *.yaml -File | ForEach-Object {
     $currentTechnique = [System.IO.Path]::GetFileNameWithoutExtension($_.FullName)  
     $parsedYaml = (ConvertFrom-Yaml (Get-Content $_.FullName -Raw ))
-    $AllAtomicTests.Add($currentTechnique, $parsedYaml); 
+    $AllAtomicTests.Add($currentTechnique, $parsedYaml);
 }
 $AllAtomicTests.GetEnumerator() | Foreach-Object { Invoke-AtomicTest $_.Value -GenerateOnly }
 ```


### PR DESCRIPTION
This addresses issue 
[373](https://github.com/redcanaryco/atomic-red-team/issues/373)

Moved the Write-Debug Into the BEGIN{} block . By floating it was not properly interpreted.
