### PR TITLE
T1089 Disable Arbitrary Security Service

### DIFF
--- a/atomics/T1089/T1089.md
+++ b/atomics/T1089/T1089.md
@@ -28,6 +28,8 @@
 
 - [Atomic Test #12 - AMSI Bypass - Remove AMSI Provider Reg Key](#atomic-test-12---amsi-bypass---remove-amsi-provider-reg-key)
 
+- [Atomic Test #13 - Disable Arbitrary Security Windows Service](#atomic-test-13---disable-arbitrary-security-windows-service)
+
 
 <br/>
 
@@ -280,6 +282,33 @@ Remove-Item -Path "HKLM:\SOFTWARE\Microsoft\AMSI\Providers\{2781761E-28E0-4109-9
 #### Cleanup Commands:
 ```
 New-Item -Path "HKLM:\SOFTWARE\Microsoft\AMSI\Providers" -Name "{2781761E-28E0-4109-99FE-B9D127C57AFE}"
+```
+
+<br/>
+<br/>
+
+## Atomic Test #13 - Disable Arbitrary Security Windows Service
+With administrative rights, an adversary can disable Windows Services related to security products. 
+
+**Supported Platforms:** Windows
+
+
+#### Inputs
+| Name | Description | Type | Default Value | 
+|------|-------------|------|---------------|
+| service_name | The name of the service to stop | String | McAfeeDLPAgentService|
+
+#### Run it with `command_prompt`!  Elevation Required (e.g. root or admin) 
+```
+net.exe stop #{service_name}
+sc.exe config #{service_name} start= disabled
+```
+
+
+#### Cleanup Commands:
+```
+sc.exe config #{service_name} start= auto
+net.exe start #{service_name}
 ```
 
 <br/>

--- a/atomics/T1089/T1089.yaml
+++ b/atomics/T1089/T1089.yaml
@@ -188,7 +188,7 @@ atomic_tests:
   supported_platforms:
     - windows
   input_arguments:
-    service_naem:
+    service_name:
       description: The name of the service to stop
       type: String
       default: McAfeeDLPAgentService

--- a/atomics/T1089/T1089.yaml
+++ b/atomics/T1089/T1089.yaml
@@ -181,3 +181,23 @@ atomic_tests:
        Remove-Item -Path "HKLM:\SOFTWARE\Microsoft\AMSI\Providers\{2781761E-28E0-4109-99FE-B9D127C57AFE}" -Recurse
     cleanup_command: |
        New-Item -Path "HKLM:\SOFTWARE\Microsoft\AMSI\Providers" -Name "{2781761E-28E0-4109-99FE-B9D127C57AFE}"
+
+- name: Disable Arbitrary Security Windows Service
+  description: |
+    With administrative rights, an adversary can disable Windows Services related to security products. 
+  supported_platforms:
+    - windows
+  input_arguments:
+    service_naem:
+      description: The name of the service to stop
+      type: String
+      default: McAfeeDLPAgentService
+  executor:
+    name: command_prompt
+    elevation_required: true
+    command: |
+       net.exe stop #{service_name}
+       sc.exe config #{service_name} start= disabled
+    cleanup_command: |
+       sc.exe config #{service_name} start= auto
+       net.exe start #{service_name}

--- a/atomics/index.md
+++ b/atomics/index.md
@@ -207,6 +207,7 @@
   - Atomic Test #10: Uninstall Sysmon [windows]
   - Atomic Test #11: AMSI Bypass - AMSI InitFailed [windows]
   - Atomic Test #12: AMSI Bypass - Remove AMSI Provider Reg Key [windows]
+  - Atomic Test #13: Disable Arbitrary Security Windows Service [windows]
 - T1480 Execution Guardrails [CONTRIBUTE A TEST](https://atomicredteam.io/contributing)
 - T1211 Exploitation for Defense Evasion [CONTRIBUTE A TEST](https://atomicredteam.io/contributing)
 - T1181 Extra Window Memory Injection [CONTRIBUTE A TEST](https://atomicredteam.io/contributing)

--- a/atomics/index.yaml
+++ b/atomics/index.yaml
@@ -6571,8 +6571,29 @@ defense-evasion:
           -Recurse
 
 '
-        cleanup_command: New-Item -Path "HKLM:\SOFTWARE\Microsoft\AMSI\Providers"
+        cleanup_command: 'New-Item -Path "HKLM:\SOFTWARE\Microsoft\AMSI\Providers"
           -Name "{2781761E-28E0-4109-99FE-B9D127C57AFE}"
+
+'
+    - name: Disable Arbitrary Security Windows Service
+      description: "With administrative rights, an adversary can disable Windows Services
+        related to security products. \n"
+      supported_platforms:
+      - windows
+      input_arguments:
+        service_name:
+          description: The name of the service to stop
+          type: String
+          default: McAfeeDLPAgentService
+      executor:
+        name: command_prompt
+        elevation_required: true
+        command: |
+          net.exe stop #{service_name}
+          sc.exe config #{service_name} start= disabled
+        cleanup_command: |-
+          sc.exe config #{service_name} start= auto
+          net.exe start #{service_name}
   T1107:
     technique:
       x_mitre_data_sources:

--- a/atomics/windows-index.md
+++ b/atomics/windows-index.md
@@ -41,6 +41,7 @@
   - Atomic Test #10: Uninstall Sysmon [windows]
   - Atomic Test #11: AMSI Bypass - AMSI InitFailed [windows]
   - Atomic Test #12: AMSI Bypass - Remove AMSI Provider Reg Key [windows]
+  - Atomic Test #13: Disable Arbitrary Security Windows Service [windows]
 - T1480 Execution Guardrails [CONTRIBUTE A TEST](https://atomicredteam.io/contributing)
 - T1211 Exploitation for Defense Evasion [CONTRIBUTE A TEST](https://atomicredteam.io/contributing)
 - T1181 Extra Window Memory Injection [CONTRIBUTE A TEST](https://atomicredteam.io/contributing)


### PR DESCRIPTION
**Details:**
Stops and disables an arbitrary service (security related) like Ryuk does.

**Testing:**
Tested on Win10

**Associated Issues:**
No associated issues