### PR TITLE
T1016 Firewall Rule Enumeration with Netsh

### DIFF
--- a/atomics/T1016/T1016.md
+++ b/atomics/T1016/T1016.md
@@ -8,7 +8,9 @@ Adversaries may use the information from [System Network Configuration Discovery
 
 - [Atomic Test #1 - System Network Configuration Discovery](#atomic-test-1---system-network-configuration-discovery)
 
-- [Atomic Test #2 - System Network Configuration Discovery](#atomic-test-2---system-network-configuration-discovery)
+- [Atomic Test #2 - List Windows Firewall Rules](#atomic-test-2---list-windows-firewall-rules)
+
+- [Atomic Test #3 - System Network Configuration Discovery](#atomic-test-3---system-network-configuration-discovery)
 
 
 <br/>
@@ -33,7 +35,23 @@ net config
 <br/>
 <br/>
 
-## Atomic Test #2 - System Network Configuration Discovery
+## Atomic Test #2 - List Windows Firewall Rules
+Enumerates Windows Firewall Rules using netsh.
+
+**Supported Platforms:** Windows
+
+
+#### Run it with `command_prompt`! 
+```
+netsh advfirewall firewall show rule name=all
+```
+
+
+
+<br/>
+<br/>
+
+## Atomic Test #3 - System Network Configuration Discovery
 Identify network configuration information
 
 **Supported Platforms:** macOS, Linux

--- a/atomics/T1016/T1016.yaml
+++ b/atomics/T1016/T1016.yaml
@@ -20,6 +20,19 @@ atomic_tests:
       nbtstat -n
       net config
 
+- name: List Windows Firewall Rules
+  description: |
+    Enumerates Windows Firewall Rules using netsh.
+
+  supported_platforms:
+    - windows
+
+  executor:
+    name: command_prompt
+    elevation_required: false
+    command: |
+      netsh advfirewall firewall show rule name=all
+
 - name: System Network Configuration Discovery
   description: |
     Identify network configuration information

--- a/atomics/index.md
+++ b/atomics/index.md
@@ -599,7 +599,8 @@
   - Atomic Test #5: Linux VM Check via Kernel Modules [linux]
 - [T1016 System Network Configuration Discovery](./T1016/T1016.md)
   - Atomic Test #1: System Network Configuration Discovery [windows]
-  - Atomic Test #2: System Network Configuration Discovery [macos, linux]
+  - Atomic Test #2: List Windows Firewall Rules [windows]
+  - Atomic Test #3: System Network Configuration Discovery [macos, linux]
 - [T1049 System Network Connections Discovery](./T1049/T1049.md)
   - Atomic Test #1: System Network Connections Discovery [windows]
   - Atomic Test #2: System Network Connections Discovery with PowerShell [windows]

--- a/atomics/index.yaml
+++ b/atomics/index.yaml
@@ -17300,6 +17300,18 @@ discovery:
           arp -a
           nbtstat -n
           net config
+    - name: List Windows Firewall Rules
+      description: 'Enumerates Windows Firewall Rules using netsh.
+
+'
+      supported_platforms:
+      - windows
+      executor:
+        name: command_prompt
+        elevation_required: false
+        command: 'netsh advfirewall firewall show rule name=all
+
+'
     - name: System Network Configuration Discovery
       description: 'Identify network configuration information
 

--- a/atomics/linux-index.md
+++ b/atomics/linux-index.md
@@ -103,7 +103,7 @@
   - Atomic Test #4: Linux VM Check via Hardware [linux]
   - Atomic Test #5: Linux VM Check via Kernel Modules [linux]
 - [T1016 System Network Configuration Discovery](./T1016/T1016.md)
-  - Atomic Test #2: System Network Configuration Discovery [macos, linux]
+  - Atomic Test #3: System Network Configuration Discovery [macos, linux]
 - [T1049 System Network Connections Discovery](./T1049/T1049.md)
   - Atomic Test #3: System Network Connections Discovery Linux & MacOS [linux, macos]
 - [T1033 System Owner/User Discovery](./T1033/T1033.md)

--- a/atomics/macos-index.md
+++ b/atomics/macos-index.md
@@ -115,7 +115,7 @@
   - Atomic Test #2: System Information Discovery [linux, macos]
   - Atomic Test #3: List OS Information [linux, macos]
 - [T1016 System Network Configuration Discovery](./T1016/T1016.md)
-  - Atomic Test #2: System Network Configuration Discovery [macos, linux]
+  - Atomic Test #3: System Network Configuration Discovery [macos, linux]
 - [T1049 System Network Connections Discovery](./T1049/T1049.md)
   - Atomic Test #3: System Network Connections Discovery Linux & MacOS [linux, macos]
 - [T1033 System Owner/User Discovery](./T1033/T1033.md)

--- a/atomics/windows-index.md
+++ b/atomics/windows-index.md
@@ -420,6 +420,7 @@
   - Atomic Test #1: System Information Discovery [windows]
 - [T1016 System Network Configuration Discovery](./T1016/T1016.md)
   - Atomic Test #1: System Network Configuration Discovery [windows]
+  - Atomic Test #2: List Windows Firewall Rules [windows]
 - [T1049 System Network Connections Discovery](./T1049/T1049.md)
   - Atomic Test #1: System Network Connections Discovery [windows]
   - Atomic Test #2: System Network Connections Discovery with PowerShell [windows]


### PR DESCRIPTION
**Details:**
Added test for firewall rule enumeration. This was spotted in a red team/pentest engagement.

**Testing:**
Tested in Win2012r2

**Associated Issues:**
No associated issues