### PR TITLE
Leverage PathToAtomicsFolder in Python framework

### DIFF
--- a/execution-frameworks/contrib/python/runner.py
+++ b/execution-frameworks/contrib/python/runner.py
@@ -394,6 +394,11 @@ def execute_command(launcher, command, cwd):
         # We skip empty lines.  This is due to the split just above.
         if comm == "":
             continue
+            
+        # Replace instances of PathToAtomicsFolder
+        atomics = os.path.join(cwd,"..")
+        comm = comm.replace("$PathToAtomicsFolder", atomics)
+        comm = comm.replace("PathToAtomicsFolder", atomics)
 
         # # We actually run the command itself.
         p = subprocess.Popen(launcher, shell=False, stdin=subprocess.PIPE, stdout=subprocess.PIPE,


### PR DESCRIPTION
**Details:**
Parsing the command to replace PathToAtomicsFolder variable.
Can-t use environment variables as some Powershell based tests use "$PathToAtomicsFolder".
I admit that it-s a bit hackish but I think it-s the most straightforward way to handle this without going through a major refactor of this framework