### PR TITLE
[FIX] T1087

### DIFF
--- a/atomics/T1087/T1087.yaml
+++ b/atomics/T1087/T1087.yaml
@@ -50,6 +50,8 @@ atomic_tests:
     name: sh
     command: |
       grep 'x:0:' /etc/passwd > #{output_file} - name: List opened files by user
+
+- name: List opened files by user
   description: |
     List opened files by user
   supported_platforms:


### PR DESCRIPTION
**Details:**
Fixed issue where a test was missing a `-name:` key, and was "piggybacking" off another test and causing a conflict of duplicate keys.
