### PR TITLE
Update T1042 with cmd /c argument

### DIFF
--- a/atomics/T1042/T1042.yaml
+++ b/atomics/T1042/T1042.yaml
@@ -21,4 +21,4 @@ atomic_tests:
   executor:
     name: command_prompt
     command: |
-      cmd.exe assoc #{extension_to_change}="#{target_exenstion_handler}"
+      cmd.exe /c assoc #{extension_to_change}="#{target_exenstion_handler}"


### PR DESCRIPTION
**Details:**
Added the missing `/c` flag from `cmd.exe`, which caused the `assoc` command to be skipped.

**Testing:**
![image](https://user-images.githubusercontent.com/31489089/48658663-a1861f80-ea13-11e8-8428-683fcbdb2120.png)

As an additional sanity check, ran with `whoami` instead.
```console
C:\Users\vagrant>cmd whoami
Microsoft Windows [Version 6.1.7601]
Copyright (c) 2009 Microsoft Corporation.  All rights reserved.

C:\Users\vagrant>exit

C:\Users\vagrant>cmd /c whoami
endpoint-w-4-04\vagrant
```

**Associated Issues:**
None