### PR TITLE
T1007 Service Discovery Net Start to File

### DIFF
--- a/atomics/T1007/T1007.yaml
+++ b/atomics/T1007/T1007.yaml
@@ -25,3 +25,18 @@ atomic_tests:
       sc start #{service_name}
       sc stop #{service_name}
       wmic service where (displayname like "#{service_name}") get name
+
+- name: System Service Discovery - net.exe
+  description: |
+    Enumerates started system services using net.exe and writes them to a file. This technique has been used by multiple threat actors.
+  supported_platforms:
+    - windows
+  input_arguments:
+    output_file:
+      description: Path of file to hold net.exe output
+      type: Path
+      default: C:\Windows\Temp\service-list.txt
+  executor:
+    name: command_prompt
+    command: |
+      net.exe start >> #{output_file}


### PR DESCRIPTION
**Details:**
Added test to enumerate system services started using net.exe start and writing to file (used by multiple threat actors).

**Testing:**
Tested on Windows 2012 R2

**Associated Issues:**
No associated issues