### PR TITLE
rename InputParameters to InputArgs

### DIFF
--- a/execution-frameworks/Invoke-AtomicRedTeam/Invoke-AtomicRedTeam/Public/Invoke-AtomicTest.ps1
+++ b/execution-frameworks/Invoke-AtomicRedTeam/Invoke-AtomicRedTeam/Public/Invoke-AtomicTest.ps1
@@ -83,7 +83,7 @@ function Invoke-AtomicTest {
         [Parameter(Mandatory = $false,
             ParameterSetName = 'technique')]
         [HashTable]
-        $InputParameters
+        $InputArgs
     )
     BEGIN { } # Intentionally left blank and can be removed
     PROCESS {
@@ -92,18 +92,18 @@ function Invoke-AtomicTest {
         $isElevated = ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
 
         function Get-InputArgs([hashtable]$ip) {
-            $inputArgs = [Array]($ip.Keys).Split(" ")
+            $inputArgsDefault = [Array]($ip.Keys).Split(" ")
             $inputDefaults = [Array]($ip.Values | ForEach-Object { $_.default.toString() }).Split(" ")
             $defaultArgs = @{ }
-            for ($i = 0; $i -lt $inputArgs.Length; $i++) {
-                $defaultArgs[$inputArgs[$i]] = $inputDefaults[$i]
+            for ($i = 0; $i -lt $inputArgsDefault.Length; $i++) {
+                $defaultArgs[$inputArgsDefault[$i]] = $inputDefaults[$i]
 
             }
             # overwrite defaults with any user supplied values
-            foreach ($key in $InputParameters.Keys) {
+            foreach ($key in $InputArgs.Keys) {
                 if ($defaultArgs.Keys -contains $key) {
                     # replace default with user supplied
-                    $defaultArgs.set_Item($key, $InputParameters[$key])
+                    $defaultArgs.set_Item($key, $InputArgs[$key])
                 }
             }
             $defaultArgs
@@ -198,7 +198,7 @@ function Invoke-AtomicTest {
                     }
 
                     if (($null -ne $finalCommand) -and ($test.input_arguments.Count -gt 0)) {
-                        Write-Verbose -Message 'Replacing inputArgs with user specified values or default values none provided'
+                        Write-Verbose -Message 'Replacing inputArgs with user specified values, or default values if none provided'
                         $inputArgs = Get-InputArgs $test.input_arguments
 
                         foreach ($key in $inputArgs.Keys) {

--- a/execution-frameworks/Invoke-AtomicRedTeam/README.md
+++ b/execution-frameworks/Invoke-AtomicRedTeam/README.md
@@ -114,8 +114,8 @@ Invoke-AtomicTest T1117 -TestNames "Regsvr32 remote COM scriptlet execution","Re
 #### Specify Input Parameters on the Command Line
 
 ```powershell
-$inputParameters = @{ "file_name" = "c:\Temp\myfile.txt"; "ads_filename" = "C:\Temp\ads-file.txt"  }
-Invoke-AtomicTest T1158 -TestNames "Create ADS command prompt" -InputParameters $inputParameters
+$myArgs = @{ "file_name" = "c:\Temp\myfile.txt"; "ads_filename" = "C:\Temp\ads-file.txt"  }
+Invoke-AtomicTest T1158 -TestNames "Create ADS command prompt" -InputArgs $myArgs
 ```
 
 You can specify a subset of the input parameters via the command line. Any input parameters not explicitly defined will maintain their default values.


### PR DESCRIPTION
InputArgs more closely matches the yaml test definition name of input_arguments