### PR TITLE
fix default PathToAtomicsFolder

### DIFF
--- a/execution-frameworks/Invoke-AtomicRedTeam/Invoke-AtomicRedTeam/Public/Invoke-AtomicTest.ps1
+++ b/execution-frameworks/Invoke-AtomicRedTeam/Invoke-AtomicRedTeam/Public/Invoke-AtomicTest.ps1
@@ -51,7 +51,7 @@ function Invoke-AtomicTest {
         [Parameter(Mandatory = $false,
             ParameterSetName = 'technique')]
         [String]
-        $PathToAtomicsFolder = $( if ($IsLinux -or $IsMacOS) { $Env:HOME + "/AtomicRedTeam/atomic-red-team-master/atomics" } else { $env:HOMEDRIVE + "\AtomicRedTeam\atomic-red-team-master\atomics" }),
+        $PathToAtomicsFolder = $( if ($IsLinux -or $IsMacOS) { $Env:HOME + "/AtomicRedTeam/atomics" } else { $env:HOMEDRIVE + "\AtomicRedTeam\atomics" }),
 
         [Parameter(Mandatory = $false,
             ValueFromPipelineByPropertyName = $true,


### PR DESCRIPTION
My last commit accidentally brought back the "atomic-red-team-master" to the default PathToAtomicsFolder parameter. Removing it again so that the default path works for a standard install