### PR TITLE
escaping double quotes for command_prompt execution

### DIFF
--- a/execution-frameworks/Invoke-AtomicRedTeam/Invoke-AtomicRedTeam/Public/Invoke-AtomicTest.ps1
+++ b/execution-frameworks/Invoke-AtomicRedTeam/Invoke-AtomicRedTeam/Public/Invoke-AtomicTest.ps1
@@ -111,7 +111,8 @@ function Invoke-AtomicTest {
                         switch ($test.executor.name) {
                             "command_prompt" {
                                 Write-Information -MessageData "Command Prompt:`n $finalCommand" -Tags 'AtomicTest'
-                                $execCommand = $finalCommand.Split("`n")
+                                $finalCommandEscaped = $finalCommand -replace "`"","```""
+                                $execCommand = $finalCommandEscaped.Split("`n")
                                 $execCommand | ForEach-Object { Invoke-Expression "cmd.exe /c `"$_`" " }
                                 continue
                             }


### PR DESCRIPTION
**Details:**
When the yaml for a TTP is set to run with *command_prompt*, any double quotes in the executor command should be escaped to avoid double quotes inside of double quotes

**Testing:**
Before this bug fix, running T1117 resulted in this error:
> 'ELSE' is not recognized as an internal or external command,
>operable program or batch file.
