### PR TITLE
markdown fix for manual tests

### DIFF
--- a/atomic_red_team/atomic_doc_template.md.erb
+++ b/atomic_red_team/atomic_doc_template.md.erb
@@ -37,6 +37,7 @@ end.join(', ') %>
 
 <%- if test['executor']['name'] == 'manual' -%>
 #### Run it with these steps! <%- if test['executor']['elevation_required'] -%> Elevation Required (e.g. root or admin) <%- end -%>
+
 <%= test['executor']['steps'] %>
 
 <%- else -%>


### PR DESCRIPTION
Step 1 was showing up on the header line in the markdown for manual tests

![image](https://user-images.githubusercontent.com/22311332/64186353-ec024c80-ce2b-11e9-9508-bab78dd909e2.png)
