### PR TITLE
fix bug:  $IsWindows returns null except on PS Core or PS v7

### DIFF
--- a/execution-frameworks/Invoke-AtomicRedTeam/Invoke-AtomicRedTeam/Public/Invoke-AtomicTest.ps1
+++ b/execution-frameworks/Invoke-AtomicRedTeam/Invoke-AtomicRedTeam/Public/Invoke-AtomicTest.ps1
@@ -89,19 +89,15 @@ function Invoke-AtomicTest {
     PROCESS {
         # $InformationPrefrence = 'Continue'
         Write-Verbose -Message 'Attempting to run Atomic Techniques'
-        if ($IsWindows){
-            $isElevated = ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
-        }
+        $isElevated = $false
         if ($IsLinux -or $IsMacOS){
             $privid = id -u                
-            if ($privid -eq 0){
-                $isElevated = $true
-            } else {
-                $isElevated = $false
-            }
-        } else {
-            $isElevated = $false
+            if ($privid -eq 0){ $isElevated = $true }
         }
+        else {
+            $isElevated = ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+        }
+
         function Get-InputArgs([hashtable]$ip) {
             $defaultArgs = @{ }
             foreach ($key in $ip.Keys) {


### PR DESCRIPTION
The code was referring to the magic $IsWindows variable but that only works in PS Core and PS v7 so we needed to change the code to still work in the case that we are using other PowerShell versions (not core)