### PR TITLE
Added test for deletion of prefetch files (anti-forensic technique)

### DIFF
--- a/atomics/T1107/T1107.yaml
+++ b/atomics/T1107/T1107.yaml
@@ -169,3 +169,14 @@ atomic_tests:
     name: bash
     command: |
       rm -rf / --no-preserve-root > /dev/null 2> /dev/null
+
+- name: Delete-PrefetchFile
+  description: |
+    Delete a single prefetch file.  Deletion of prefetch files is a known anti-forensic technique.
+  supported_platforms:
+    - windows
+  executor:
+    name: powershell
+    elevation_required: true
+    command: |
+      Remove-Item -Path (Join-Path "$Env:SystemRoot\prefetch\" (Get-ChildItem -Path "$Env:SystemRoot\prefetch\*.pf" -Name)[0])


### PR DESCRIPTION
**Details:**  Adding a new atomic for support on 1107, Delete a single prefetch file.  Deletion of prefetch files is a known anti-forensic technique.  An earlier version of this was drafted by Carrie Roberts (@clr2of8 )

**Testing:**  Atomic was tested with success by another jb on Windows 10, powershell with elevated privileges.

**Associated Issues:**  No known issues