### PR TITLE
Added new atomic 'Remote System Discovery - nslookup' + typo fixes

### DIFF
--- a/atomics/T1018/T1018.yaml
+++ b/atomics/T1018/T1018.yaml
@@ -17,7 +17,7 @@ atomic_tests:
       net view /domain
       net view
 
-- name: Remote System Discover - ping sweep
+- name: Remote System Discovery - ping sweep
   description: |
     Identify remote systems via ping sweep
 
@@ -30,7 +30,7 @@ atomic_tests:
     command: |
       for /l %i in (1,1,254) do ping -n 1 -w 100 192.168.1.%i
 
-- name: Remote System Discover - arp
+- name: Remote System Discovery - arp
   description: |
     Identify remote systems via arp
 
@@ -70,3 +70,19 @@ atomic_tests:
     elevation_required: false
     command: |
       for ip in $(seq 1 254); do ping -c 1 192.168.1.$ip -o; [ $? -eq 0 ] && echo "192.168.1.$ip UP" || : ; done
+      
+- name: Remote System Discovery - nslookup
+  description: |
+    Powershell script that runs nslookup on cmd.exe against the local /24 network of the first network adaptor listed in ipconfig
+  supported_platforms:
+    - windows
+  executor:
+    name: powershell
+    elevation_required: true
+    command: |
+      $localip = ((ipconfig | findstr [0-9].\.)[0]).Split()[-1]
+      $pieces = $localip.split(".")
+      $firstOctet = $pieces[0]
+      $secondOctet = $pieces[1]
+      $thirdOctet = $pieces[2]
+      foreach ($ip in 1..255 | % { "$firstOctet.$secondOctet.$thirdOctet.$_" } ) {cmd.exe /c nslookup $ip}


### PR DESCRIPTION
**Details:**
  Added test 6:  Powershell script that runs nslookup on cmd.exe against the local /24 network of the first network adaptor listed in ipconfig.  I also formatted the name of this atomic and numbers 1 and 2 to match the others e.g. ("Remote System Discovery - [tool]"). 

**Testing:**
I tested the script portion directly on powershell, as well as the .yaml called with Invoke-Atomic

**Associated Issues:**
There are no known issues. 