### PR TITLE
T1055 svchost writing a file to a unc path

### DIFF
--- a/atomics/T1055/T1055.yaml
+++ b/atomics/T1055/T1055.yaml
@@ -102,3 +102,20 @@ atomic_tests:
     name: command_prompt
     command: |
       .\bin\#{exe_binary}
+
+- name: svchost writing a file to a UNC path
+  description: | 
+    svchost.exe writing a non microsoft office file to a file with a UNC path
+    This works by copying cmd.exe to a file and naming in svchost.exe, then copying a file to the localhost\c$ folder
+  supported_platforms:
+    - windows
+
+  executor:
+    name: command_prompt
+    elevation_required: true
+    command: |
+      copy C:\Windows\System32\cmd.exe C:\svchost.exe
+      C:\svchost.exe /c echo T1055 > \\localhost\c$\T1055.txt
+    cleanup_command: |
+      del C:\T1055.txt
+      

--- a/atomics/T1055/T1055.yaml
+++ b/atomics/T1055/T1055.yaml
@@ -105,7 +105,7 @@ atomic_tests:
 
 - name: svchost writing a file to a UNC path
   description: | 
-    svchost.exe writing a non microsoft office file to a file with a UNC path
+    svchost.exe writing a non-Microsoft Office file to a file with a UNC path.
     This works by copying cmd.exe to a file, naming it svchost.exe, then copying a file to the localhost\c$ folder.
   supported_platforms:
     - windows

--- a/atomics/T1055/T1055.yaml
+++ b/atomics/T1055/T1055.yaml
@@ -106,7 +106,7 @@ atomic_tests:
 - name: svchost writing a file to a UNC path
   description: | 
     svchost.exe writing a non microsoft office file to a file with a UNC path
-    This works by copying cmd.exe to a file and naming in svchost.exe, then copying a file to the localhost\c$ folder
+    This works by copying cmd.exe to a file, naming it svchost.exe, then copying a file to the localhost\c$ folder.
   supported_platforms:
     - windows
 

--- a/atomics/T1055/T1055.yaml
+++ b/atomics/T1055/T1055.yaml
@@ -118,4 +118,5 @@ atomic_tests:
       C:\svchost.exe /c echo T1055 > \\localhost\c$\T1055.txt
     cleanup_command: |
       del C:\T1055.txt
+      del C:\svchost.exe
       


### PR DESCRIPTION
**Details:**
svchost.exe writing a non microsoft office file to a file with a UNC path
This works by copying cmd.exe to a file and naming in svchost.exe, then copying a file to the localhost\c$ folder

**Testing:**
tested on windows 10 vm

**Associated Issues:**
no issues fixed