### PR TITLE
T1028 fixing parameter in powershell Invoke-Command

### DIFF
--- a/atomics/T1028/T1028.md
+++ b/atomics/T1028/T1028.md
@@ -118,7 +118,7 @@ Execute Invoke-command on remote host
 
 #### Run it with `powershell`! 
 ```
-invoke-command -computer_name #{host_name} -scriptblock {#{remote_command}}
+invoke-command -ComputerName #{host_name} -scriptblock {#{remote_command}}
 ```
 
 

--- a/atomics/T1028/T1028.yaml
+++ b/atomics/T1028/T1028.yaml
@@ -107,4 +107,4 @@ atomic_tests:
   executor:
     name: powershell
     command: |
-      invoke-command -computer_name #{host_name} -scriptblock {#{remote_command}}
+      invoke-command -ComputerName #{host_name} -scriptblock {#{remote_command}}


### PR DESCRIPTION
Currently executing the Invoke-Command variant generates this output
`PS  invoke-command -computer_name Test -scriptblock {ipconfig}
Invoke-Command : A parameter cannot be found that matches parameter name 'computer_name'.`
Setting correct parameter name based on this documentation https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/invoke-command?view=powershell-6