### PR TITLE
a little bug fix

### DIFF
--- a/execution-frameworks/Invoke-AtomicRedTeam/Invoke-AtomicRedTeam/Public/Invoke-AtomicTest.ps1
+++ b/execution-frameworks/Invoke-AtomicRedTeam/Invoke-AtomicRedTeam/Public/Invoke-AtomicTest.ps1
@@ -303,4 +303,3 @@ function Invoke-AtomicTest {
     } # End of PROCESS block
     END { } # Intentionally left blank and can be removed
 }
-Invoke-AtomicTest t1003 -ShowDetails -InformationAction Continue

--- a/execution-frameworks/Invoke-AtomicRedTeam/Invoke-AtomicRedTeam/Public/Invoke-AtomicTest.ps1
+++ b/execution-frameworks/Invoke-AtomicRedTeam/Invoke-AtomicRedTeam/Public/Invoke-AtomicTest.ps1
@@ -234,8 +234,8 @@ function Invoke-AtomicTest {
                     if ($ShowDetails) {
                         if ($null -ne $finalCommand){
                             $executor_name = $test.executor.name
-                            Write-Information -MessageData "executor": $executor_name -Tags 'Name'
-                            Write-Information -MessageData $test.executor.elevation_required -Tags 'Name'
+                            Write-Information -MessageData "Executor: $executor_name" -Tags 'Name'
+                            Write-Information -MessageData "ElevationRequired: $($($test.executor).elevation_required)`nCommand:`n" -Tags 'Elevation'
                             Write-Information -MessageData $finalCommand -Tags 'Command' 
                         }
                     }
@@ -303,3 +303,4 @@ function Invoke-AtomicTest {
     } # End of PROCESS block
     END { } # Intentionally left blank and can be removed
 }
+Invoke-AtomicTest t1003 -ShowDetails -InformationAction Continue


### PR DESCRIPTION
The -ShowDetails flag was throwing this error:

Write-Information : A positional parameter cannot be found that accepts argument ':'.
At \Documents\code\atomic-red-team\execution-frameworks\Invoke-AtomicRedTeam\Invoke-AtomicRedTeam\Public\Invoke-AtomicTest.ps1:237 char:29 
+ ...             Write-Information -MessageData "executor": $executor_name ...
+                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ CategoryInfo          : InvalidArgument: (:) [Write-Information], ParameterBindingException
+ FullyQualifiedErrorId : PositionalParameterNotFound,Microsoft.PowerShell.Commands.WriteInformationCommand