### PR TITLE
T1112 atomic 4 name clarification

### DIFF
--- a/atomics/T1112/T1112.yaml
+++ b/atomics/T1112/T1112.yaml
@@ -88,7 +88,7 @@ atomic_tests:
       [gc]::Collect()
       reg unload "HKU\$($ProfileList[$p].SID)"
 
-- name: Modify registry for password downgrade to plain text
+- name: Modify registry to store logon credentials
   description: |
     Sets registry key that will tell windows to store plaintext passwords (making the system vulnerable to clear text / cleartext password dumping) 
   supported_platforms:


### PR DESCRIPTION
**Details:**
After further thought & discussion; suggesting a more precise name for atomic 4 (originally pulled here by me).  Changing to "Modify registry to store logon credentials," and removing the former word "downgrade."  The registry modification in this test does not actually enable a "downgrade," rather it allows the storage of auto-login credentials overall; they are resultingly stored as text, but that is not a downgrade

**Testing:**
 no testing required (only name change)

**Associated Issues:** 
none