### PR TITLE
remove atomic-red-team-master folder from install

### DIFF
--- a/execution-frameworks/Invoke-AtomicRedTeam/Invoke-AtomicRedTeam/Public/Invoke-AtomicTest.ps1
+++ b/execution-frameworks/Invoke-AtomicRedTeam/Invoke-AtomicRedTeam/Public/Invoke-AtomicTest.ps1
@@ -51,7 +51,7 @@ function Invoke-AtomicTest {
         [Parameter(Mandatory = $false,
             ParameterSetName = 'technique')]
         [String]
-        $PathToAtomicsFolder = $( if($IsLinux -or $IsMacOS) {$Env:HOME + "/AtomicRedTeam/atomic-red-team-master/atomics"} else{$env:HOMEDRIVE + "\AtomicRedTeam\atomic-red-team-master\atomics"}),
+        $PathToAtomicsFolder = $( if($IsLinux -or $IsMacOS) {$Env:HOME + "/AtomicRedTeam/atomics"} else{$env:HOMEDRIVE + "\AtomicRedTeam\atomics"}),
 
         [Parameter(Mandatory = $false,
             ValueFromPipelineByPropertyName = $true,

--- a/execution-frameworks/Invoke-AtomicRedTeam/README.md
+++ b/execution-frameworks/Invoke-AtomicRedTeam/README.md
@@ -61,7 +61,7 @@ Force
 Before you can use the **_Invoke-AtomicTest_** function, you must first import the module:
 
 ```powershell
-Import-Module C:\AtomicRedTeam\atomic-red-team-master\execution-frameworks\Invoke-AtomicRedTeam\Invoke-AtomicRedTeam\Invoke-AtomicRedTeam.psm1
+Import-Module C:\AtomicRedTeam\execution-frameworks\Invoke-AtomicRedTeam\Invoke-AtomicRedTeam\Invoke-AtomicRedTeam.psm1
 ```
 
 Note: Your path to the **_Invoke-AtomicRedTeam.psm1_** may be different.
@@ -74,7 +74,7 @@ Execute all Atomic tests:
 Invoke-AtomicTest All
 ```
 
-This assumes your atomics folder is in the default location of `<BASEPATH>\AtomicRedTeam\atomic-red-team-master\atomics`
+This assumes your atomics folder is in the default location of `<BASEPATH>\AtomicRedTeam\atomics`
 
 Where `<BASEPATH>` is `C:` in Windows or `~` in Linux/MacOS
 

--- a/execution-frameworks/Invoke-AtomicRedTeam/install-atomicredteam.ps1
+++ b/execution-frameworks/Invoke-AtomicRedTeam/install-atomicredteam.ps1
@@ -89,7 +89,7 @@ function Install-AtomicRedTeam {
         $lp = Join-Path "$DownloadPath" "master.zip" 
         expand-archive -LiteralPath $lp -DestinationPath "$InstallPath" -Force:$Force
         $unzipPath = Join-Path $InstallPath "atomic-red-team-master"
-        Get-ChildItem $unzipPath | Move-Item -dest $InstallPath
+        Get-ChildItem $unzipPath -Force | Move-Item -dest $InstallPath
         Remove-Item $unzipPath
 
         if (-not $IsMacOS -and -not $IsLinux) {

--- a/execution-frameworks/Invoke-AtomicRedTeam/install-atomicredteam.ps1
+++ b/execution-frameworks/Invoke-AtomicRedTeam/install-atomicredteam.ps1
@@ -58,7 +58,7 @@ function Install-AtomicRedTeam {
     }
     if (-not $isElevated) { Write-Error "This script must be run as an administrator."; return }
 
-    $modulePath = Join-Path "$InstallPath" "atomic-red-team-master\execution-frameworks\Invoke-AtomicRedTeam\Invoke-AtomicRedTeam\Invoke-AtomicRedTeam.psm1"
+    $modulePath = Join-Path "$InstallPath" "execution-frameworks\Invoke-AtomicRedTeam\Invoke-AtomicRedTeam\Invoke-AtomicRedTeam.psm1"
     if ($Force -or -Not (Test-Path -Path $InstallPath )) {
         write-verbose "Directory Creation"
         if ($Force) {
@@ -88,6 +88,9 @@ function Install-AtomicRedTeam {
         write-verbose "Extracting ART to $InstallPath"
         $lp = Join-Path "$DownloadPath" "master.zip" 
         expand-archive -LiteralPath $lp -DestinationPath "$InstallPath" -Force:$Force
+        $unzipPath = Join-Path $InstallPath "atomic-red-team-master"
+        Get-ChildItem $unzipPath | Move-Item -dest $InstallPath
+        Remove-Item $unzipPath
 
         if (-not $IsMacOS -and -not $IsLinux) {
             write-verbose "Installing NuGet PackageProvider"


### PR DESCRIPTION
this was extra, unnecessary folder depth to the install due to the unzipping process