### PR TITLE
T1158 Added tests for hidden and system file hiding using attrib.exe

### DIFF
--- a/atomics/T1158/T1158.yaml
+++ b/atomics/T1158/T1158.yaml
@@ -49,6 +49,40 @@ atomic_tests:
     command: |
       mv #{filename} .#{output_filename}
 
+- name: Create Windows System File with Attrib
+  description: |
+    Creates a file and marks it as a system file using the attrib.exe utility.
+
+  supported_platforms:
+    - windows
+
+  input_arguments:
+    filename:
+      description: path of file to hide
+      type: path
+      default: "C:\Windows\Temp\sensitive_file.txt"
+  executor:
+    name: command_prompt
+    command: |
+      attrib.exe +s #{filename}
+
+- name: Create Windows Hidden File with Attrib
+  description: |
+    Creates a file and marks it as hidden using the attrib.exe utility.
+
+  supported_platforms:
+    - windows
+
+  input_arguments:
+    filename:
+      description: path of file to hide
+      type: path
+      default: "C:\Windows\Temp\sensitive_file.txt"
+  executor:
+    name: command_prompt
+    command: |
+      attrib.exe +h #{filename}
+
 - name: Hidden files
   description: |
     Requieres Apple Dev Tools


### PR DESCRIPTION
**Details:**
Added tests to mark a file as hidden or a system file using attrib.exe

**Testing:**
Tested on Windows 7

**Associated Issues:**
No associated issues