### PR TITLE
fix null error when using -Cleanup and -ShowDetails

### DIFF
--- a/execution-frameworks/Invoke-AtomicRedTeam/Invoke-AtomicRedTeam/Public/Invoke-AtomicTest.ps1
+++ b/execution-frameworks/Invoke-AtomicRedTeam/Invoke-AtomicRedTeam/Public/Invoke-AtomicTest.ps1
@@ -209,7 +209,7 @@ function Invoke-AtomicTest {
 
                     Write-Debug -Message 'Getting executor and build command script'
 
-                    if ($ShowDetails) {
+                    if ($ShowDetails -and ($null -ne $finalCommand)) {
                         Write-Information -MessageData $finalCommand -Tags 'Command'
                     }
                     else {


### PR DESCRIPTION
Using the -Cleanup and -ShowDetails switches together resulted in a null reference error for tests that did not include cleanup commands in their definition.