### PR TITLE
Added repository_asset setting to input arguments for atomic tests containing payloads

### DIFF
--- a/atomic_red_team/atomic_test_template.yaml
+++ b/atomic_red_team/atomic_test_template.yaml
@@ -17,8 +17,13 @@ atomic_tests:
   input_arguments:
     output_file:
       description: TODO
-      type: todo
+      type: TODO
       default: TODO
+    input_file:
+      description: TODO
+      type: TODO
+      default: TODO
+      repository_asset: TODO
 
   executor:
     name: command_prompt

--- a/atomic_red_team/spec.yaml
+++ b/atomic_red_team/spec.yaml
@@ -69,6 +69,8 @@ atomic_tests:
       type: Path
       # default value for this argument that will be used if one is not specifid
       default: test.wma
+      # relative path of payload provided as argument for test
+      repository_asset: src/test.wma
 
     # this is a example of a second argument
     malware_payload_url:

--- a/atomics/T1010/T1010.yaml
+++ b/atomics/T1010/T1010.yaml
@@ -15,6 +15,7 @@ atomic_tests:
       description: Path to source of C# code
       type: path
       default: C:\AtomicRedTeam\atomics\T1010\src\T1010.cs
+      repository_asset: src\T1010.cs
     output_file_name:
       description: Name of output binary
       type: string

--- a/atomics/T1050/T1050.yaml
+++ b/atomics/T1050/T1050.yaml
@@ -14,6 +14,7 @@ atomic_tests:
       description: Name of the service binary, include path.
       type: Path
       default: C:\AtomicRedTeam\atomics\T1050\bin\AtomicService.exe
+      repository_asset: bin\AtomicService.exe
     service_name:
       description: Name of the Service
       type: String
@@ -38,6 +39,7 @@ atomic_tests:
       description: Name of the service binary, include path.
       type: Path
       default: C:\AtomicRedTeam\atomics\T1050\bin\AtomicService.exe
+      repository_asset: bin\AtomicService.exe
     service_name:
       description: Name of the Service
       type: String

--- a/atomics/T1055/T1055.yaml
+++ b/atomics/T1055/T1055.yaml
@@ -15,6 +15,7 @@ atomic_tests:
       description: DLL to Inject
       type: Path
       default: C:\AtomicRedTeam\atomics\T1055\src\x64\T1055.dll
+      repository_asset: src\x64\T1055.dll
     process_id:
       description: PID of input_arguments
       type: Int
@@ -36,6 +37,7 @@ atomic_tests:
       description: DLL to Inject
       type: Path
       default: T1055.dll
+      repository_asset: src\x64\T1055.dll
     process_id:
       description: PID of input_arguments
       type: Int

--- a/atomics/T1117/T1117.yaml
+++ b/atomics/T1117/T1117.yaml
@@ -12,6 +12,7 @@ atomic_tests:
     description: Name of the local file, include path.
     type: Path
     default: C:\AtomicRedTeam\atomics\T1117\RegSvr32.sct
+    repository_asset: RegSvr32.sct
   executor:
    name: command_prompt
    command: |
@@ -40,6 +41,7 @@ atomic_tests:
     description: Name of DLL to Execute, DLL Should export DllRegisterServer
     type: Path
     default: C:\AtomicRedTeam\atomics\T1117\bin\AllTheThingsx86.dll
+    repository_asset: bin\AllTheThingsx86.dll
   executor:
    name: command_prompt
    command: |

--- a/atomics/T1118/T1118.yaml
+++ b/atomics/T1118/T1118.yaml
@@ -9,6 +9,11 @@ atomic_tests:
   supported_platforms:
     - windows
   input_arguments:
+    input_source_code:
+      description: Path to source of C# code
+      type: path
+      default: C:\AtomicRedTeam\atomics\T1118\src\T1118.cs
+      repository_asset: src\T1118.cs
     filename:
       description: location of the payload
       type: Path
@@ -16,5 +21,5 @@ atomic_tests:
   executor:
     name: command_prompt
     command: |
-      C:\Windows\Microsoft.NET\Framework\v4.0.30319\csc.exe /target:library T1118.cs
+      C:\Windows\Microsoft.NET\Framework\v4.0.30319\csc.exe /target:library #{input_source_code}
       C:\Windows\Microsoft.NET\Framework\v4.0.30319\InstallUtil.exe /logfile= /LogToConsole=false /U #{filename}

--- a/atomics/T1121/T1121.yaml
+++ b/atomics/T1121/T1121.yaml
@@ -17,6 +17,7 @@ atomic_tests:
       description: Location of the CSharp source_file
       type: Path
       default: C:\AtomicRedTeam\atomics\T1121\src\T1121.cs
+      repository_asset: src\T1121.cs
   executor:
     name: command_prompt
     command: |
@@ -38,6 +39,7 @@ atomic_tests:
       description: Location of the CSharp source_file
       type: Path
       default: C:\AtomicRedTeam\atomics\T1121\src\T1121.cs
+      repository_asset: src\T1121.cs
   executor:
     name: powershell
     command: |

--- a/atomics/T1122/T1122.yaml
+++ b/atomics/T1122/T1122.yaml
@@ -9,9 +9,22 @@ atomic_tests:
 
   supported_platforms:
     - windows
+
+  input_arguments:
+    input_hijack_reg:
+      description: Path to registry file for COM Hijack
+      type: path
+      default: C:\AtomicRedTeam\atomics\T1122\src\COMHijack.reg
+      repository_asset: src\COMHijack.reg
+    input_clean_reg:
+      description: Path to registry file for COM Hijack Cleanup
+      type: path
+      default: C:\AtomicRedTeam\atomics\T1122\src\COMHijackCleanup.reg
+      repository_asset: src\COMHijackCleanup.reg
+
   executor:
     name: command_prompt
     command: |
-      reg import ..\src\COMHijack.reg
+      reg import #{input_hijack_reg}
       certutil.exe -CAInfo
-      reg import ..\src\COMHijackCleanup.reg
+      reg import #{input_clean_reg}

--- a/atomics/T1127/T1127.yaml
+++ b/atomics/T1127/T1127.yaml
@@ -12,6 +12,7 @@ atomic_tests:
       description: Location of the project file
       type: Path
       default: T1127.csproj
+      repository_asset: src\T1127.csproj
   executor:
     name: command_prompt
     command: |

--- a/atomics/T1134/T1134.yaml
+++ b/atomics/T1134/T1134.yaml
@@ -14,6 +14,11 @@ atomic_tests:
       description: Username To Steal Token From
       type: String
       default: SYSTEM
+    input_script_path:
+      description: Path to PowerShell script
+      type: path
+      default: C:\AtomicRedTeam\atomics\T1134\src\T1134.ps1
+      repository_asset: src\T1134.ps1
   executor:
     name: powershell
     command: |
@@ -23,4 +28,4 @@ atomic_tests:
       gwmi win32_process |% {$owners[$_.handle] = $_.getowner().user}
       get-process | select processname,Id,@{l="Owner";e={$owners[$_.id.tostring()]}}
       #Steal Token
-      . .\src\T1134.ps1
+      . #{input_script_path}

--- a/atomics/T1138/T1138.yaml
+++ b/atomics/T1138/T1138.yaml
@@ -10,7 +10,14 @@ atomic_tests:
   supported_platforms:
     - windows
 
+  input_arguments:
+    dll_payload:
+      description: SDB to Inject
+      type: Path
+      default: C:\AtomicRedTeam\atomics\T1138\src\AtomicShimx86.sdb
+      repository_asset: src\AtomicShimx86.sdb
+
   executor:
     name: command_prompt
     command: |
-      sdbinst.exe AtomicShimx86.sdb
+      sdbinst.exe #{dll_payload}

--- a/atomics/T1179/T1179.yaml
+++ b/atomics/T1179/T1179.yaml
@@ -13,6 +13,7 @@ atomic_tests:
       description: Dll To Inject
       type: Path
       default: C:\AtomicRedTeam\atomics\T1179\bin\T1179x64.dll
+      repository_asset: bin\T1179x64.dll
     server_name:
       description: TLS Server To Test Get Request
       type: Url

--- a/atomics/T1218/T1218.yaml
+++ b/atomics/T1218/T1218.yaml
@@ -15,6 +15,7 @@ atomic_tests:
       description: DLL to inject
       type: Path
       default: C:\AtomicRedTeam\atomics\T1218\src\x64\T1218.dll
+      repository_asset: src\x64\T1218.dll
     process_id:
       description: PID of process receiving injection
       type: string
@@ -53,6 +54,7 @@ atomic_tests:
       description: DLL to execute
       type: Path
       default: C:\AtomicRedTeam\atomics\T1218\src\Win32\T1218-2.dll
+      repository_asset: src\Win32\T1218-2.dll
   executor:
     name: command_prompt
     command: |

--- a/atomics/T1220/T1220.yaml
+++ b/atomics/T1220/T1220.yaml
@@ -13,10 +13,12 @@ atomic_tests:
       description: Location of the test XML file on the local filesystem.
       type: Path
       default: C:\AtomicRedTeam\atomics\T1220\src\msxsl-xmlfile.xml
+      repository_asset: src\msxsl-xmlfile.xml
     xslfile:
       description: Location of the test XSL script file on the local filesystem.
       type: Path
       default: C:\AtomicRedTeam\atomics\T1220\src\msxsl-script.xsl
+      repository_asset: src\msxsl-script.xsl
   executor:
     name: command_prompt
     command: |
@@ -55,6 +57,7 @@ atomic_tests:
       description: Location of the test XSL script file on the local filesystem.
       type: path
       default: C:\AtomicRedTeam\atomics\T1220\src\wmic-script.xsl
+      repository_asset: src\wmic-script.xsl
   executor:
     name: command_prompt
     command: |

--- a/atomics/T1223/T1223.yaml
+++ b/atomics/T1223/T1223.yaml
@@ -15,6 +15,7 @@ atomic_tests:
       description: Local .chm payload
       type: path
       default: C:\atomic-red-team\atomics\T1223\src\T1223.chm
+      repository_asset: src\T1223.chm
 
   executor:
     name: command_prompt


### PR DESCRIPTION
**Details:**
Added a 'repository_asset' setting to input arguments for atomic tests that are accompanied with a proof-of-concept asset in the repository. Also modified the 'spec.yaml' to support

**Testing:**
Locally tested YAML deserialization using YamlDotNet on all modified atomic test configurations.

**Associated Issues:**
The following atomic tests previously had hard-coded values for paths and/or filenames. They were moved to an input_argument as an effort to standardize configurations. Any automated testing executors that previously relied on hard-coded values may need to be modified to supply the corresponding input argument.
T1118: Moved hard-coded source code filename to input argument
T1122: Moved hard-coded registry filenames to input arguments
T1134: Moved hard-coded script path to input argument
T1138: Moved hard-coded DLL filename to input argument