### PR TITLE
Fixing T1055.yaml. Int is not a valid value type

### DIFF
--- a/atomics/T1055/T1055.yaml
+++ b/atomics/T1055/T1055.yaml
@@ -17,7 +17,7 @@ atomic_tests:
       default: C:\AtomicRedTeam\atomics\T1055\src\x64\T1055.dll
     process_id:
       description: PID of input_arguments
-      type: Int
+      type: integer
       default: $pid
   executor:
     name: powershell
@@ -39,7 +39,7 @@ atomic_tests:
       default: T1055.dll
     process_id:
       description: PID of input_arguments
-      type: Int
+      type: integer
       default: $pid
   executor:
     name: powershell


### PR DESCRIPTION
Changing Int for integer. This is required to execute this Technique with python execution framework.
