### PR TITLE
T1145 discover SSH keys

### DIFF
--- a/atomics/T1145/T1145.yaml
+++ b/atomics/T1145/T1145.yaml
@@ -32,5 +32,5 @@ atomic_tests:
   executor:
     name: sh
     command: |
-      find / -name id_rsa > #{output_file}
+      find / -name id_rsa >> #{output_file}
       find / -name id_dsa >> #{output_file}

--- a/atomics/T1145/T1145.yaml
+++ b/atomics/T1145/T1145.yaml
@@ -17,3 +17,20 @@ atomic_tests:
     command: |
       echo "ATOMICREDTEAM" > %windir%\cert.key
       dir c:\ /b /s .key | findstr /e .key
+
+- name: Discover Private SSH Keys
+  description: |
+    Discover private SSH keys on a macOS or Linux system.
+  supported_platforms:
+    - macos
+    - linux
+  input_arguments:
+    output_file:
+      description: Output file containing locations of SSH key files
+      type: path
+      default: /tmp/keyfile_locations.txt
+  executor:
+    name: sh
+    command: |
+      find / -name id_rsa > #{output_file}
+      find / -name id_dsa >> #{output_file}


### PR DESCRIPTION
**Details:**
Added test to discover SSH private keys by common names

**Testing:**
Tested on Fedora 28

**Associated Issues:**
No associated issues