### PR TITLE
PathToAtomicsFolder Input Parameters auto-replaced with actual path

### DIFF
--- a/execution-frameworks/Invoke-AtomicRedTeam/Invoke-AtomicRedTeam/Public/Invoke-AtomicTest.ps1
+++ b/execution-frameworks/Invoke-AtomicRedTeam/Invoke-AtomicRedTeam/Public/Invoke-AtomicTest.ps1
@@ -114,6 +114,10 @@ function Invoke-AtomicTest {
                     $defaultArgs.set_Item($key, $InputArgs[$key])
                 }
             }
+            # Replace $PathToAtomicsFolder or PathToAtomicsFolder with the actual -PathToAtomicsFolder value
+            foreach ($key in $defaultArgs.Clone().Keys) {
+                $defaultArgs.set_Item($key, ($defaultArgs[$key] -replace "\`$PathToAtomicsFolder",$PathToAtomicsFolder -replace "PathToAtomicsFolder",$PathToAtomicsFolder))
+            }
             $defaultArgs
         }
 


### PR DESCRIPTION
Many atomics have input parameters with default values like the following:

C:\AtomicRedTeam\atomics\T1121\src\T1121.cs

or

..\\..\atomics

But all of these are dependent on your atomic redteam install path or your current working directory. Since Invoke-AtomicTest already knows the path to the atomics folder, we should be able to specify we want to use that path when we specify input parameters. This code allows you to use either "$PathToAtomicsFolder" or "PathToAtomicsFolder" when specifying a path to refer to path that Invoke-AtomicTest already knows. So for example, you could specify your input args like the following and it will always work, regardless of install path or current working directory:

$PathToAtomicsFolder\T1121\src\T1121.cs

or

PathToAtomicsFolder

This works for both windows executors (powershell and command_prompt)

