### PR TITLE
T1156 .bash_profile .bashrc reorg into separate tests

### DIFF
--- a/atomics/T1156/T1156.yaml
+++ b/atomics/T1156/T1156.yaml
@@ -3,22 +3,34 @@ attack_technique: T1156
 display_name: .bash_profile and .bashrc
 
 atomic_tests:
-- name: .bash_profile and .bashrc
+- name: Add command to .bash_profile
   description: |
-    xxx
-
+    Adds a command to the .bash_profile file of the current user
   supported_platforms:
     - macos
     - linux
-
   input_arguments:
-    script:
-      description: path to script
-      type: path
+    command_to_add:
+      description: Command to add to the .bash_profile file
+      type: string
       default: /path/to/script.py
-
   executor:
     name: sh
     command: |
-      echo "#{script}" >> ~/.bash_profile
-      echo "#{script}" >> ~/.bashrc
+      echo "#{command_to_add}" >> ~/.bash_profile
+
+- name: Add command to .bashrc
+  description: |
+    Adds a command to the .bashrc file of the current user
+  supported_platforms:
+    - macos
+    - linux
+  input_arguments:
+    command_to_add:
+      description: Command to add to the .bashrc file
+      type: string
+      default: /path/to/script.py
+  executor:
+    name: sh
+    command: |
+      echo "#{command_to_add}" >> ~/.bashrc


### PR DESCRIPTION
**Details:**
Reorg'd T1156 test into separate tests for .bash_profile and .bashrc each. Added documentation for clarity.

**Testing:**
No additional testing

**Associated Issues:**
No associated issues