### PR TITLE
Added atomic "Access "unattend.xml," corrected and simplified names o…

### DIFF
--- a/atomics/T1081/T1081.yaml
+++ b/atomics/T1081/T1081.yaml
@@ -3,7 +3,7 @@ attack_technique: T1081
 display_name: Credentials in Files
 
 atomic_tests:
-- name: Browser and System credentials
+- name: Extract Browser and System credentials with LaZagne
   description: |
     [LaZagne Source](https://github.com/AlessandroZ/LaZagne)
 
@@ -15,7 +15,7 @@ atomic_tests:
     command: |
       python2 laZagne.py all
 
-- name: Extract credentials from files
+- name: Extract passwords with grep
   description: |
     Extracting credentials from files
   input_arguments:
@@ -31,7 +31,7 @@ atomic_tests:
     command: |
       grep -ri password #{file_path}
 
-- name: Mimikatz & Kittenz
+- name: Runs Mimikatz & Mimikittenz by name
   description: |
     Mimikatz/kittenz - This will require a Mimikatz executable or invoke-mimikittenz ps module.
   supported_platforms:
@@ -43,7 +43,7 @@ atomic_tests:
       invoke-mimikittenz
       mimikatz.exe
 
-- name: Extracting credentials from files
+- name: Extracting passwords with findstr
   description: |
     Extracting Credentials from Files
   supported_platforms:
@@ -54,4 +54,17 @@ atomic_tests:
     command: |
       findstr /si pass *.xml | *.doc | *.txt | *.xls
       ls -R | select-string -Pattern password
+      
+- name: Access "unattend.xml"
+  description: |
+    Attempts to access unattend.xml, where credentials are commonly stored, within the Panther directory where installation logs are stored.
+   
+  supported_platforms:
+    - windows
+  executor:
+    name: command_prompt
+    elevation_required: true
+    command: |
+      cmd /c type C:\Windows\Panther\unattend.xml > nul 2>&1
+      cmd /c type C:\Windows\Panther\Unattend\unattend.xml > nul 2>&1
 


### PR DESCRIPTION
**Details:**
Added a new test that attempts to access unattend.xml, where credentials are commonly stored, within the Panther directory where installation logs are stored.  Carrie Roberts @clr2of8 drafted an earlier version of this test.  As well, I updated the names of the tests here while keeping them simple; un-needed duplicates were present and titles were very unclear.

**Testing:**
new atomic was tested for us by John Blackburn on Windows 10 and worked fine. requires elevated

**Associated Issues:**
no known issues