### PR TITLE
Update PyYAML to >= 4.2b1 due to security alert: https://nvd.nist.gov/vuln/detail/CVE-2017-18342

### DIFF
--- a/execution-frameworks/contrib/python/requirements.txt
+++ b/execution-frameworks/contrib/python/requirements.txt
@@ -1,2 +1,2 @@
 Unidecode==1.0.22
-PyYAML==3.12
+PyYAML>=4.2b1


### PR DESCRIPTION
**Details:**
Update PyYAML to >= 4.2b1 due to security alert: https://nvd.nist.gov/vuln/detail/CVE-2017-18342.

This simply updates PyYAML to 4.2b1 or greater.

**Testing:**
Script was tested locally.

**Associated Issues:**
Fixes the CVE referenced her: https://github.com/redcanaryco/atomic-red-team/network/alert/execution-frameworks/contrib/python/requirements.txt/pyyaml/open