### PR TITLE
Added new atomic, 'Modify registry for password downgrade to plain text'

### DIFF
--- a/atomics/T1112/T1112.yaml
+++ b/atomics/T1112/T1112.yaml
@@ -87,3 +87,16 @@ atomic_tests:
       ### Garbage collection and closing of ntuser.dat ###
       [gc]::Collect()
       reg unload "HKU\$($ProfileList[$p].SID)"
+
+- name: Modify registry for password downgrade to plain text
+  description: |
+    Sets registry key that will tell windows to store plaintext passwords (making the system vulnerable to clear text / cleartext password dumping) 
+  supported_platforms:
+    - windows
+  executor:
+  name: command_prompt
+  elevation_required: true
+  command: |
+    reg add HKLM\SYSTEM\CurrentControlSet\Control\SecurityProviders\WDigest /v UseLogonCredential /t REG_DWORD /d 1 /f
+  cleanup_command: |
+    reg add HKLM\SYSTEM\CurrentControlSet\Control\SecurityProviders\WDigest /v UseLogonCredential /t REG_DWORD /d 0 /f

--- a/atomics/T1112/T1112.yaml
+++ b/atomics/T1112/T1112.yaml
@@ -94,9 +94,9 @@ atomic_tests:
   supported_platforms:
     - windows
   executor:
-  name: command_prompt
-  elevation_required: true
-  command: |
-    reg add HKLM\SYSTEM\CurrentControlSet\Control\SecurityProviders\WDigest /v UseLogonCredential /t REG_DWORD /d 1 /f
-  cleanup_command: |
-    reg add HKLM\SYSTEM\CurrentControlSet\Control\SecurityProviders\WDigest /v UseLogonCredential /t REG_DWORD /d 0 /f
+      name: command_prompt
+      elevation_required: true
+      command: |
+        reg add HKLM\SYSTEM\CurrentControlSet\Control\SecurityProviders\WDigest /v UseLogonCredential /t REG_DWORD /d 1 /f
+      cleanup_command: |
+        reg add HKLM\SYSTEM\CurrentControlSet\Control\SecurityProviders\WDigest /v UseLogonCredential /t REG_DWORD /d 0 /f


### PR DESCRIPTION
**Details:**
Added new atomic, 'Modify registry for password downgrade to plain text.'  An earlier version of this was drafted by Carrie Roberts (@clr2of8 ).  Test sets a registry key that will tell windows to store plaintext passwords (making the system vulnerable to clear text / cleartext password dumping) which are easily retrievable and usable by an adversary. 

**Testing:**
Original version was tested by Carrie and this atomic was tested by a different jb, and re-written and published by cherokeejb_

**Associated Issues:**
No known issues