### PR TITLE
warn if running admin test without admin

### DIFF
--- a/execution-frameworks/Invoke-AtomicRedTeam/Invoke-AtomicRedTeam/Public/Invoke-AtomicTest.ps1
+++ b/execution-frameworks/Invoke-AtomicRedTeam/Invoke-AtomicRedTeam/Public/Invoke-AtomicTest.ps1
@@ -129,7 +129,9 @@ function Invoke-AtomicTest {
                     Write-Host -ForegroundColor Red "Prerequisites not met: $testId"
                 }
             }
-
+            elseif ($test.executor.elevation_required -and -not $isElevated) {
+                Write-Host -ForegroundColor yellow "Warning: Test '$testId' should be run from an elevated context but wasn't. Try running this test with administrative privileges. "
+            }
         }
 
         function Invoke-AtomicTestSingle ($AT) {


### PR DESCRIPTION
Invoke-Atomic test will tell you that you don't pass the pre-requisite checks if you try to run a test defined with 'elevation_required: true' from a non-admin shell but it will not stop you from invoking the test. This commit will warn the user when they have run a test without admin that requires admin and suggest that they do it from an elevated context.