### PR TITLE
T1099 Timestomp test with Rocke example

### DIFF
--- a/atomics/T1099/T1099.md
+++ b/atomics/T1099/T1099.md
@@ -10,6 +10,8 @@
 
 - [Atomic Test #3 - Set a file's creation timestamp](#atomic-test-3---set-a-files-creation-timestamp)
 
+- [Atomic Test #4 - Modify file timestamps using reference file](#atomic-test-4---modify-file-timestamps-using-reference-file)
+
 
 <br/>
 
@@ -70,5 +72,26 @@ date -s "1970-01-01 00:00:00"
 touch #{target_filename}
 date -s "$NOW"
 stat #{target_filename}
+```
+<br/>
+<br/>
+
+## Atomic Test #4 - Modify file timestamps using reference file
+Modifies the `modify` and `access` timestamps using the timestamps of a specified reference file.
+
+This technique was used by the threat actor Rocke during the compromise of Linux web servers.
+
+**Supported Platforms:** Linux, macOS
+
+
+#### Inputs
+| Name | Description | Type | Default Value | 
+|------|-------------|------|---------------|
+| reference_file_path | Path of reference file to read timestamps from | Path | /bin/sh|
+| target_file_path | Path of file to modify timestamps of | Path | /opt/filename|
+
+#### Run it with `sh`!
+```
+touch -acmr #{reference_file_path} {target_file_path}
 ```
 <br/>

--- a/atomics/T1099/T1099.yaml
+++ b/atomics/T1099/T1099.yaml
@@ -58,3 +58,26 @@ atomic_tests:
       touch #{target_filename}
       date -s "$NOW"
       stat #{target_filename}
+
+- name: Modify file timestamps using reference file
+  description: |
+    Modifies the `modify` and `access` timestamps using the timestamps of a specified reference file.
+
+    This technique was used by the threat actor Rocke during the compromise of Linux web servers.
+
+  supported_platforms:
+    - linux
+    - macos
+  input_arguments:
+    reference_file_path:
+      description: Path of reference file to read timestamps from
+      type: Path
+      default: /bin/sh
+    target_file_path:
+      description: Path of file to modify timestamps of
+      type: Path
+      default: /opt/filename
+  executor:
+    name: sh
+    command: |
+      touch -acmr #{reference_file_path} {target_file_path}


### PR DESCRIPTION
**Details:**
Added timestomp with `touch` test where a reference file is specified to source the timestamps. This technique was observed in use by the Rocke threat actor on Linux systems.

**Testing:**
Tested on CentOS 7.

**Associated Issues:**
No associated issues