### PR TITLE
Readme documents required Import-Module command

### DIFF
--- a/execution-frameworks/Invoke-AtomicRedTeam/README.md
+++ b/execution-frameworks/Invoke-AtomicRedTeam/README.md
@@ -47,6 +47,14 @@ DownloadPath
 
 ## Getting Started
 
+Before you can use the **_Invoke-AtomicTest_** function, you must first import the module:
+
+```powershell
+Import-Module C:\AtomicRedTeam\atomic-red-team-master\execution-frameworks\Invoke-AtomicRedTeam\Invoke-AtomicRedTeam\Invoke-AtomicRedTeam.psm1
+```
+
+Note: Your path the the **_Invoke-AtomicRedTeam.psm1_** my be different.
+
 #### Execute All Tests
 
 Execute all Atomic tests:

--- a/execution-frameworks/Invoke-AtomicRedTeam/README.md
+++ b/execution-frameworks/Invoke-AtomicRedTeam/README.md
@@ -53,7 +53,7 @@ Before you can use the **_Invoke-AtomicTest_** function, you must first import t
 Import-Module C:\AtomicRedTeam\atomic-red-team-master\execution-frameworks\Invoke-AtomicRedTeam\Invoke-AtomicRedTeam\Invoke-AtomicRedTeam.psm1
 ```
 
-Note: Your path the the **_Invoke-AtomicRedTeam.psm1_** my be different.
+Note: Your path to the **_Invoke-AtomicRedTeam.psm1_** may be different.
 
 #### Execute All Tests
 


### PR DESCRIPTION
Updated readme to clarify that you must use "Import-Module" to make the Invoke-AtomicTest function available for use.