### PR TITLE
Update to T1053 to add Register-ScheduledTask

### DIFF
--- a/atomics/T1053/T1053.yaml
+++ b/atomics/T1053/T1053.yaml
@@ -69,3 +69,23 @@ atomic_tests:
     name: command_prompt
     command: |
       SCHTASKS /Create /S #{target} /RU #{user_name} /RP #{password} /TN "Atomic task" /TR "#{task_command}" /SC daily /ST #{time}
+      
+- name: Powershell Cmdlet Scheduled Task
+  description: |
+    Create an atomic scheduled task that leverages native powershell cmdlets. 
+    These could be concidered "fileless" scheduled task creation.
+  supported_platforms:
+    - windows
+
+  executor:
+    name: powershell
+    elevation_required: false
+    command: |
+      $Action = New-ScheduledTaskAction -Execute "calc.exe"
+      $Trigger = New-ScheduledTaskTrigger -AtLogon
+      $User = New-ScheduledTaskPrincipal -GroupId "BUILTIN\Administrators" -RunLevel Highest
+      $Set = New-ScheduledTaskSettingsSet
+      $object = New-ScheduledTask -Action $Action -Principal $User -Trigger $Trigger -Settings $Set
+      Register-ScheduledTask AtomicTask -InputObject $object
+    cleanup_command: |
+      Unregister-ScheduledTask -TaskName "AtomicTask" -confirm:$false


### PR DESCRIPTION
New atomic test to include Register-ScheduledTask:
https://docs.microsoft.com/en-us/powershell/module/scheduledtasks/register-scheduledtask?view=win10-ps

**Details:**
Add a new atomic test to the existing scheduled task atomic test to include the native powershell commandlets including New-ScheduledTask and Register-Scheduled task. 

**Testing:**
Ran this via the Invoke-AtomicTest framework successfully on a Windows 10 RS4 VM 64 bit. The cleanup was also run via the Invoke-AtomicTest
**Associated Issues:**
None