### PR TITLE
Fix a macOS vs Linux and fix a description bug

### DIFF
--- a/atomics/T1081/T1081.yaml
+++ b/atomics/T1081/T1081.yaml
@@ -29,7 +29,7 @@ atomic_tests:
   executor:
     name: sh
     command: |
-      grep -riP password #{file_path}
+      grep -ri password #{file_path}
 
 - name: Mimikatz & Kittenz
   description: |

--- a/atomics/T1201/T1201.yaml
+++ b/atomics/T1201/T1201.yaml
@@ -82,7 +82,7 @@ atomic_tests:
 
 - name: Examine password policy - macOS
   description: |
-    Lists the password policy to console on Windows.
+    Lists the password policy to console on macOS.
 
   supported_platforms:
     - macos


### PR DESCRIPTION
**Details:**
Fix a bug in T1081 where the macos version of grep is wrongly expected to accept the -P flag and fix a labeling bug in T1201 where a macOS command is wrongly described as a Windows command

**Testing:**
I made the changes locally and was still able to successfully use the YAML files in question

**Associated Issues:**
N/A