### PR TITLE
T1022 parameters that can actually be parsed by windows command prompt

### DIFF
--- a/atomics/T1022/T1022.yaml
+++ b/atomics/T1022/T1022.yaml
@@ -35,9 +35,9 @@ atomic_tests:
     name: command_prompt
     elevation_required: false
     command: |
-      mkdir ./tmp/victim-files
-      cd ./tmp/victim-files
-      echo "This file will be encrypted" > ./encrypted_file.txt
+      mkdir .\tmp\victim-files
+      cd .\tmp\victim-files
+      echo "This file will be encrypted" > .\encrypted_file.txt
       rar a -hp"blue" hello.rar
       dir
 
@@ -52,9 +52,9 @@ atomic_tests:
     elevation_required: false
     command: |
       path=%path%;"C:\Program Files (x86)\winzip"
-      mkdir ./tmp/victim-files
-      cd ./tmp/victim-files
-      echo "This file will be encrypted" > ./encrypted_file.txt
+      mkdir .\tmp\victim-files
+      cd .\tmp\victim-files
+      echo "This file will be encrypted" > .\encrypted_file.txt
       winzip32 -min -a -s"hello" archive.zip *
       dir
 
@@ -67,8 +67,8 @@ atomic_tests:
     name: command_prompt
     elevation_required: false
     command: |
-      mkdir ./tmp/victim-files
-      cd ./tmp/victim-files
-      echo "This file will be encrypted" > ./encrypted_file.txt
+      mkdir .\tmp\victim-files
+      cd .\tmp\victim-files
+      echo "This file will be encrypted" > .\encrypted_file.txt
       7z a archive.7z -pblue
       dir


### PR DESCRIPTION
I am using the python executor provided with this distribution. T1022 fails  with:
```
Output: Microsoft Windows [Version 10.0.17134.1069]

(c) 2018 Microsoft Corporation. All rights reserved.mkdir ./tmp/victim-files
The syntax of the command is incorrect.
```
Windows mkdir command expects paths with other slash