### PR TITLE
T1222 - chattr Remove Immutable Attribute

### DIFF
--- a/atomics/T1222/T1222.md
+++ b/atomics/T1222/T1222.md
@@ -36,6 +36,8 @@ Adversaries may modify file permissions/attributes to evade intended DACLs. (Cit
 
 - [Atomic Test #15 - chown - Change file or folder ownership recursively](#atomic-test-15---chown---change-file-or-folder-ownership-recursively)
 
+- [Atomic Test #16 - chattr - Remove immutable file attribute](#atomic-test-16---chattr---remove-immutable-file-attribute)
+
 
 <br/>
 
@@ -319,5 +321,24 @@ Changes a file or folder's ownership only recursively using chown.
 #### Run it with `bash`!
 ```
 chown #{owner} #{file_or_folder} -R
+```
+<br/>
+<br/>
+
+## Atomic Test #16 - chattr - Remove immutable file attribute
+Remove's a file's `immutable` attribute using `chattr`.
+This technique was used by the threat actor Rocke during the compromise of Linux web servers.
+
+**Supported Platforms:** macOS, Linux
+
+
+#### Inputs
+| Name | Description | Type | Default Value | 
+|------|-------------|------|---------------|
+| file_to_modify | Path of the file | path | /var/spool/cron/root|
+
+#### Run it with `sh`!
+```
+chattr -i #{file_to_modify}
 ```
 <br/>

--- a/atomics/T1222/T1222.yaml
+++ b/atomics/T1222/T1222.yaml
@@ -334,3 +334,22 @@ atomic_tests:
     name: bash
     command: |
       chown #{owner} #{file_or_folder} -R
+
+- name: chattr - Remove immutable file attribute
+  description: |
+    Remove's a file's `immutable` attribute using `chattr`.
+    This technique was used by the threat actor Rocke during the compromise of Linux web servers.
+  supported_platforms:
+    - macos
+    - linux
+
+  input_arguments:
+    file_to_modify:
+      description: Path of the file
+      type: path
+      default: /var/spool/cron/root
+
+  executor:
+    name: sh
+    command: |
+      chattr -i #{file_to_modify}


### PR DESCRIPTION
**Details:**
T1222 test using `chattr` to remove the immutable file attribute. This was used by the threat actor Rocke during the compromise of Linux web servers.

**Testing:**
Tested on CentOS 7

**Associated Issues:**
No associated issues