### PR TITLE
new default PathToAtomicsFolder value

### DIFF
--- a/execution-frameworks/Invoke-AtomicRedTeam/Invoke-AtomicRedTeam/Public/Invoke-AtomicTest.ps1
+++ b/execution-frameworks/Invoke-AtomicRedTeam/Invoke-AtomicRedTeam/Public/Invoke-AtomicTest.ps1
@@ -103,8 +103,6 @@ function Invoke-AtomicTest {
             $isElevated = $false
         }
 
-        # Read PathToAtomicsFolder from config file if it exists in the current directory
-        if(Test-Path "atomic-red-team.config") { $PathToAtomicsFolder = Get-Content "atomic-red-team.config"}
         Write-Host -ForegroundColor Cyan "PathToAtomicsFolder = $PathToAtomicsFolder`n"
 
         function Get-InputArgs([hashtable]$ip) {

--- a/execution-frameworks/Invoke-AtomicRedTeam/Invoke-AtomicRedTeam/Public/Invoke-AtomicTest.ps1
+++ b/execution-frameworks/Invoke-AtomicRedTeam/Invoke-AtomicRedTeam/Public/Invoke-AtomicTest.ps1
@@ -51,7 +51,7 @@ function Invoke-AtomicTest {
         [Parameter(Mandatory = $false,
             ParameterSetName = 'technique')]
         [String]
-        $PathToAtomicsFolder = "..\..\atomics",
+        $PathToAtomicsFolder = "C:\AtomicRedTeam\atomic-red-team-master\atomics",
 
         [Parameter(Mandatory = $false,
             ValueFromPipelineByPropertyName = $true,
@@ -102,6 +102,11 @@ function Invoke-AtomicTest {
         } else {
             $isElevated = $false
         }
+
+        # Read PathToAtomicsFolder from config file if it exists in the current directory
+        if(Test-Path "atomic-red-team.config") { $PathToAtomicsFolder = Get-Content "atomic-red-team.config"}
+        Write-Host -ForegroundColor Cyan "PathToAtomicsFolder = $PathToAtomicsFolder`n"
+
         function Get-InputArgs([hashtable]$ip) {
             $defaultArgs = @{ }
             foreach ($key in $ip.Keys) {

--- a/execution-frameworks/Invoke-AtomicRedTeam/README.md
+++ b/execution-frameworks/Invoke-AtomicRedTeam/README.md
@@ -58,11 +58,12 @@ Invoke-AtomicTest All
 This assumes your atomics folder is in the default location of `C:\AtomicRedTeam\atomic-red-team-master\atomics`
 
 You can overide the default path to the atomics folder using the `$PSDefaultParameterValues` preference variable as shown below. 
-Tip: Add this to your PowerShell profile so it is always set to your preferred default value.
 
 ```
 $PSDefaultParameterValues = @{"Invoke-AtomicTest:PathToAtomicsFolder"="C:\Users\myuser\Documents\code\atomic-red-team\atomics"}
 ```
+
+Tip: Add this to your PowerShell profile so it is always set to your preferred default value.
 
 #### Execute All Tests - Specific Directory
 

--- a/execution-frameworks/Invoke-AtomicRedTeam/README.md
+++ b/execution-frameworks/Invoke-AtomicRedTeam/README.md
@@ -55,7 +55,10 @@ Execute all Atomic tests:
 Invoke-AtomicTest All
 ```
 
-This assumes your atomics folder is in the default location of `..\..\atomics`
+This assumes your atomics folder is in the default location of `C:\AtomicRedTeam\atomic-red-team-master\atomics`
+
+You can specify a different path to the atomics folder using the `-PathToAtomicsFolder` parameter as shown in the next example.
+Or you can specify the path to the atomics folder in a file called `atomic-red-team.config` in your current working directory. The file contains only the path and nothing else.
 
 #### Execute All Tests - Specific Directory
 

--- a/execution-frameworks/Invoke-AtomicRedTeam/README.md
+++ b/execution-frameworks/Invoke-AtomicRedTeam/README.md
@@ -57,8 +57,12 @@ Invoke-AtomicTest All
 
 This assumes your atomics folder is in the default location of `C:\AtomicRedTeam\atomic-red-team-master\atomics`
 
-You can specify a different path to the atomics folder using the `-PathToAtomicsFolder` parameter as shown in the next example.
-Or you can specify the path to the atomics folder in a file called `atomic-red-team.config` in your current working directory. The file contains only the path and nothing else.
+You can overide the default path to the atomics folder using the `$PSDefaultParameterValues` preference variable as shown below. 
+Tip: Add this to your PowerShell profile so it is always set to your preferred default value.
+
+```
+$PSDefaultParameterValues = @{"Invoke-AtomicTest:PathToAtomicsFolder"="C:\Users\myuser\Documents\code\atomic-red-team\atomics"}
+```
 
 #### Execute All Tests - Specific Directory
 


### PR DESCRIPTION
The default value that `Invoke-AtomicTest` used for `PathToAtomicsFolder` was "..\\..\atomics". I changed  this default to "C:\AtomicRedTeam\atomic-red-team-master\atomics" so that it will work by default for all the users that install atomic red team with the Install-AtomicRedTeam script.

However, if the user does not install to the default location they may be facing a lifetime of adding the `-PathToAtomicsFolder my\custom\path\to\atomics` to every `Invoke-AtomicTest` call. To
avoid this, users can take advantage of the `$PSDefaultParameterValues` preference variable. Tip: add your default value to your PowerShell profile for a set-and-forget solution. Example:

```
$PSDefaultParameterValues = @{"Invoke-AtomicTest:PathToAtomicsFolder"="C:\Users\myuser\Documents\code\atomic-red-team\atomics"}
```

More details on `$PSDefaultParameterValues` [here](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_parameters_default_values?view=powershell-6)