### PR TITLE
T1089 Disable IIS HTTP logging

### DIFF
--- a/atomics/T1089/T1089.yaml
+++ b/atomics/T1089/T1089.yaml
@@ -110,3 +110,19 @@ atomic_tests:
     name: command_prompt
     command: |
       fltmc.exe unload #{sysmon_driver}
+
+- name: Disable Windows IIS HTTP Logging
+  description: |
+    Disables HTTP logging on a Windows IIS web server as seen by Threat Group 3390 (Bronze Union). 
+    This action requires HTTP logging configurations in IIS to be unlocked.
+  supported_platforms:
+    - windows
+  input_arguments:
+    website_name:
+      description: The name of the website on a server
+      type: string
+      default: Default Web Site
+  executor:
+    name: command_prompt
+    command: |
+      C:\Windows\System32\inetsrv\appcmd.exe set config "#{website_name}" /section:httplogging /dontLog:true


### PR DESCRIPTION
**Details:**
Disables HTTP logging on Windows IIS in the same manner as Threat Group 3390 (Bronze Union).

**Testing:**
Tested on Windows 2012 IIS. Requires HTTP logging configuration to be unlocked/misconfigured.

**Associated Issues:**
No associated issues