### PR TITLE
$testCount++ before  $targetPlatform check

### DIFF
--- a/execution-frameworks/Invoke-AtomicRedTeam/Invoke-AtomicRedTeam/Public/Invoke-AtomicTest.ps1
+++ b/execution-frameworks/Invoke-AtomicRedTeam/Invoke-AtomicRedTeam/Public/Invoke-AtomicTest.ps1
@@ -168,12 +168,12 @@ function Invoke-AtomicTest {
 
                     Write-Verbose -Message 'Determining tests for target operating system'
 
+                    $testCount++
+
                     if (-Not $test.supported_platforms.Contains($targetPlatform)) {
                         Write-Verbose -Message "Unable to run non-$targetPlatform tests"
                         continue
                     }
-
-                    $testCount++
 
                     if ($null -ne $TestNumbers) {
                         if (-Not ($TestNumbers -contains $testCount) ) { continue }


### PR DESCRIPTION
**Details:**
moved $testCount++ so that -testnumbers option is not thrown off by is $targetPlatform check

**Testing:**
Tested on T1002 on powershell core Ubuntu

**Associated Issues:**
N/A