### PR TITLE
T1027 Execution of base64 PowerShell

### DIFF
--- a/atomics/T1027/T1027.md
+++ b/atomics/T1027/T1027.md
@@ -14,6 +14,10 @@ Another example of obfuscation is through the use of steganography, a technique 
 
 - [Atomic Test #1 - Decode base64 Data into Script](#atomic-test-1---decode-base64-data-into-script)
 
+- [Atomic Test #2 - Execute base64-encoded PowerShell](#atomic-test-2---execute-base64-encoded-powershell)
+
+- [Atomic Test #3 - Execute base64-encoded PowerShell from Windows Registry](#atomic-test-3---execute-base64-encoded-powershell-from-windows-registry)
+
 
 <br/>
 
@@ -32,5 +36,64 @@ chmod +x /tmp/art.sh
 ```
 
 
+
+<br/>
+<br/>
+
+## Atomic Test #2 - Execute base64-encoded PowerShell
+Creates base64-encoded PowerShell code and executes it. This is used by numerous adversaries and malicious tools.
+
+**Supported Platforms:** Windows
+
+
+#### Inputs
+| Name | Description | Type | Default Value | 
+|------|-------------|------|---------------|
+| powershell_command | PowerShell command to encode | String | Write-Host "Hey, Atomic!"|
+
+#### Run it with `powershell`! 
+```
+$OriginalCommand = '#{powershell_command}'
+$Bytes = [System.Text.Encoding]::Unicode.GetBytes($OriginalCommand)
+$EncodedCommand =[Convert]::ToBase64String($Bytes)
+$EncodedCommand
+
+powershell.exe -EncodedCommand $EncodedCommand
+```
+
+
+
+<br/>
+<br/>
+
+## Atomic Test #3 - Execute base64-encoded PowerShell from Windows Registry
+Stores base64-encoded PowerShell code in the Windows Registry and deobfuscates it for execution. This is used by numerous adversaries and malicious tools.
+
+**Supported Platforms:** Windows
+
+
+#### Inputs
+| Name | Description | Type | Default Value | 
+|------|-------------|------|---------------|
+| powershell_command | PowerShell command to encode | String | Write-Host "Hey, Atomic!"|
+| registry_key_storage | Windows Registry Key to store code | String | HKCU:Software\Microsoft\Windows\CurrentVersion|
+| registry_entry_storage | Windows Registry entry to store code under key | String | Debug|
+
+#### Run it with `powershell`! 
+```
+$OriginalCommand = '#{powershell_command}'
+$Bytes = [System.Text.Encoding]::Unicode.GetBytes($OriginalCommand)
+$EncodedCommand =[Convert]::ToBase64String($Bytes)
+$EncodedCommand
+
+Set-ItemProperty -Force -Path #{registry_key_storage} -Name #{registry_entry_storage} -Value $EncodedCommand
+powershell.exe -Command "IEX ([Text.Encoding]::UNICODE.GetString([Convert]::FromBase64String((gp #{registry_key_storage} #{registry_entry_storage}).#{registry_entry_storage})))"
+```
+
+
+#### Cleanup Commands:
+```
+Remove-ItemProperty -Force -Path -Path #{registry_key_storage} -Name #{registry_entry_storage}
+```
 
 <br/>

--- a/atomics/T1027/T1027.yaml
+++ b/atomics/T1027/T1027.yaml
@@ -19,3 +19,58 @@ atomic_tests:
       cat /tmp/encoded.dat | base64 -d > /tmp/art.sh
       chmod +x /tmp/art.sh
       /tmp/art.sh
+
+- name: Execute base64-encoded PowerShell
+  description: |
+    Creates base64-encoded PowerShell code and executes it. This is used by numerous adversaries and malicious tools.
+
+  supported_platforms:
+    - windows
+  input_arguments:
+    powershell_command:
+      description: PowerShell command to encode
+      type: String
+      default: Write-Host "Hey, Atomic!"
+  executor:
+    name: powershell
+    elevation_required: false
+    command: |
+      $OriginalCommand = '#{powershell_command}'
+      $Bytes = [System.Text.Encoding]::Unicode.GetBytes($OriginalCommand)
+      $EncodedCommand =[Convert]::ToBase64String($Bytes)
+      $EncodedCommand
+
+      powershell.exe -EncodedCommand $EncodedCommand
+
+- name: Execute base64-encoded PowerShell from Windows Registry
+  description: |
+    Stores base64-encoded PowerShell code in the Windows Registry and deobfuscates it for execution. This is used by numerous adversaries and malicious tools.
+
+  supported_platforms:
+    - windows
+  input_arguments:
+    powershell_command:
+      description: PowerShell command to encode
+      type: String
+      default: Write-Host "Hey, Atomic!"
+    registry_key_storage:
+      description: Windows Registry Key to store code
+      type: String
+      default: HKCU:Software\Microsoft\Windows\CurrentVersion
+    registry_entry_storage:
+      description: Windows Registry entry to store code under key
+      type: String
+      default: Debug
+  executor:
+    name: powershell
+    elevation_required: false
+    command: |
+      $OriginalCommand = '#{powershell_command}'
+      $Bytes = [System.Text.Encoding]::Unicode.GetBytes($OriginalCommand)
+      $EncodedCommand =[Convert]::ToBase64String($Bytes)
+      $EncodedCommand
+
+      Set-ItemProperty -Force -Path #{registry_key_storage} -Name #{registry_entry_storage} -Value $EncodedCommand
+      powershell.exe -Command "IEX ([Text.Encoding]::UNICODE.GetString([Convert]::FromBase64String((gp #{registry_key_storage} #{registry_entry_storage}).#{registry_entry_storage})))"
+    cleanup_command: |
+      Remove-ItemProperty -Force -Path -Path #{registry_key_storage} -Name #{registry_entry_storage}

--- a/atomics/index.md
+++ b/atomics/index.md
@@ -318,6 +318,8 @@
   - Atomic Test #3: Remove Network Share PowerShell [windows]
 - [T1027 Obfuscated Files or Information](./T1027/T1027.md)
   - Atomic Test #1: Decode base64 Data into Script [macos, linux]
+  - Atomic Test #2: Execute base64-encoded PowerShell [windows]
+  - Atomic Test #3: Execute base64-encoded PowerShell from Windows Registry [windows]
 - T1502 Parent PID Spoofing [CONTRIBUTE A TEST](https://atomicredteam.io/contributing)
 - [T1150 Plist Modification](./T1150/T1150.md)
   - Atomic Test #1: Plist Modification [macos]

--- a/atomics/index.yaml
+++ b/atomics/index.yaml
@@ -9740,11 +9740,69 @@ defense-evasion:
       executor:
         name: sh
         elevation_required: false
-        command: |-
+        command: |
           sh -c "echo ZWNobyBIZWxsbyBmcm9tIHRoZSBBdG9taWMgUmVkIFRlYW0= > /tmp/encoded.dat"
           cat /tmp/encoded.dat | base64 -d > /tmp/art.sh
           chmod +x /tmp/art.sh
           /tmp/art.sh
+    - name: Execute base64-encoded PowerShell
+      description: 'Creates base64-encoded PowerShell code and executes it. This is
+        used by numerous adversaries and malicious tools.
+
+'
+      supported_platforms:
+      - windows
+      input_arguments:
+        powershell_command:
+          description: PowerShell command to encode
+          type: String
+          default: Write-Host "Hey, Atomic!"
+      executor:
+        name: powershell
+        elevation_required: false
+        command: |
+          $OriginalCommand = '#{powershell_command}'
+          $Bytes = [System.Text.Encoding]::Unicode.GetBytes($OriginalCommand)
+          $EncodedCommand =[Convert]::ToBase64String($Bytes)
+          $EncodedCommand
+
+          powershell.exe -EncodedCommand $EncodedCommand
+    - name: Execute base64-encoded PowerShell from Windows Registry
+      description: 'Stores base64-encoded PowerShell code in the Windows Registry
+        and deobfuscates it for execution. This is used by numerous adversaries and
+        malicious tools.
+
+'
+      supported_platforms:
+      - windows
+      input_arguments:
+        powershell_command:
+          description: PowerShell command to encode
+          type: String
+          default: Write-Host "Hey, Atomic!"
+        registry_key_storage:
+          description: Windows Registry Key to store code
+          type: String
+          default: HKCU:Software\Microsoft\Windows\CurrentVersion
+        registry_entry_storage:
+          description: Windows Registry entry to store code under key
+          type: String
+          default: Debug
+      executor:
+        name: powershell
+        elevation_required: false
+        command: |
+          $OriginalCommand = '#{powershell_command}'
+          $Bytes = [System.Text.Encoding]::Unicode.GetBytes($OriginalCommand)
+          $EncodedCommand =[Convert]::ToBase64String($Bytes)
+          $EncodedCommand
+
+          Set-ItemProperty -Force -Path #{registry_key_storage} -Name #{registry_entry_storage} -Value $EncodedCommand
+          powershell.exe -Command "IEX ([Text.Encoding]::UNICODE.GetString([Convert]::FromBase64String((gp #{registry_key_storage} #{registry_entry_storage}).#{registry_entry_storage})))"
+        cleanup_command: 'Remove-ItemProperty -Force -Path -Path #{registry_key_storage}
+          -Name #{registry_entry_storage}
+
+'
   T1150:
     technique:
       x_mitre_data_sources:

--- a/atomics/windows-index.md
+++ b/atomics/windows-index.md
@@ -114,6 +114,8 @@
   - Atomic Test #2: Remove Network Share [windows]
   - Atomic Test #3: Remove Network Share PowerShell [windows]
 - [T1027 Obfuscated Files or Information](./T1027/T1027.md)
+  - Atomic Test #2: Execute base64-encoded PowerShell [windows]
+  - Atomic Test #3: Execute base64-encoded PowerShell from Windows Registry [windows]
 - T1502 Parent PID Spoofing [CONTRIBUTE A TEST](https://atomicredteam.io/contributing)
 - T1186 Process Doppelgänging [CONTRIBUTE A TEST](https://atomicredteam.io/contributing)
 - T1093 Process Hollowing [CONTRIBUTE A TEST](https://atomicredteam.io/contributing)


### PR DESCRIPTION
**Details:**
Tests for executing base64-encoded PowerShell code via CLI and via deobfuscation from the Windows Registry. 

**Testing:**
Tested in WIn2012r2

**Associated Issues:**
none