### PR TITLE
Fix issue #499 for T1007

### DIFF
--- a/atomics/T1007/T1007.md
+++ b/atomics/T1007/T1007.md
@@ -17,19 +17,11 @@ Identify system services
 **Supported Platforms:** Windows
 
 
-#### Inputs
-| Name | Description | Type | Default Value | 
-|------|-------------|------|---------------|
-| service_name | Name of service to start stop, query | string | svchost.exe|
-
 #### Run it with `command_prompt`!  Elevation Required (e.g. root or admin) 
 ```
 tasklist.exe
 sc query
 sc query state= all
-sc start #{service_name}
-sc stop #{service_name}
-wmic service where (displayname like "#{service_name}") get name
 ```
 
 

--- a/atomics/T1007/T1007.yaml
+++ b/atomics/T1007/T1007.yaml
@@ -10,12 +10,6 @@ atomic_tests:
   supported_platforms:
     - windows
 
-  input_arguments:
-    service_name:
-      description: Name of service to start stop, query
-      type: string
-      default: svchost.exe
-
   executor:
     name: command_prompt
     elevation_required: true
@@ -23,9 +17,6 @@ atomic_tests:
       tasklist.exe
       sc query
       sc query state= all
-      sc start #{service_name}
-      sc stop #{service_name}
-      wmic service where (displayname like "#{service_name}") get name
 
 - name: System Service Discovery - net.exe
   description: |


### PR DESCRIPTION
**Details:**
T1007:  removed service start/stop from Atomic Test #1 as well as its input arguments.
Service start/stop is covered in T1489.

**Testing:**
1.  Reproduced bug reported in #499 in commit f51c26a.
2.  Verified no errors with fix in T1007.yaml during execution of "Invoke-AtomicTest T1007."

**Associated Issues:**
Fixes #499.