### PR TITLE
T1077 Redirect output to Admin Share

### DIFF
--- a/atomics/T1077/T1077.md
+++ b/atomics/T1077/T1077.md
@@ -14,6 +14,8 @@ The [Net](https://attack.mitre.org/software/S0039) utility can be used to connec
 
 - [Atomic Test #3 - Copy and Execute File with PsExec](#atomic-test-3---copy-and-execute-file-with-psexec)
 
+- [Atomic Test #4 - Execute command writing output to local Admin Share](#atomic-test-4---execute-command-writing-output-to-local-admin-share)
+
 
 <br/>
 
@@ -79,6 +81,29 @@ Copies a file to a remote host and executes it using PsExec. Requires the downlo
 #### Run it with `command_prompt`!  Elevation Required (e.g. root or admin) 
 ```
 psexec.exe #{remote_host} -c #{command_path}
+```
+
+
+
+<br/>
+<br/>
+
+## Atomic Test #4 - Execute command writing output to local Admin Share
+Executes a command, writing the output to a local Admin Share.
+This technique is used by post-exploitation frameworks.
+
+**Supported Platforms:** Windows
+
+
+#### Inputs
+| Name | Description | Type | Default Value | 
+|------|-------------|------|---------------|
+| output_file | Remote computer to receive the copy and execute the file | String | output.txt|
+| command_to_execute | Command to execute for output. | String | hostname|
+
+#### Run it with `command_prompt`!  Elevation Required (e.g. root or admin) 
+```
+cmd.exe /Q /c #{command_to_execute} 1> \\127.0.0.1\ADMIN$\#{output_file} 2>&1
 ```
 
 

--- a/atomics/T1077/T1077.yaml
+++ b/atomics/T1077/T1077.yaml
@@ -76,3 +76,24 @@ atomic_tests:
     elevation_required: true
     command: |
       psexec.exe #{remote_host} -c #{command_path}
+
+- name: Execute command writing output to local Admin Share
+  description: |
+    Executes a command, writing the output to a local Admin Share.
+    This technique is used by post-exploitation frameworks.
+  supported_platforms:
+    - windows
+  input_arguments:
+    output_file:
+      description: Remote computer to receive the copy and execute the file
+      type: String
+      default: output.txt
+    command_to_execute:
+      description: Command to execute for output.
+      type: String
+      default: hostname
+  executor:
+    name: command_prompt
+    elevation_required: true
+    command: |
+      cmd.exe /Q /c #{command_to_execute} 1> \\127.0.0.1\ADMIN$\#{output_file} 2>&1

--- a/atomics/index.md
+++ b/atomics/index.md
@@ -839,6 +839,7 @@
   - Atomic Test #1: Map admin share [windows]
   - Atomic Test #2: Map Admin Share PowerShell [windows]
   - Atomic Test #3: Copy and Execute File with PsExec [windows]
+  - Atomic Test #4: Execute command writing output to local Admin Share [windows]
 - [T1028 Windows Remote Management](./T1028/T1028.md)
   - Atomic Test #1: Enable Windows Remote Management [windows]
   - Atomic Test #2: PowerShell Lateral Movement [windows]

--- a/atomics/index.yaml
+++ b/atomics/index.yaml
@@ -23969,6 +23969,28 @@ lateral-movement:
         command: 'psexec.exe #{remote_host} -c #{command_path}
 
 '
+    - name: Execute command writing output to local Admin Share
+      description: |
+        Executes a command, writing the output to a local Admin Share.
+        This technique is used by post-exploitation frameworks.
+      supported_platforms:
+      - windows
+      input_arguments:
+        output_file:
+          description: Remote computer to receive the copy and execute the file
+          type: String
+          default: output.txt
+        command_to_execute:
+          description: Command to execute for output.
+          type: String
+          default: hostname
+      executor:
+        name: command_prompt
+        elevation_required: true
+        command: 'cmd.exe /Q /c #{command_to_execute} 1> \\127.0.0.1\ADMIN$\#{output_file}
+          2>&1
+
+'
   T1028:
     technique:
       x_mitre_data_sources:

--- a/atomics/windows-index.md
+++ b/atomics/windows-index.md
@@ -513,6 +513,7 @@
   - Atomic Test #1: Map admin share [windows]
   - Atomic Test #2: Map Admin Share PowerShell [windows]
   - Atomic Test #3: Copy and Execute File with PsExec [windows]
+  - Atomic Test #4: Execute command writing output to local Admin Share [windows]
 - [T1028 Windows Remote Management](./T1028/T1028.md)
   - Atomic Test #1: Enable Windows Remote Management [windows]
   - Atomic Test #2: PowerShell Lateral Movement [windows]


### PR DESCRIPTION
**Details:**
Test to redirect command output to admin share
**Testing:**
Tested on Win2012r2
**Associated Issues:**
none