### PR TITLE
bug fix for order of operations

### DIFF
--- a/execution-frameworks/Invoke-AtomicRedTeam/Invoke-AtomicRedTeam/Public/Invoke-AtomicTest.ps1
+++ b/execution-frameworks/Invoke-AtomicRedTeam/Invoke-AtomicRedTeam/Public/Invoke-AtomicTest.ps1
@@ -197,7 +197,7 @@ function Invoke-AtomicTest {
                         $finalCommand = $command
                     }
 
-                    if ($null -ne $finalCommand -and $test.input_arguments.Count -gt 0) {
+                    if (($null -ne $finalCommand) -and ($test.input_arguments.Count -gt 0)) {
                         Write-Verbose -Message 'Replacing inputArgs with user specified values or default values none provided'
                         $inputArgs = Get-InputArgs $test.input_arguments
 


### PR DESCRIPTION
if statement was working wrong because it needed parenthesis. This resulted in a null references error when running prereq checks on a test with no prereqs defined.