### PR TITLE
fail pre-req check if elevation required but not provided

### DIFF
--- a/execution-frameworks/Invoke-AtomicRedTeam/README.md
+++ b/execution-frameworks/Invoke-AtomicRedTeam/README.md
@@ -111,6 +111,15 @@ Invoke-AtomicTest T1117 -TestNumbers 1, 2
 ```powershell
 Invoke-AtomicTest T1117 -TestNames "Regsvr32 remote COM scriptlet execution","Regsvr32 local DLL execution"
 ```
+#### Specify Input Parameters on the Command Line
+
+```powershell
+$inputParameters = @{ "file_name" = "c:\Temp\myfile.txt"; "ads_filename" = "C:\Temp\ads-file.txt"  }
+Invoke-AtomicTest T1158 -TestNames "Create ADS command prompt" -InputParameters $inputParameters
+```
+
+You can specify a subset of the input parameters via the command line. Any input parameters not explicitly defined will maintain their default values.
+
 #### Run the Cleanup Commands For the Specified Test
 
 ```powershell


### PR DESCRIPTION
If the user specifies the -CheckPrereqs switch from an un-elevated context and the test requires elevation (based on the elevation_required attribute in the yaml file) the Pre-req will be reported as not met.

You can still invoke the test regardless of whether it meets the pre-reqs but just be aware that the attack steps likely won't complete.

![image](https://user-images.githubusercontent.com/22311332/64267538-d35d6980-cef3-11e9-85c6-1b009f4ea679.png)
