### PR TITLE
T1145 Copy SSH keys using cp/rsync

### DIFF
--- a/atomics/T1145/T1145.yaml
+++ b/atomics/T1145/T1145.yaml
@@ -34,3 +34,38 @@ atomic_tests:
     command: |
       find / -name id_rsa >> #{output_file}
       find / -name id_dsa >> #{output_file}
+
+- name: Copy Private SSH Keys with CP
+  description: |
+    Copy private SSH keys on a Linux system to a staging folder using the `cp` command.
+  supported_platforms:
+    - linux
+  input_arguments:
+    output_folder:
+      description: Output folder containing copies of SSH private key files
+      type: path
+      default: /tmp/art-staging
+  executor:
+    name: sh
+    command: |
+      mkdir #{output_folder}
+      find / -name id_rsa -exec cp --parents {} #{output_folder} \;
+      find / -name id_dsa -exec cp --parents {} #{output_folder} \;
+
+- name: Copy Private SSH Keys with rsync
+  description: |
+    Copy private SSH keys on a Linux or macOS system to a staging folder using the `rsync` command.
+  supported_platforms:
+    - macos
+    - linux
+  input_arguments:
+    output_folder:
+      description: Output folder containing copies of SSH private key files
+      type: path
+      default: /tmp/art-staging
+  executor:
+    name: sh
+    command: |
+      mkdir #{output_folder}
+      find / -name id_rsa -exec rsync -R {} #{output_folder} \;
+      find / -name id_dsa -exec rsync -R {} #{output_folder} \;

--- a/atomics/T1145/T1145.yaml
+++ b/atomics/T1145/T1145.yaml
@@ -32,5 +32,5 @@ atomic_tests:
   executor:
     name: sh
     command: |
-      find / -name id_rsa > #{output_file}
+      find / -name id_rsa >> #{output_file}
       find / -name id_dsa >> #{output_file}

--- a/atomics/T1145/T1145.yaml
+++ b/atomics/T1145/T1145.yaml
@@ -17,3 +17,20 @@ atomic_tests:
     command: |
       echo "ATOMICREDTEAM" > %windir%\cert.key
       dir c:\ /b /s .key | findstr /e .key
+
+- name: Discover Private SSH Keys
+  description: |
+    Discover private SSH keys on a macOS or Linux system.
+  supported_platforms:
+    - macos
+    - linux
+  input_arguments:
+    output_file:
+      description: Output file containing locations of SSH key files
+      type: path
+      default: /tmp/keyfile_locations.txt
+  executor:
+    name: sh
+    command: |
+      find / -name id_rsa > #{output_file}
+      find / -name id_dsa >> #{output_file}


### PR DESCRIPTION
**Details:**
Added tests to copy SSH private keys to staging area using cp and rsync for Linux/macOS

**Testing:**
Tested on Fedora 28

**Associated Issues:**
No associated issues