### PR TITLE
T1076 rdp to domain controller

### DIFF
--- a/atomics/T1076/T1076.yaml
+++ b/atomics/T1076/T1076.yaml
@@ -19,3 +19,30 @@ atomic_tests:
       sc.exe create sesshijack binpath= "cmd.exe /k tscon 1337 /dest:rdp-tcp#55"
       net start sesshijack
       sc.exe delete sesshijack
+
+- name: RDPto-DomainController
+  description: |
+    Attempt an RDP session via "Connect-RDP" to a system. Default RDPs to (%logonserver%) as the current user
+
+  supported_platforms:
+    - windows
+
+  input_arguments:
+    
+    logonserver:
+      description: ComputerName argument default %logonserver%
+      type: String
+      default: $ENV:logonserver.TrimStart("\")
+    
+    username:
+      description: Username argument default %USERDOMAIN%\%username%
+      type: String
+      default: $Env:USERDOMAIN\$ENV:USERNAME
+
+  executor:
+    name: powershell
+    elevation_required: false
+    prereq_command: |
+      if((Get-WmiObject -Class Win32_ComputerSystem).PartOfDomain) {0} else {1}
+    command: |
+      Connect-RDP -ComputerName #{logonserver} -User #{username}

--- a/execution-frameworks/Invoke-AtomicRedTeam/Invoke-AtomicRedTeam/Public/Invoke-AtomicTest.ps1
+++ b/execution-frameworks/Invoke-AtomicRedTeam/Invoke-AtomicRedTeam/Public/Invoke-AtomicTest.ps1
@@ -96,8 +96,9 @@ function Invoke-AtomicTest {
             $privid = id -u                
             if ($privid -eq 0){
                 $isElevated = $true
-            }
-
+            } else {
+                $isElevated = $false
+        }
         function Get-InputArgs([hashtable]$ip) {
             $inputArgsDefault = [Array]($ip.Keys).Split(" ")
             $inputDefaults = [Array]($ip.Values | ForEach-Object { $_.default.toString() }).Split(" ")

--- a/execution-frameworks/Invoke-AtomicRedTeam/Invoke-AtomicRedTeam/Public/Invoke-AtomicTest.ps1
+++ b/execution-frameworks/Invoke-AtomicRedTeam/Invoke-AtomicRedTeam/Public/Invoke-AtomicTest.ps1
@@ -98,6 +98,7 @@ function Invoke-AtomicTest {
                 $isElevated = $true
             } else {
                 $isElevated = $false
+            }
         }
         function Get-InputArgs([hashtable]$ip) {
             $inputArgsDefault = [Array]($ip.Keys).Split(" ")

--- a/execution-frameworks/Invoke-AtomicRedTeam/Invoke-AtomicRedTeam/Public/Invoke-AtomicTest.ps1
+++ b/execution-frameworks/Invoke-AtomicRedTeam/Invoke-AtomicRedTeam/Public/Invoke-AtomicTest.ps1
@@ -89,7 +89,14 @@ function Invoke-AtomicTest {
     PROCESS {
         # $InformationPrefrence = 'Continue'
         Write-Verbose -Message 'Attempting to run Atomic Techniques'
-        $isElevated = ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+        if ($IsWindows){
+            $isElevated = ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+        }
+        if ($IsLinux -or $IsMacOS){
+            $privid = id -u                
+            if ($privid -eq 0){
+                $isElevated = $true
+            }
 
         function Get-InputArgs([hashtable]$ip) {
             $inputArgsDefault = [Array]($ip.Keys).Split(" ")

--- a/execution-frameworks/Invoke-AtomicRedTeam/Invoke-AtomicRedTeam/Public/Invoke-AtomicTest.ps1
+++ b/execution-frameworks/Invoke-AtomicRedTeam/Invoke-AtomicRedTeam/Public/Invoke-AtomicTest.ps1
@@ -99,6 +99,8 @@ function Invoke-AtomicTest {
             } else {
                 $isElevated = $false
             }
+        } else {
+            $isElevated = $false
         }
         function Get-InputArgs([hashtable]$ip) {
             $inputArgsDefault = [Array]($ip.Keys).Split(" ")


### PR DESCRIPTION
**Details:**
Added a Connect-RDP test to T1076. by default it attempts to RDP from the logged on user to %logonserver%. The Source User and Target can be changed via "logonserver" and "username input variables. Prereq check ensures the user is logged onto a domain.

**Testing:**
Windows 10. @clr2of8 wrote original version. Has been Reviewed by @cherokeejb. 

**Associated Issues:**
N/A