### PR TITLE
Add MPCmdRun.exe - T1089

### DIFF
--- a/atomics/T1089/T1089.yaml
+++ b/atomics/T1089/T1089.yaml
@@ -183,18 +183,18 @@ atomic_tests:
        New-Item -Path "HKLM:\SOFTWARE\Microsoft\AMSI\Providers" -Name "{2781761E-28E0-4109-99FE-B9D127C57AFE}"
 
 
-- name: MPCmdRun.exe - Revert Windows Defender Signatures
- description: |
-   With administrative rights, an adversary can revert Windows Defender AV engine, definition and dynamic signatures using mpcmdrun.exe.
+ - name: MPCmdRun.exe - Revert Windows Defender Signatures
+   description: |
+     With administrative rights, an adversary can revert Windows Defender AV engine, definition and dynamic signatures using mpcmdrun.exe.
 
- supported_platforms:
-   - windows
+   supported_platforms:
+     - windows
 
- executor:
-   name: command_prompt
-   elevation_required: true
-   command: |
-      %ProgramFiles%\Windows Defender\MpCMDRun.exe -RemoveDefinitions -All
-      %ProgramFiles%\Windows Defender\MpCMDRun.exe -removedefinitions -dynamicsignatures
-   cleanup_command: |
-      %ProgramFiles%\Windows Defender\MpCMDRun.exe -SignatureUpdate
+   executor:
+     name: command_prompt
+     elevation_required: true
+     command: |
+        %ProgramFiles%\Windows Defender\MpCMDRun.exe -RemoveDefinitions -All
+        %ProgramFiles%\Windows Defender\MpCMDRun.exe -removedefinitions -dynamicsignatures
+     cleanup_command: |
+        %ProgramFiles%\Windows Defender\MpCMDRun.exe -SignatureUpdate

--- a/atomics/T1089/T1089.yaml
+++ b/atomics/T1089/T1089.yaml
@@ -183,18 +183,18 @@ atomic_tests:
        New-Item -Path "HKLM:\SOFTWARE\Microsoft\AMSI\Providers" -Name "{2781761E-28E0-4109-99FE-B9D127C57AFE}"
 
 
- - name: MPCmdRun.exe - Revert Windows Defender Signatures
-   description: |
-     With administrative rights, an adversary can revert Windows Defender AV engine, definition and dynamic signatures using mpcmdrun.exe.
+- name: MPCmdRun.exe - Revert Windows Defender Signatures
+ description: |
+   With administrative rights, an adversary can revert Windows Defender AV engine, definition and dynamic signatures using mpcmdrun.exe.
 
-   supported_platforms:
-     - windows
+ supported_platforms:
+   - windows
 
-   executor:
-     name: command_prompt
-     elevation_required: true
-     command: |
-        %ProgramFiles%\Windows Defender\MpCMDRun.exe -RemoveDefinitions -All
-        %ProgramFiles%\Windows Defender\MpCMDRun.exe -removedefinitions -dynamicsignatures
-     cleanup_command: |
-        %ProgramFiles%\Windows Defender\MpCMDRun.exe -SignatureUpdate
+ executor:
+   name: command_prompt
+   elevation_required: true
+   command: |
+      %ProgramFiles%\Windows Defender\MpCMDRun.exe -RemoveDefinitions -All
+      %ProgramFiles%\Windows Defender\MpCMDRun.exe -removedefinitions -dynamicsignatures
+   cleanup_command: |
+      %ProgramFiles%\Windows Defender\MpCMDRun.exe -SignatureUpdate

--- a/atomics/T1089/T1089.yaml
+++ b/atomics/T1089/T1089.yaml
@@ -98,7 +98,7 @@ atomic_tests:
 
 - name: Unload Sysmon Filter Driver
   description: |
-    Unloads the Sysinternals Sysmon filter driver without stopping the Sysmon service. 
+    Unloads the Sysinternals Sysmon filter driver without stopping the Sysmon service.
   supported_platforms:
     - windows
   input_arguments:
@@ -120,7 +120,7 @@ atomic_tests:
 
 - name: Disable Windows IIS HTTP Logging
   description: |
-    Disables HTTP logging on a Windows IIS web server as seen by Threat Group 3390 (Bronze Union). 
+    Disables HTTP logging on a Windows IIS web server as seen by Threat Group 3390 (Bronze Union).
     This action requires HTTP logging configurations in IIS to be unlocked.
   supported_platforms:
     - windows
@@ -153,7 +153,7 @@ atomic_tests:
 
 - name: AMSI Bypass - AMSI InitFailed
   description: |
-    Any easy way to bypass AMSI inspection is it patch the dll in memory setting the "amsiInitFailed" function to true. 
+    Any easy way to bypass AMSI inspection is it patch the dll in memory setting the "amsiInitFailed" function to true.
     https://www.mdsec.co.uk/2018/06/exploring-powershell-amsi-and-logging-evasion/
   supported_platforms:
     - windows
@@ -169,7 +169,7 @@ atomic_tests:
 - name: AMSI Bypass - Remove AMSI Provider Reg Key
   description: |
     With administrative rights, an adversary can remove the AMSI Provider registry key in HKLM\Software\Microsoft\AMSI to disable AMSI inspection.
-    This test removes the Windows Defender provider registry key. 
+    This test removes the Windows Defender provider registry key.
 
   supported_platforms:
     - windows
@@ -181,3 +181,19 @@ atomic_tests:
        Remove-Item -Path "HKLM:\SOFTWARE\Microsoft\AMSI\Providers\{2781761E-28E0-4109-99FE-B9D127C57AFE}" -Recurse
     cleanup_command: |
        New-Item -Path "HKLM:\SOFTWARE\Microsoft\AMSI\Providers" -Name "{2781761E-28E0-4109-99FE-B9D127C57AFE}"
+
+- name: MPCmdRun.exe - Revert Windows Defender Signatures
+ description: |
+   With administrative rights, an adversary can revert Windows Defender AV engine, definition and dynamic signatures using mpcmdrun.exe.
+
+ supported_platforms:
+   - windows
+
+ executor:
+   name: command_prompt
+   elevation_required: true
+   command: |
+      %ProgramFiles%\Windows Defender\MpCMDRun.exe -RemoveDefinitions -All
+      %ProgramFiles%\Windows Defender\MpCMDRun.exe -removedefinitions -dynamicsignatures
+   cleanup_command: |
+      %ProgramFiles%\Windows Defender\MpCMDRun.exe -SignatureUpdate

--- a/atomics/T1089/T1089.yaml
+++ b/atomics/T1089/T1089.yaml
@@ -98,7 +98,7 @@ atomic_tests:
 
 - name: Unload Sysmon Filter Driver
   description: |
-    Unloads the Sysinternals Sysmon filter driver without stopping the Sysmon service. 
+    Unloads the Sysinternals Sysmon filter driver without stopping the Sysmon service.
   supported_platforms:
     - windows
   input_arguments:
@@ -120,7 +120,7 @@ atomic_tests:
 
 - name: Disable Windows IIS HTTP Logging
   description: |
-    Disables HTTP logging on a Windows IIS web server as seen by Threat Group 3390 (Bronze Union). 
+    Disables HTTP logging on a Windows IIS web server as seen by Threat Group 3390 (Bronze Union).
     This action requires HTTP logging configurations in IIS to be unlocked.
   supported_platforms:
     - windows
@@ -153,7 +153,7 @@ atomic_tests:
 
 - name: AMSI Bypass - AMSI InitFailed
   description: |
-    Any easy way to bypass AMSI inspection is it patch the dll in memory setting the "amsiInitFailed" function to true. 
+    Any easy way to bypass AMSI inspection is it patch the dll in memory setting the "amsiInitFailed" function to true.
     https://www.mdsec.co.uk/2018/06/exploring-powershell-amsi-and-logging-evasion/
   supported_platforms:
     - windows
@@ -169,7 +169,7 @@ atomic_tests:
 - name: AMSI Bypass - Remove AMSI Provider Reg Key
   description: |
     With administrative rights, an adversary can remove the AMSI Provider registry key in HKLM\Software\Microsoft\AMSI to disable AMSI inspection.
-    This test removes the Windows Defender provider registry key. 
+    This test removes the Windows Defender provider registry key.
 
   supported_platforms:
     - windows
@@ -181,3 +181,20 @@ atomic_tests:
        Remove-Item -Path "HKLM:\SOFTWARE\Microsoft\AMSI\Providers\{2781761E-28E0-4109-99FE-B9D127C57AFE}" -Recurse
     cleanup_command: |
        New-Item -Path "HKLM:\SOFTWARE\Microsoft\AMSI\Providers" -Name "{2781761E-28E0-4109-99FE-B9D127C57AFE}"
+
+
+ - name: MPCmdRun.exe - Revert Windows Defender Signatures
+   description: |
+     With administrative rights, an adversary can revert Windows Defender AV engine, definition and dynamic signatures using mpcmdrun.exe.
+
+   supported_platforms:
+     - windows
+
+   executor:
+     name: command_prompt
+     elevation_required: true
+     command: |
+        %ProgramFiles%\Windows Defender\MpCMDRun.exe -RemoveDefinitions -All
+        %ProgramFiles%\Windows Defender\MpCMDRun.exe -removedefinitions -dynamicsignatures
+     cleanup_command: |
+        %ProgramFiles%\Windows Defender\MpCMDRun.exe -SignatureUpdate

--- a/atomics/T1089/T1089.yaml
+++ b/atomics/T1089/T1089.yaml
@@ -98,7 +98,7 @@ atomic_tests:
 
 - name: Unload Sysmon Filter Driver
   description: |
-    Unloads the Sysinternals Sysmon filter driver without stopping the Sysmon service.
+    Unloads the Sysinternals Sysmon filter driver without stopping the Sysmon service. 
   supported_platforms:
     - windows
   input_arguments:
@@ -120,7 +120,7 @@ atomic_tests:
 
 - name: Disable Windows IIS HTTP Logging
   description: |
-    Disables HTTP logging on a Windows IIS web server as seen by Threat Group 3390 (Bronze Union).
+    Disables HTTP logging on a Windows IIS web server as seen by Threat Group 3390 (Bronze Union). 
     This action requires HTTP logging configurations in IIS to be unlocked.
   supported_platforms:
     - windows
@@ -153,7 +153,7 @@ atomic_tests:
 
 - name: AMSI Bypass - AMSI InitFailed
   description: |
-    Any easy way to bypass AMSI inspection is it patch the dll in memory setting the "amsiInitFailed" function to true.
+    Any easy way to bypass AMSI inspection is it patch the dll in memory setting the "amsiInitFailed" function to true. 
     https://www.mdsec.co.uk/2018/06/exploring-powershell-amsi-and-logging-evasion/
   supported_platforms:
     - windows
@@ -169,7 +169,7 @@ atomic_tests:
 - name: AMSI Bypass - Remove AMSI Provider Reg Key
   description: |
     With administrative rights, an adversary can remove the AMSI Provider registry key in HKLM\Software\Microsoft\AMSI to disable AMSI inspection.
-    This test removes the Windows Defender provider registry key.
+    This test removes the Windows Defender provider registry key. 
 
   supported_platforms:
     - windows
@@ -181,20 +181,3 @@ atomic_tests:
        Remove-Item -Path "HKLM:\SOFTWARE\Microsoft\AMSI\Providers\{2781761E-28E0-4109-99FE-B9D127C57AFE}" -Recurse
     cleanup_command: |
        New-Item -Path "HKLM:\SOFTWARE\Microsoft\AMSI\Providers" -Name "{2781761E-28E0-4109-99FE-B9D127C57AFE}"
-
-
- - name: MPCmdRun.exe - Revert Windows Defender Signatures
-   description: |
-     With administrative rights, an adversary can revert Windows Defender AV engine, definition and dynamic signatures using mpcmdrun.exe.
-
-   supported_platforms:
-     - windows
-
-   executor:
-     name: command_prompt
-     elevation_required: true
-     command: |
-        %ProgramFiles%\Windows Defender\MpCMDRun.exe -RemoveDefinitions -All
-        %ProgramFiles%\Windows Defender\MpCMDRun.exe -removedefinitions -dynamicsignatures
-     cleanup_command: |
-        %ProgramFiles%\Windows Defender\MpCMDRun.exe -SignatureUpdate


### PR DESCRIPTION
Adding MpCmdRun.exe tests:
1. Remove all definitions, set's it back to default signature set
2. Remove Dynamic Security intelligence

References:
- https://docs.microsoft.com/en-us/windows/security/threat-protection/windows-defender-antivirus/command-line-arguments-windows-defender-antivirus
- https://twitter.com/DissectMalware/status/1009880785631969280?s=20

Tested on Win10 Latest