### PR TITLE
Fix t1138path

### DIFF
--- a/atomics/T1138/T1138.md
+++ b/atomics/T1138/T1138.md
@@ -22,13 +22,23 @@ To keep shims secure, Windows designed them to run in user mode so they cannot m
 <br/>
 
 ## Atomic Test #1 - Application Shim Installation
-This test injects a DLL into a custom application
+To test injecting DLL into a custom application
+you need to copy AtomicShim.dll Into C:\Tools
+As well as Compile the custom app.
+We believe observing the shim install is a good
+place to start.
 
 **Supported Platforms:** Windows
 
 
+#### Inputs
+| Name | Description | Type | Default Value | 
+|------|-------------|------|---------------|
+| file_path | Path to the shim databaase file | String | C:\AtomicRedTeam\atomics\T1138\src\AtomicShimx86.sdb|
+
 #### Run it with `command_prompt`!
 ```
-sdbinst.exe AtomicShimx86.sdb
+sdbinst.exe #{file_path}
+sdbinst.exe -u #{file_path}
 ```
 <br/>

--- a/atomics/T1138/T1138.yaml
+++ b/atomics/T1138/T1138.yaml
@@ -5,12 +5,21 @@ display_name: Application Shimming
 atomic_tests:
 - name: Application Shim Installation
   description: |
-    This test injects a DLL into a custom application
+    To test injecting DLL into a custom application
+    you need to copy AtomicShim.dll Into C:\Tools
+    As well as Compile the custom app.
+    We believe observing the shim install is a good
+    place to start.
 
   supported_platforms:
     - windows
-
+  input_arguments:
+    file_path:
+      description: Path to the shim databaase file
+      type: String
+      default: C:\AtomicRedTeam\atomics\T1138\src\AtomicShimx86.sdb
   executor:
     name: command_prompt
     command: |
-      sdbinst.exe AtomicShimx86.sdb
+      sdbinst.exe #{file_path}
+      sdbinst.exe -u #{file_path}

--- a/atomics/index.yaml
+++ b/atomics/index.yaml
@@ -640,16 +640,24 @@ persistence:
       identifier: T1138
     atomic_tests:
     - name: Application Shim Installation
-      description: 'This test injects a DLL into a custom application
-
-'
+      description: |
+        To test injecting DLL into a custom application
+        you need to copy AtomicShim.dll Into C:\Tools
+        As well as Compile the custom app.
+        We believe observing the shim install is a good
+        place to start.
       supported_platforms:
       - windows
+      input_arguments:
+        file_path:
+          description: Path to the shim databaase file
+          type: String
+          default: C:\AtomicRedTeam\atomics\T1138\src\AtomicShimx86.sdb
       executor:
         name: command_prompt
-        command: 'sdbinst.exe AtomicShimx86.sdb
-
-'
+        command: |
+          sdbinst.exe #{file_path}
+          sdbinst.exe -u #{file_path}
   T1197:
     technique:
       external_references:
@@ -10366,16 +10374,24 @@ privilege-escalation:
       identifier: T1138
     atomic_tests:
     - name: Application Shim Installation
-      description: 'This test injects a DLL into a custom application
-
-'
+      description: |
+        To test injecting DLL into a custom application
+        you need to copy AtomicShim.dll Into C:\Tools
+        As well as Compile the custom app.
+        We believe observing the shim install is a good
+        place to start.
       supported_platforms:
       - windows
+      input_arguments:
+        file_path:
+          description: Path to the shim databaase file
+          type: String
+          default: C:\AtomicRedTeam\atomics\T1138\src\AtomicShimx86.sdb
       executor:
         name: command_prompt
-        command: 'sdbinst.exe AtomicShimx86.sdb
-
-'
+        command: |
+          sdbinst.exe #{file_path}
+          sdbinst.exe -u #{file_path}
   T1088:
     technique:
       external_references:


### PR DESCRIPTION
**Details:**
Updated relative path, to be a variable and default to the full path of base atomic install.
**Testing:**
Windows 10 x64

**Associated Issues:**
<!-- Please link any issues that this pull request impacts or fixes. -->