### PR TITLE
Certutil update

### DIFF
--- a/atomics/T1105/T1105.yaml
+++ b/atomics/T1105/T1105.yaml
@@ -178,7 +178,7 @@ atomic_tests:
   input_arguments:
     remote_file:
       description: URL of file to copy
-      type: URL
+      type: Url
       default: https://raw.githubusercontent.com/redcanaryco/atomic-red-team/master/LICENSE.txt
     local_path:
       description: Local path to place file
@@ -196,7 +196,7 @@ atomic_tests:
   input_arguments:
     remote_file:
       description: URL of file to copy
-      type: URL
+      type: Url
       default: https://raw.githubusercontent.com/redcanaryco/atomic-red-team/master/LICENSE.txt
     local_path:
       description: Local path to place file

--- a/atomics/T1105/T1105.yaml
+++ b/atomics/T1105/T1105.yaml
@@ -190,7 +190,7 @@ atomic_tests:
       cmd /c certutil -urlcache -split -f #{remote_file} #{local_path}
 - name: certutil download (verifyctl)
   description: |
-    Use certutil -verifyctl argument to download a file from the web. Output file will be named with a .bin or .key extension, but file content is complete. Note - /verifyctl also works!
+    Use certutil -verifyctl argument to download a file from the web. Note - /verifyctl also works!
   supported_platforms:
     - windows
   input_arguments:
@@ -198,7 +198,15 @@ atomic_tests:
       description: URL of file to copy
       type: URL
       default: https://raw.githubusercontent.com/redcanaryco/atomic-red-team/master/LICENSE.txt
+    local_path:
+      description: Local path to place file
+      type: Path
+      default: Atomic-license.txt
   executor:
-    name: command_prompt
+    name: powershell
     command: |
-      cmd /c certutil -verifyctl -split -f #{remote_file}
+      $datePath = "certutil-$(Get-Date -format yyyy_MM_dd_HH_mm)"
+      New-Item -Path $datePath -ItemType Directory
+      Set-Location $datePath
+      certutil -verifyctl -split -f #{remote_file}
+      Get-ChildItem | Where-Object {$_.Name -notlike "*.txt"} | Foreach-Object { Move-Item $_.Name -Destination #{local_path} }

--- a/atomics/T1105/T1105.yaml
+++ b/atomics/T1105/T1105.yaml
@@ -170,3 +170,35 @@ atomic_tests:
     name: bash
     command: |
       sftp #{username}@#{remote_host}:#{remote_file} #{local_path}
+- name: certutil download (urlcache)
+  description: |
+    Use certutil -urlcache argument to download a file from the web. Note - /urlcache also works!
+  supported_platforms:
+    - windows
+  input_arguments:
+    remote_file:
+      description: URL of file to copy
+      type: URL
+      default: https://raw.githubusercontent.com/redcanaryco/atomic-red-team/master/LICENSE.txt
+    local_path:
+      description: Local path to place file
+      type: Path
+      default: Atomic-license.txt
+  executor:
+    name: command_prompt
+    command: |
+      cmd /c certutil -urlcache -split -f #{remote_file} #{local_path}
+- name: certutil download (verifyctl)
+  description: |
+    Use certutil -verifyctl argument to download a file from the web. Output file will be named with a .bin or .key extension, but file content is complete. Note - /verifyctl also works!
+  supported_platforms:
+    - windows
+  input_arguments:
+    remote_file:
+      description: URL of file to copy
+      type: URL
+      default: https://raw.githubusercontent.com/redcanaryco/atomic-red-team/master/LICENSE.txt
+  executor:
+    name: command_prompt
+    command: |
+      cmd /c certutil -verifyctl -split -f #{remote_file}

--- a/atomics/T1140/T1140.yaml
+++ b/atomics/T1140/T1140.yaml
@@ -39,4 +39,4 @@ atomic_tests:
     name: command_prompt
     command: |
       cmd.exe /c copy %windir%\\system32\\certutil.exe %temp%tcm.tmp
-      cmd.exe /c %temp%tcm.tmp -decode #{executable}
+      cmd.exe /c %temp%tcm.tmp -decode #{executable} file.txt


### PR DESCRIPTION
**Details:**
Syntax fix + adding `certutil` download tests.

**Testing:**
Tested commands on Windows 10 - certutil should be cross-compatable down to Win 7.

**Associated Issues:**
None known.