### PR TITLE
Write test execution details to log file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ atomic-red-team/enterprise-attack.json
 
 docs/.sass-cache/
 docs/_site/
+**/Invoke-AtomicTest-ExecutionLog.csv

--- a/execution-frameworks/Invoke-AtomicRedTeam/Invoke-AtomicRedTeam/Invoke-AtomicRedTeam.psm1
+++ b/execution-frameworks/Invoke-AtomicRedTeam/Invoke-AtomicRedTeam/Invoke-AtomicRedTeam.psm1
@@ -5,7 +5,7 @@ $Public = @( Get-ChildItem -Path $PSScriptRoot\Public\*.ps1 -Recurse -ErrorActio
 $Private = @( Get-ChildItem -Path $PSScriptRoot\Private\*.ps1 -Recurse -ErrorAction SilentlyContinue )
 
 #Dot source the files
-Foreach ($import in @($Public + $Private)) {
+Foreach ($import in @($Private + $Public)) {
     Try {
         . $import.fullname
     }

--- a/execution-frameworks/Invoke-AtomicRedTeam/Invoke-AtomicRedTeam/Public/Write-ExecutionLog.ps1
+++ b/execution-frameworks/Invoke-AtomicRedTeam/Invoke-AtomicRedTeam/Public/Write-ExecutionLog.ps1
@@ -1,0 +1,9 @@
+function Write-ExecutionLog($startTime, $technique, $testNum, $testName, $logPath) {
+    if (!(Test-Path $logPath)) { 
+        New-Item $logPath -Force -ItemType File 
+    } 
+
+    $timeUTC = (Get-Date($startTime).toUniversalTime() -uformat "%Y-%m-%dT%H:%m:%SZ").ToString()
+    $timeLocal = (Get-Date($startTime) -uformat "%Y-%m-%dT%H:%m:%SZ").ToString()
+    [PSCustomObject][ordered]@{ "Execution Time (UTC)" = $timeUTC; "Execution Time (Local)" = $timeLocal; "Technique" = $technique; "Test Number" = $testNum; "Test Name" = $testName } | Export-Csv -Path $LogPath -NoTypeInformation -Append
+}

--- a/execution-frameworks/Invoke-AtomicRedTeam/README.md
+++ b/execution-frameworks/Invoke-AtomicRedTeam/README.md
@@ -68,10 +68,20 @@ Specify a path to atomics folder, example C:\AtomicRedTeam\atomics
 Invoke-AtomicTest T1117
 ```
 
+By default, test execution details are written to `Invoke-AtomicTest-ExecutionLog.csv` in the current directory.
+
+#### Specify an Alternate Path for the Execution Log
+
+```powershell
+Invoke-AtomicTest T1117 -ExecutionLogPath 'C:\Temp\mylog.csv'
+```
+
+By default, test execution details are written to `Invoke-AtomicTest-ExecutionLog.csv` in the current directory. Use the `-ExecutionLogPath` parameter to write to a different file. Nothing is logged in the execution log when only running pre-requisite checks with `-CheckPrereqs` or cleanup commands with `-Cleanup`. Use the `-NoExecutionLog` switch to not write execution details to disk.
+
 #### Check that Prerequistes for a Given TTP are met
 
 For the "command_prompt" executor, if any of the prereq_command's return a non-zero exit code, the pre-requisites are not met. Example: **fltmc.exe filters | findstr #{sysmon_driver}**
-For the "powershell" executor, the prereq_command's are run as a script block and the script must return 0 for success. Example: **if(Test-Path C:\Windows\System32\cmd.exe) { 0 } else { -1 }**
+For the "powershell" executor, the prereq_command's are run as a script block and the script must return 0 if the pre-requisites are met. Example: **if(Test-Path C:\Windows\System32\cmd.exe) { 0 } else { -1 }**
 
 ```powershell
 Invoke-AtomicTest T1117 -CheckPrereqs


### PR DESCRIPTION
Each test that is executed is written to a log file by default as shown below. This is useful for comparing what tests where run to what tests were detected, in an automated fashion.

By default, test execution details are written to `Invoke-AtomicTest-ExecutionLog.csv` in the current directory. Use the `-ExecutionLogPath` parameter to write to a different file. Nothing is logged in the execution log when only running pre-requisite checks with `-CheckPrereqs` or cleanup commands with `-Cleanup`. Use the `-NoExecutionLog` switch to not write execution details to disk.


![image](https://user-images.githubusercontent.com/22311332/64042266-c2d97780-cb1e-11e9-86a7-a7cdc89e5973.png)
