### PR TITLE
removing dead links

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,17 +39,13 @@ Join the community on Slack at [https://atomicredteam.slack.com](https://atomicr
 ## Getting Started
 
 * [Getting Started With Atomic Tests](https://atomicredteam.io/testing)
+* Automated Test Execution with the [Execution Frameworks](https://github.com/redcanaryco/atomic-red-team/blob/master/execution-frameworks)
 * Peruse the [Complete list of Atomic Tests](atomics/index.md) and the [ATT&CK Matrix](atomics/matrix.md)
   - Windows [Tests](atomics/windows-index.md) and [Matrix](atomics/windows-matrix.md)
   - macOS [Tests](atomics/macos-index.md) and [Matrix](atomics/macos-matrix.md)
   - Linux [Tests](atomics/linux-index.md) and [Matrix](atomics/linux-matrix.md)
 * Using [ATT&CK Navigator](https://github.com/mitre-attack/attack-navigator)? Check out our [coverage layer](atomics/art_navigator_layer.json)
 * [Fork](https://github.com/redcanaryco/atomic-red-team/fork) and [Contribute](https://atomicredteam.io/contributing) your own modifications
-* [Doing more with Atomic Red Team](#doing-more-with-atomic-red-team)
-    * [Using the Atomic Red Team Ruby API](#using-the-atomic-red-team-ruby-api)
-    * [Bonus APIs: Ruby ATT&CK API](#bonus-apis-ruby-attck-api)
-    * [Execution Frameworks](https://github.com/redcanaryco/atomic-red-team/blob/master/execution-frameworks)
-      * [Using Invoke-AtomicTest to run tests effeciently](https://github.com/redcanaryco/atomic-red-team/tree/master/execution-frameworks/Invoke-AtomicRedTeam)
 * Have questions? Join the community on Slack at [https://atomicredteam.slack.com](https://atomicredteam.slack.com)
     * Need a Slack invitation? Grab one at [https://slack.atomicredteam.io/](https://slack.atomicredteam.io/)
 


### PR DESCRIPTION
Removed links that didn't go anywhere and also made the execution frameworks more prominent (I missed the fact that these frameworks existing when I started with atomic red team)