### PR TITLE
added path to src directory

### DIFF
--- a/atomics/T1127/T1127.yaml
+++ b/atomics/T1127/T1127.yaml
@@ -11,7 +11,7 @@ atomic_tests:
     filename:
       description: Location of the project file
       type: Path
-      default: PathToAtomicsFolder\T1127\T1127.csproj
+      default: PathToAtomicsFolder\T1127\src\T1127.csproj
   executor:
     name: command_prompt
     elevation_required: false


### PR DESCRIPTION
**Details:**
because of recent upgrades to the invoke-atomic framework; the duplicate csproj file is no longer needed by directing yaml to correct path (in src, where it should be).  able also to remove duplicate csproj file

**Testing:**
ran T1127 (msbuild) before and after change on a test box, test still.  adding @clr2of8 to review

**Associated Issues:**
n/a