### PR TITLE
remove hard-coded path to atomics folder in tests

### DIFF
--- a/atomics/T1010/T1010.yaml
+++ b/atomics/T1010/T1010.yaml
@@ -14,7 +14,7 @@ atomic_tests:
     input_source_code:
       description: Path to source of C# code
       type: path
-      default: C:\AtomicRedTeam\atomics\T1010\src\T1010.cs
+      default: PathToAtomicsFolder\T1010\src\T1010.cs
     output_file_name:
       description: Name of output binary
       type: string

--- a/atomics/T1050/T1050.yaml
+++ b/atomics/T1050/T1050.yaml
@@ -13,7 +13,7 @@ atomic_tests:
     binary_path:
       description: Name of the service binary, include path.
       type: Path
-      default: C:\AtomicRedTeam\atomics\T1050\bin\AtomicService.exe
+      default: PathToAtomicsFolder\T1050\bin\AtomicService.exe
     service_name:
       description: Name of the Service
       type: String
@@ -38,7 +38,7 @@ atomic_tests:
     binary_path:
       description: Name of the service binary, include path.
       type: Path
-      default: C:\AtomicRedTeam\atomics\T1050\bin\AtomicService.exe
+      default: PathToAtomicsFolder\T1050\bin\AtomicService.exe
     service_name:
       description: Name of the Service
       type: String

--- a/atomics/T1055/T1055.yaml
+++ b/atomics/T1055/T1055.yaml
@@ -14,7 +14,7 @@ atomic_tests:
     dll_payload:
       description: DLL to Inject
       type: Path
-      default: C:\AtomicRedTeam\atomics\T1055\src\x64\T1055.dll
+      default: PathToAtomicsFolder\T1055\src\x64\T1055.dll
     process_id:
       description: PID of input_arguments
       type: Int

--- a/atomics/T1100/T1100.yaml
+++ b/atomics/T1100/T1100.yaml
@@ -19,7 +19,7 @@ atomic_tests:
     web_shells:
       description: Path of Web Shell
       type: path
-      default: C:\AtomicRedTeam\atomics\T1100\shells\
+      default: PathToAtomicsFolder\T1100\shells\
   executor:
     name: command_prompt
     command: |

--- a/atomics/T1117/T1117.yaml
+++ b/atomics/T1117/T1117.yaml
@@ -11,7 +11,7 @@ atomic_tests:
    filename:
     description: Name of the local file, include path.
     type: Path
-    default: C:\AtomicRedTeam\atomics\T1117\RegSvr32.sct
+    default: PathToAtomicsFolder\T1117\RegSvr32.sct
   executor:
    name: command_prompt
    elevation_required: false
@@ -41,7 +41,7 @@ atomic_tests:
    dll_name:
     description: Name of DLL to Execute, DLL Should export DllRegisterServer
     type: Path
-    default: C:\AtomicRedTeam\atomics\T1117\bin\AllTheThingsx86.dll
+    default: PathToAtomicsFolder\T1117\bin\AllTheThingsx86.dll
   executor:
    name: command_prompt
    elevation_required: false

--- a/atomics/T1118/T1118.yaml
+++ b/atomics/T1118/T1118.yaml
@@ -12,13 +12,18 @@ atomic_tests:
     filename:
       description: location of the payload
       type: Path
-      default: C:\AtomicRedTeam\atomics\T1118\src\T1118.dll
+      default: PathToAtomicsFolder\T1118\src\T1118.dll
+    source:
+      description: location of the source code to compile
+      type: Path
+      default: PathToAtomicsFolder\T1118\src\T1118.cs 
   executor:
     name: command_prompt
     elevation_required: false
     command: |
-      C:\Windows\Microsoft.NET\Framework\v4.0.30319\csc.exe /target:library /out:C:\AtomicRedTeam\atomics\T1118\src\T1118.dll C:\AtomicRedTeam\atomics\T1118\src\T1118.cs 
+      C:\Windows\Microsoft.NET\Framework\v4.0.30319\csc.exe /target:library /out:#{filename}  #{source}
       C:\Windows\Microsoft.NET\Framework\v4.0.30319\InstallUtil.exe /logfile= /LogToConsole=false /U #{filename}
+
 - name: InstallUtil GetHelp method call
   description: |
     Executes the Uninstall Method
@@ -28,10 +33,14 @@ atomic_tests:
     filename:
       description: location of the payload
       type: Path
-      default: C:\AtomicRedTeam\atomics\T1118\src\T1118.dll
+      default: PathToAtomicsFolder\T1118\src\T1118.dll
+    source:
+      description: location of the source code to compile
+      type: Path
+      default: PathToAtomicsFolder\T1118\src\T1118.cs
   executor:
     name: command_prompt
     elevation_required: false
     command: |
-      C:\Windows\Microsoft.NET\Framework\v4.0.30319\csc.exe /target:library /out:C:\AtomicRedTeam\atomics\T1118\src\T1118.dll C:\AtomicRedTeam\atomics\T1118\src\T1118.cs 
+      C:\Windows\Microsoft.NET\Framework\v4.0.30319\csc.exe /target:library /out:#{filename} #{source}
       C:\Windows\Microsoft.NET\Framework\v4.0.30319\InstallUtil.exe /? #{filename}

--- a/atomics/T1121/T1121.yaml
+++ b/atomics/T1121/T1121.yaml
@@ -16,7 +16,7 @@ atomic_tests:
     source_file:
       description: Location of the CSharp source_file
       type: Path
-      default: C:\AtomicRedTeam\atomics\T1121\src\T1121.cs
+      default: PathToAtomicsFolder\T1121\src\T1121.cs
   executor:
     name: command_prompt
     elevation_required: false
@@ -38,7 +38,7 @@ atomic_tests:
     source_file:
       description: Location of the CSharp source_file
       type: Path
-      default: C:\AtomicRedTeam\atomics\T1121\src\T1121.cs
+      default: PathToAtomicsFolder\T1121\src\T1121.cs
   executor:
     name: powershell
     elevation_required: false

--- a/atomics/T1138/T1138.yaml
+++ b/atomics/T1138/T1138.yaml
@@ -17,7 +17,7 @@ atomic_tests:
     file_path:
       description: Path to the shim databaase file
       type: String
-      default: C:\AtomicRedTeam\atomics\T1138\src\AtomicShimx86.sdb
+      default: PathToAtomicsFolder\T1138\src\AtomicShimx86.sdb
   executor:
     name: command_prompt
     elevation_required: true

--- a/atomics/T1174/T1174.yaml
+++ b/atomics/T1174/T1174.yaml
@@ -14,7 +14,7 @@ atomic_tests:
     input_dll:
       description: Path to DLL to be installed and registered
       type: Path
-      default: C:\AtomicRedTeam\atomics\T1174\src\AtomicPasswordFilter.dll
+      default: PathToAtomicsFolder\T1174\src\AtomicPasswordFilter.dll
 
   executor:
     name: powershell

--- a/atomics/T1218/T1218.yaml
+++ b/atomics/T1218/T1218.yaml
@@ -14,7 +14,7 @@ atomic_tests:
     dll_payload:
       description: DLL to inject
       type: Path
-      default: C:\AtomicRedTeam\atomics\T1218\src\x64\T1218.dll
+      default: PathToAtomicsFolder\T1218\src\x64\T1218.dll
     process_id:
       description: PID of process receiving injection
       type: string
@@ -53,7 +53,7 @@ atomic_tests:
     dll_payload:
       description: DLL to execute
       type: Path
-      default: C:\AtomicRedTeam\atomics\T1218\src\Win32\T1218-2.dll
+      default: PathToAtomicsFolder\T1218\src\Win32\T1218-2.dll
   executor:
     name: command_prompt
     command: |

--- a/atomics/T1220/T1220.yaml
+++ b/atomics/T1220/T1220.yaml
@@ -12,11 +12,11 @@ atomic_tests:
     xmlfile:
       description: Location of the test XML file on the local filesystem.
       type: Path
-      default: C:\AtomicRedTeam\atomics\T1220\src\msxslxmlfile.xml
+      default: PathToAtomicsFolder\T1220\src\msxslxmlfile.xml
     xslfile:
       description: Location of the test XSL script file on the local filesystem.
       type: Path
-      default: C:\AtomicRedTeam\atomics\T1220\src\msxslscript.xsl
+      default: PathToAtomicsFolder\T1220\src\msxslscript.xsl
   executor:
     name: command_prompt
     command: |
@@ -54,7 +54,7 @@ atomic_tests:
     local_xsl_file:
       description: Location of the test XSL script file on the local filesystem.
       type: path
-      default: C:\AtomicRedTeam\atomics\T1220\src\wmicscript.xsl
+      default: PathToAtomicsFolder\T1220\src\wmicscript.xsl
   executor:
     name: command_prompt
     command: |

--- a/atomics/T1222/T1222.yaml
+++ b/atomics/T1222/T1222.yaml
@@ -14,7 +14,7 @@ atomic_tests:
     file_folder_to_own:
       description: Path of the file or folder for takeown to take ownership.
       type: path
-      default: C:\AtomicRedTeam\atomics\T1222\T1222.yaml
+      default: PathToAtomicsFolder\T1222\T1222.yaml
 
   executor:
     name: command_prompt
@@ -32,7 +32,7 @@ atomic_tests:
     folder_to_own:
       description: Path of the folder for takeown to take ownership.
       type: path
-      default: C:\AtomicRedTeam\atomics\T1222
+      default: PathToAtomicsFolder\T1222
 
   executor:
     name: command_prompt
@@ -50,7 +50,7 @@ atomic_tests:
     file_or_folder:
       description: Path of the file or folder to change permissions.
       type: path
-      default: C:\AtomicRedTeam\atomics\T1222\T1222.yaml
+      default: PathToAtomicsFolder\T1222\T1222.yaml
     user_or_group:
       description: User or group to allow full control
       type: string
@@ -72,7 +72,7 @@ atomic_tests:
     file_or_folder:
       description: Path of the file or folder to change permissions.
       type: path
-      default: C:\AtomicRedTeam\atomics\T1222
+      default: PathToAtomicsFolder\T1222
     user_or_group:
       description: User or group to allow full control
       type: string
@@ -94,7 +94,7 @@ atomic_tests:
     file_or_folder:
       description: Path of the file or folder to change permissions.
       type: path
-      default: C:\AtomicRedTeam\atomics\T1222\T1222.yaml
+      default: PathToAtomicsFolder\T1222\T1222.yaml
     user_or_group:
       description: User or group to allow full control
       type: string
@@ -116,7 +116,7 @@ atomic_tests:
     file_or_folder:
       description: Path of the file or folder to change permissions.
       type: path
-      default: C:\AtomicRedTeam\atomics\T1222
+      default: PathToAtomicsFolder\T1222
     user_or_group:
       description: User or group to allow full control
       type: string
@@ -138,7 +138,7 @@ atomic_tests:
     file_or_folder:
       description: Path of the file or folder remove attribute.
       type: path
-      default: C:\AtomicRedTeam\atomics\T1222
+      default: PathToAtomicsFolder\T1222
 
   executor:
     name: command_prompt

--- a/atomics/T1223/T1223.yaml
+++ b/atomics/T1223/T1223.yaml
@@ -14,7 +14,7 @@ atomic_tests:
     local_chm_file:
       description: Local .chm payload
       type: path
-      default: C:\atomic-red-team\atomics\T1223\src\T1223.chm
+      default: PathToAtomicsFolder\T1223\src\T1223.chm
 
   executor:
     name: command_prompt


### PR DESCRIPTION
make test defaults more robust by specifying path to files with the magic "PathToAtomicsFolder" variable