### PR TITLE
Added 'Elevated group enumeration using net group' + minor titles edit

### DIFF
--- a/atomics/T1069/T1069.yaml
+++ b/atomics/T1069/T1069.yaml
@@ -55,7 +55,7 @@ atomic_tests:
 
 - name: Elevated group enumeration using net group
   description: |
-    Runs 'net group' command including possible obfuscation/typos to simulate enumeration/discovery of high value domain groups
+    Runs 'net group' command including command aliases to simulate enumeration/discovery of high value domain groups
 
   supported_platforms:
     - windows
@@ -66,5 +66,5 @@ atomic_tests:
     command: |
       net group /domai 'Domain Admins'
       net groups 'Account Operators' /doma
-      net groups 'Exchange Organization Management` /doma
-      net group `BUILTIN\Backup Operators` /doma
+      net groups 'Exchange Organization Management' /doma
+      net group 'BUILTIN\Backup Operators' /doma

--- a/atomics/T1069/T1069.yaml
+++ b/atomics/T1069/T1069.yaml
@@ -55,7 +55,7 @@ atomic_tests:
 
 - name: Elevated group enumeration using net group
   description: |
-    Runs 'net group' command including command aliases to simulate enumeration/discovery of high value domain groups
+    Runs 'net group' command including command aliases and loose typing to simulate enumeration/discovery of high value domain groups
 
   supported_platforms:
     - windows

--- a/atomics/T1069/T1069.yaml
+++ b/atomics/T1069/T1069.yaml
@@ -18,9 +18,9 @@ atomic_tests:
       dscl . -list /Groups
       groups
 
-- name: Permission Groups Discovery Windows
+- name: Basic Permission Groups Discovery Windows
   description: |
-    Permission Groups Discovery for Windows
+    Basic Permission Groups Discovery for Windows
 
   supported_platforms:
     - windows
@@ -51,5 +51,20 @@ atomic_tests:
     command: |
       get-localgroup
       get-ADPrinicipalGroupMembership #{user} | select name
+atomic_tests:
 
+- name: Elevated group enumeration using net group
+  description: |
+    Runs 'net group' command including possible obfuscation/typos to simulate enumeration/discovery of high value domain groups
 
+  supported_platforms:
+    - windows
+
+  executor:
+    name: command_prompt
+    elevation_required: false
+    command: |
+      net group /domai 'Domain Admins'
+      net groups 'Account Operators' /doma
+      net groups 'Exchange Organization Management` /doma
+      net group `BUILTIN\Backup Operators` /doma


### PR DESCRIPTION
sa`w**Details:**
Added a new atomic (test 4), and updated the test 2 name to more clearly reflect what it is doing versus the newly added atomic (which has commands more specific to high value, elevated groups, and as well simple obfuscation).  The new test mimics an adversary attempting to enumerate groups in Windows.  The attacker runs the 'net group' command (4 examples were included here to simulate enumeration/discovery of high value domain groups).  This test could be easily customized or added-to.  An earlier version of this test 4 was drafted by Carrie Roberts (@clr2of8 ).  @Andras32 helped review her test and a similar test for net user. 

**Testing:**
Carrie tested her original draft; this test 4 is simply the typing of the net user command; I've checked the syntax, and @Andras32 tested an earlier version of this test.

**Associated Issues:**
no known issues