### PR TITLE
Install-AtomicRedTeam Script

### DIFF
--- a/execution-frameworks/Invoke-AtomicRedTeam/README.md
+++ b/execution-frameworks/Invoke-AtomicRedTeam/README.md
@@ -1,23 +1,26 @@
 # Invoke-AtomicRedTeam
 
-## Requires Installation of PowerShell-Yaml
+## Setup
 
-```powershell
-Install-Module -Name powershell-yaml  
-```
+### Install Atomic Red Team
 
-For Additional Details:
-    [PowerShell-Yaml](https://github.com/cloudbase/powershell-yaml)
+Get started quickly with our simple Powershell [script](install-atomicredteam.ps1).
 
-## Basic usage Examples
+### Manual
 
-#### Load PowerShell Script
 
-```powershell
-Import-Module .\Invoke-AtomicRedTeam.psm1  
-```
+`set-executionpolicy Unrestricted`
 
-#### Execute Single Test
+[PowerShell-Yaml](https://github.com/cloudbase/powershell-yaml) is required to parse Atomic yaml files:
+
+
+`Install-Module -Name powershell-yaml`
+
+`Import-Module .\Invoke-AtomicRedTeam.psm1`
+
+## Getting Started
+
+### Execute a Single Test
 
 ```powershell
 $T1117 = Get-AtomicTechnique -Path ..\..\atomics\T1117\T1117.yaml
@@ -81,5 +84,3 @@ Get-ChildItem $AtomicFilePath -Recurse -Filter *.yaml -File | ForEach-Object {
 }
 $AllAtomicTests.GetEnumerator() | Foreach-Object { Invoke-AtomicTest $_.Value -GenerateOnly }
 ```
-
-### Feedback Welcome

--- a/execution-frameworks/Invoke-AtomicRedTeam/install-atomicredteam.ps1
+++ b/execution-frameworks/Invoke-AtomicRedTeam/install-atomicredteam.ps1
@@ -5,11 +5,11 @@ function Install-AtomicRedTeam {
     .SYNOPSIS
 
         Atomic Function: Install-AtomicRedTeam
-        Author: Red Canary Research Team
+        Author: Red Canary Research
         License: BSD 3-Clause
-        Required Dependencies: powershell-Yaml
+        Required Dependencies: powershell-yaml
         Optional Dependencies: None
-        
+
     .EXAMPLE
 
         Install Atomic Red Team

--- a/execution-frameworks/Invoke-AtomicRedTeam/install-atomicredteam.ps1
+++ b/execution-frameworks/Invoke-AtomicRedTeam/install-atomicredteam.ps1
@@ -1,0 +1,109 @@
+#Requires -RunAsAdministrator
+
+function Install-AtomicRedTeam {
+<#
+    .SYNOPSIS
+
+        Atomic Function: Install-AtomicRedTeam
+        Author: Red Canary Research Team
+        License: BSD 3-Clause
+        Required Dependencies: powershell-Yaml
+        Optional Dependencies: None
+        
+    .EXAMPLE
+
+        Install Atomic Red Team
+        PS> Install-AtomicRedTeam.ps1
+
+    .EXAMPLE
+
+        Execute a single test
+        $T1117 = Get-AtomicTechnique -Path ..\..\atomics\T1117\T1117.yaml
+        Invoke-AtomicTest $T1117
+
+    .EXAMPLE
+
+        Informational Stream
+        Invoke-AtomicTest $T1117 -InformationAction Continue
+
+    .EXAMPLE
+
+        Verbose Stream
+        Invoke-AtomicTest $T1117 -Verbose
+
+    .EXAMPLE
+
+        Debug Stream
+        Invoke-AtomicTest $T1117 -Debug
+
+    .EXAMPLE
+
+        What if
+        If you would like to see what would happen without running the test
+        Invoke-AtomicTest $T1117 -WhatIf
+
+    .EXAMPLE
+
+
+        To run all tests without confirming them run using the Confirm switch to false
+
+        Invoke-AtomicTest $T1117 -Confirm:$false
+        Or you can set your $ConfirmPreference to 'Medium'
+
+        $ConfirmPreference = 'Medium'
+        Invoke-AtomicTest $T1117
+
+    .EXAMPLE
+
+        [System.Collections.HashTable]$AllAtomicTests = @{}
+        $AtomicFilePath = 'C:\AtomicRedTeam\atomics\'
+        Get-ChildItem $AtomicFilePath -Recurse -Filter *.yaml -File | ForEach-Object {
+            $currentTechnique = [System.IO.Path]::GetFileNameWithoutExtension($_.FullName)
+            $parsedYaml = (ConvertFrom-Yaml (Get-Content $_.FullName -Raw ))
+            $AllAtomicTests.Add($currentTechnique, $parsedYaml);
+        }
+        $AllAtomicTests.GetEnumerator() | Foreach-Object { Invoke-AtomicTest $_.Value -GenerateOnly }
+
+    .NOTES
+
+    Use the '-Verbose' option to print detailed information.
+
+#>
+
+
+write-verbose "Directory Creation"
+
+mkdir c:\AtomicRedTeam\
+
+write-verbose "Setting Execution Policy to Unrestricted"
+set-executionpolicy Unrestricted
+
+write-verbose "Setting variables for remote URL and download Path"
+$url = "https://github.com/redcanaryco/atomic-red-team/archive/master.zip"
+$path = "C:\AtomicRedTeam\master.zip"
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+$webClient = new-object System.Net.WebClient
+write-verbose "Beginning download from Github"
+$webClient.DownloadFile( $url, $path )
+
+write-verbose "Extracting ART to C:\AtomicRedTeam\"
+expand-archive -LiteralPath c:\atomicRedTeam\master.zip -DestinationPath C:\AtomicRedTeam\
+
+write-verbose "Installing NuGet PackageProvider"
+Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force
+
+write-verbose "Installing powershell-yaml"
+Install-Module -Name powershell-yaml
+
+write-verbose "Importing invoke-atomicRedTeam module"
+Import-Module C:\AtomicRedTeam\atomic-red-team-master\execution-frameworks\Invoke-AtomicRedTeam\Invoke-AtomicRedTeam\Invoke-AtomicRedTeam.psm1
+
+write-verbose "Changing current work directory Invoke-AtomicRedTeam"
+cd C:\AtomicRedTeam\atomic-red-team-master\execution-frameworks\Invoke-AtomicRedTeam\Invoke-AtomicRedTeam\
+
+write-verbose "Clearing screen"
+clear
+
+Write-Host "Installation of Invoke-AtomicRedTeam is complete" -Fore Yellow
+}
+Install-AtomicRedTeam

--- a/execution-frameworks/Invoke-AtomicRedTeam/install-atomicredteam.ps1
+++ b/execution-frameworks/Invoke-AtomicRedTeam/install-atomicredteam.ps1
@@ -13,11 +13,11 @@ function Install-AtomicRedTeam {
 <#
     .SYNOPSIS
 
-        This is a simple script to download and install Atomic Red Team Invoke-atomicRedTeam Powershell Framework. 
+        This is a simple script to download and install Atomic Red Team Invoke-atomicRedTeam Powershell Framework.
 
         Atomic Function: Install-AtomicRedTeam
         Author: Red Canary Research
-        License: BSD 3-Clause
+        License: MIT License
         Required Dependencies: powershell-yaml
         Optional Dependencies: None
 

--- a/execution-frameworks/Invoke-AtomicRedTeam/install-atomicredteam.ps1
+++ b/execution-frameworks/Invoke-AtomicRedTeam/install-atomicredteam.ps1
@@ -1,4 +1,14 @@
 #Requires -RunAsAdministrator
+[CmdletBinding()]
+Param(
+  [Parameter(Mandatory=$False,Position=0)]
+  [string]$InstallPath = 'C:\AtomicRedTeam',
+
+  [Parameter(Mandatory=$False,Position=0)]
+  [string]$DownloadPath = 'C:\AtomicRedTeam'
+
+ )
+
 
 function Install-AtomicRedTeam {
 <#
@@ -73,37 +83,46 @@ function Install-AtomicRedTeam {
 
 write-verbose "Directory Creation"
 
-mkdir c:\AtomicRedTeam\
+if(!(Test-Path -Path $InstallPath )){
+    New-Item -ItemType directory -Path $InstallPath
+	write-verbose "Setting Execution Policy to Unrestricted"
+	set-executionpolicy Unrestricted
 
-write-verbose "Setting Execution Policy to Unrestricted"
-set-executionpolicy Unrestricted
+	write-verbose "Setting variables for remote URL and download Path"
+	$url = "https://github.com/redcanaryco/atomic-red-team/archive/master.zip"
+	$path = "$DownloadPath\master.zip"
+	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+	$webClient = new-object System.Net.WebClient
+	write-verbose "Beginning download from Github"
+	$webClient.DownloadFile( $url, $path )
 
-write-verbose "Setting variables for remote URL and download Path"
-$url = "https://github.com/redcanaryco/atomic-red-team/archive/master.zip"
-$path = "C:\AtomicRedTeam\master.zip"
-[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-$webClient = new-object System.Net.WebClient
-write-verbose "Beginning download from Github"
-$webClient.DownloadFile( $url, $path )
+	write-verbose "Extracting ART to C:\AtomicRedTeam\"
+	expand-archive -LiteralPath "$DownloadPath\master.zip" -DestinationPath "$InstallPath"
 
-write-verbose "Extracting ART to C:\AtomicRedTeam\"
-expand-archive -LiteralPath c:\atomicRedTeam\master.zip -DestinationPath C:\AtomicRedTeam\
+	write-verbose "Installing NuGet PackageProvider"
+	Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force
 
-write-verbose "Installing NuGet PackageProvider"
-Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force
+	write-verbose "Installing powershell-yaml"
+	Install-Module -Name powershell-yaml -Force
 
-write-verbose "Installing powershell-yaml"
-Install-Module -Name powershell-yaml
+	write-verbose "Importing invoke-atomicRedTeam module"
+	Import-Module "$InstallPath\atomic-red-team-master\execution-frameworks\Invoke-AtomicRedTeam\Invoke-AtomicRedTeam\Invoke-AtomicRedTeam.psm1"
 
-write-verbose "Importing invoke-atomicRedTeam module"
-Import-Module C:\AtomicRedTeam\atomic-red-team-master\execution-frameworks\Invoke-AtomicRedTeam\Invoke-AtomicRedTeam\Invoke-AtomicRedTeam.psm1
+	write-verbose "Changing current work directory Invoke-AtomicRedTeam"
+	cd "$InstallPath\atomic-red-team-master\execution-frameworks\Invoke-AtomicRedTeam\Invoke-AtomicRedTeam\"
 
-write-verbose "Changing current work directory Invoke-AtomicRedTeam"
-cd C:\AtomicRedTeam\atomic-red-team-master\execution-frameworks\Invoke-AtomicRedTeam\Invoke-AtomicRedTeam\
+	write-verbose "Clearing screen"
+	clear
 
-write-verbose "Clearing screen"
-clear
+	Write-Host "Installation of Invoke-AtomicRedTeam is complete" -Fore Yellow
 
-Write-Host "Installation of Invoke-AtomicRedTeam is complete" -Fore Yellow
+}
+else
+{
+	Write-Verbose "Atomic Already exists at $InstallPath"
+	exit
+
+
+}
 }
 Install-AtomicRedTeam

--- a/execution-frameworks/Invoke-AtomicRedTeam/install-atomicredteam.ps1
+++ b/execution-frameworks/Invoke-AtomicRedTeam/install-atomicredteam.ps1
@@ -9,10 +9,11 @@ Param(
 
  )
 
-
 function Install-AtomicRedTeam {
 <#
     .SYNOPSIS
+
+        This is a simple script to download and install Atomic Red Team Invoke-atomicRedTeam Powershell Framework. 
 
         Atomic Function: Install-AtomicRedTeam
         Author: Red Canary Research

--- a/execution-frameworks/Invoke-AtomicRedTeam/install-atomicredteam.ps1
+++ b/execution-frameworks/Invoke-AtomicRedTeam/install-atomicredteam.ps1
@@ -13,7 +13,7 @@ function Install-AtomicRedTeam {
 <#
     .SYNOPSIS
 
-        This is a simple script to download and install Atomic Red Team Invoke-atomicRedTeam Powershell Framework.
+        This is a simple script to download and install Atomic Red Team Invoke-AtomicRedTeam Powershell Framework.
 
         Atomic Function: Install-AtomicRedTeam
         Author: Red Canary Research

--- a/execution-frameworks/Invoke-AtomicRedTeam/install-atomicredteam.ps1
+++ b/execution-frameworks/Invoke-AtomicRedTeam/install-atomicredteam.ps1
@@ -20,6 +20,14 @@ function Install-AtomicRedTeam {
         Required Dependencies: powershell-yaml
         Optional Dependencies: None
 
+    .PARAMETER DownloadPath
+
+    Specifies the desired path to download Atomic Red Team.
+
+    .PARAMETER InstallPath
+
+        Specifies the desired path for where to install Atomic Red Team.
+
     .EXAMPLE
 
         Install Atomic Red Team


### PR DESCRIPTION
**Details:**
This is a simple installation script to help teams get started with Atomic Red Team. 

* Downloads and extract AtomicRedTeam Repo
* Installs Dependencies (powershell-yaml)
* Set focus to execution path

Two input parameters:
* DownloadPath
* InstallPath

Feedback welcome

**Testing:**
Confirmed operational on Windows 10. 

**Associated Issues:**
None we are aware of. 