### PR TITLE
msbuild expects the csproj file in the same path

### DIFF
--- a/atomics/T1127/T1127.csproj
+++ b/atomics/T1127/T1127.csproj
@@ -1,0 +1,46 @@
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!-- This inline task executes c# code. -->
+  <!-- C:\Windows\Microsoft.NET\Framework\v4.0.30319\msbuild.exe MSBuildBypass.csproj -->
+  <!-- Feel free to use a more aggressive class for testing. -->
+  <Target Name="Hello">
+   <FragmentExample />
+   <ClassExample />
+  </Target>
+  <UsingTask
+    TaskName="FragmentExample"
+    TaskFactory="CodeTaskFactory"
+    AssemblyFile="C:\Windows\Microsoft.Net\Framework\v4.0.30319\Microsoft.Build.Tasks.v4.0.dll" >
+    <ParameterGroup/>
+    <Task>
+      <Using Namespace="System" />
+      <Code Type="Fragment" Language="cs">
+        <![CDATA[
+			    Console.WriteLine("Hello From a Code Fragment");
+        ]]>
+      </Code>
+    </Task>
+	</UsingTask>
+	<UsingTask
+    TaskName="ClassExample"
+    TaskFactory="CodeTaskFactory"
+    AssemblyFile="C:\Windows\Microsoft.Net\Framework\v4.0.30319\Microsoft.Build.Tasks.v4.0.dll" >
+	<Task>
+	<!-- <Reference Include="System.IO" /> Example Include -->
+      <Code Type="Class" Language="cs">
+        <![CDATA[
+			using System;
+			using Microsoft.Build.Framework;
+			using Microsoft.Build.Utilities;
+			public class ClassExample :  Task, ITask
+			{
+				public override bool Execute()
+				{
+					Console.WriteLine("Hello From a Class.");
+					return true;
+				}
+			}
+        ]]>
+      </Code>
+    </Task>
+  </UsingTask>
+</Project>


### PR DESCRIPTION
**Details:**
Based on the details in the blog below on a non-working test.  Adjusted the location of T1127.csproj. Leaving in both places for now, in case teams have adapted tests to overcome the nuance.
**Testing:**
Windows 10 x64

**Associated Issues:**
This blog was a good reference.
https://bleepsec.com/2018/11/26/using-attack-atomic-red-team-part1.html
