### PR TITLE
T1166 SetUID SetGID add tests with variables

### DIFF
--- a/atomics/T1166/T1166.yaml
+++ b/atomics/T1166/T1166.yaml
@@ -29,3 +29,41 @@ atomic_tests:
       3. sudo chmod u+s hello
 
       4. ./hello
+
+- name: Set a SetUID flag on file
+  description: |
+    This test sets the SetUID flag on a file in Linux and macOS.
+  supported_platforms:
+    - macos
+    - centos
+    - ubuntu
+    - linux
+  input_arguments:
+    file_to_setuid:
+      description: Path of file to set SetUID flag
+      type: path
+      default: /tmp/evilBinary
+  executor:
+    name: sh
+    command: |
+      sudo chown root #{file_to_setuid}
+      sudo chmod u+s #{file_to_setuid}
+
+- name: Set a SetGID flag on file
+  description: |
+    This test sets the SetGID flag on a file in Linux and macOS.
+  supported_platforms:
+    - macos
+    - centos
+    - ubuntu
+    - linux
+  input_arguments:
+    file_to_setuid:
+      description: Path of file to set SetGID flag
+      type: path
+      default: /tmp/evilBinary
+  executor:
+    name: sh
+    command: |
+      sudo chown root #{file_to_setuid}
+      sudo chmod g+s #{file_to_setuid}


### PR DESCRIPTION
**Details:**
Added SetUID and SetGID tests with variables for execution

**Testing:**
Tested on Fedora 29

**Associated Issues:**
No associated issues