### PR TITLE
T1082 Add Hostname and MachineGUID tests

### DIFF
--- a/atomics/T1082/T1082.md
+++ b/atomics/T1082/T1082.md
@@ -34,6 +34,10 @@ In Azure, the API request <code>GET https://management.azure.com/subscriptions/{
 
 - [Atomic Test #5 - Linux VM Check via Kernel Modules](#atomic-test-5---linux-vm-check-via-kernel-modules)
 
+- [Atomic Test #6 - Hostname Discovery](#atomic-test-6---hostname-discovery)
+
+- [Atomic Test #7 - Windows MachineGUID Discovery](#atomic-test-7---windows-machineguid-discovery)
+
 
 <br/>
 
@@ -128,6 +132,38 @@ sudo lsmod | grep -i "vmw_baloon\|vmxnet"
 sudo lsmod | grep -i "xen-vbd\|xen-vnif"
 sudo lsmod | grep -i "virtio_pci\|virtio_net"
 sudo lsmod | grep -i "hv_vmbus\|hv_blkvsc\|hv_netvsc\|hv_utils\|hv_storvsc"
+```
+
+
+
+<br/>
+<br/>
+
+## Atomic Test #6 - Hostname Discovery
+Identify system hostname for Windows, Linux, and macOS systems.
+
+**Supported Platforms:** Windows, Linux, macOS
+
+
+#### Run it with `bash`! 
+```
+hostname
+```
+
+
+
+<br/>
+<br/>
+
+## Atomic Test #7 - Windows MachineGUID Discovery
+Identify the Windows MachineGUID value for a system.
+
+**Supported Platforms:** Windows
+
+
+#### Run it with `command_prompt`! 
+```
+REG QUERY HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Cryptography /v MachineGuid
 ```
 
 

--- a/atomics/T1082/T1082.yaml
+++ b/atomics/T1082/T1082.yaml
@@ -83,3 +83,36 @@ atomic_tests:
       sudo lsmod | grep -i "xen-vbd\|xen-vnif"
       sudo lsmod | grep -i "virtio_pci\|virtio_net"
       sudo lsmod | grep -i "hv_vmbus\|hv_blkvsc\|hv_netvsc\|hv_utils\|hv_storvsc"
+
+- name: Hostname Discovery
+  description: |
+    Identify system hostname for Windows, Linux, and macOS systems.
+
+  supported_platforms:
+    - windows
+    - linux
+    - macos
+
+  executor:
+    name: command_prompt
+    elevation_required: false
+    command: |
+      hostname
+
+    name: bash
+    elevation_required: false
+    command: | 
+      hostname
+
+- name: Windows MachineGUID Discovery
+  description: |
+    Identify the Windows MachineGUID value for a system.
+
+  supported_platforms:
+    - windows
+
+  executor:
+    name: command_prompt
+    elevation_required: false
+    command: |
+      REG QUERY HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Cryptography /v MachineGuid

--- a/atomics/index.md
+++ b/atomics/index.md
@@ -597,6 +597,8 @@
   - Atomic Test #3: List OS Information [linux, macos]
   - Atomic Test #4: Linux VM Check via Hardware [linux]
   - Atomic Test #5: Linux VM Check via Kernel Modules [linux]
+  - Atomic Test #6: Hostname Discovery [windows, linux, macos]
+  - Atomic Test #7: Windows MachineGUID Discovery [windows]
 - [T1016 System Network Configuration Discovery](./T1016/T1016.md)
   - Atomic Test #1: System Network Configuration Discovery [windows]
   - Atomic Test #2: System Network Configuration Discovery [macos, linux]

--- a/atomics/index.yaml
+++ b/atomics/index.yaml
@@ -17239,12 +17239,39 @@ discovery:
       - linux
       executor:
         name: bash
-        command: |-
+        command: |
           sudo lsmod | grep -i "vboxsf\|vboxguest"
           sudo lsmod | grep -i "vmw_baloon\|vmxnet"
           sudo lsmod | grep -i "xen-vbd\|xen-vnif"
           sudo lsmod | grep -i "virtio_pci\|virtio_net"
           sudo lsmod | grep -i "hv_vmbus\|hv_blkvsc\|hv_netvsc\|hv_utils\|hv_storvsc"
+    - name: Hostname Discovery
+      description: 'Identify system hostname for Windows, Linux, and macOS systems.
+
+'
+      supported_platforms:
+      - windows
+      - linux
+      - macos
+      executor:
+        name: bash
+        elevation_required: false
+        command: 'hostname
+
+'
+    - name: Windows MachineGUID Discovery
+      description: 'Identify the Windows MachineGUID value for a system.
+
+'
+      supported_platforms:
+      - windows
+      executor:
+        name: command_prompt
+        elevation_required: false
+        command: 'REG QUERY HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Cryptography /v
+          MachineGuid
+
+'
   T1016:
     technique:
       x_mitre_data_sources:

--- a/atomics/linux-index.md
+++ b/atomics/linux-index.md
@@ -102,6 +102,7 @@
   - Atomic Test #3: List OS Information [linux, macos]
   - Atomic Test #4: Linux VM Check via Hardware [linux]
   - Atomic Test #5: Linux VM Check via Kernel Modules [linux]
+  - Atomic Test #6: Hostname Discovery [windows, linux, macos]
 - [T1016 System Network Configuration Discovery](./T1016/T1016.md)
   - Atomic Test #2: System Network Configuration Discovery [macos, linux]
 - [T1049 System Network Connections Discovery](./T1049/T1049.md)

--- a/atomics/macos-index.md
+++ b/atomics/macos-index.md
@@ -114,6 +114,7 @@
 - [T1082 System Information Discovery](./T1082/T1082.md)
   - Atomic Test #2: System Information Discovery [linux, macos]
   - Atomic Test #3: List OS Information [linux, macos]
+  - Atomic Test #6: Hostname Discovery [windows, linux, macos]
 - [T1016 System Network Configuration Discovery](./T1016/T1016.md)
   - Atomic Test #2: System Network Configuration Discovery [macos, linux]
 - [T1049 System Network Connections Discovery](./T1049/T1049.md)

--- a/atomics/windows-index.md
+++ b/atomics/windows-index.md
@@ -418,6 +418,8 @@
   - Atomic Test #1: Find and Display Iinternet Explorer Browser Version [windows]
 - [T1082 System Information Discovery](./T1082/T1082.md)
   - Atomic Test #1: System Information Discovery [windows]
+  - Atomic Test #6: Hostname Discovery [windows, linux, macos]
+  - Atomic Test #7: Windows MachineGUID Discovery [windows]
 - [T1016 System Network Configuration Discovery](./T1016/T1016.md)
   - Atomic Test #1: System Network Configuration Discovery [windows]
 - [T1049 System Network Connections Discovery](./T1049/T1049.md)


### PR DESCRIPTION
**Details:**
Added tests for hostname (cross platform) and getting MachineGUID in Windows.

**Testing:**
Tested in Win2012r2, Fedora 29, macOS something

**Associated Issues:**
None