### PR TITLE
Update to T1170: Mshta executes VBScript to execute malicious command

### DIFF
--- a/atomics/T1170/T1170.yaml
+++ b/atomics/T1170/T1170.yaml
@@ -43,15 +43,10 @@ atomic_tests:
     This attempts to emulate what FIN7 does with this technique which is using mshta.exe to execute VBScript to execute malicious code on victim systems.
   supported_platforms:
     - windows
-  input_arguments:
-    atomics_path:
-      description: path to atomics folder
-      type: path
-      default: ..\..\atomics
   executor:
     name: command_prompt
     command: |
-      mshta vbscript:Execute("CreateObject(""Wscript.Shell"").Run ""powershell -noexit -file #{atomics_path}\T1170\src\powershell.ps1"":close")
+      mshta vbscript:Execute("CreateObject(""Wscript.Shell"").Run ""powershell -noexit -file $PathToAtomicsFolder\T1170\src\powershell.ps1"":close")
 
 - name: Mshta Executes Remote HTML Application (HTA)
   description: |


### PR DESCRIPTION
**Details:**
Replaced the ${atomics_path} input variable with the $PathToAtomicsFolder global variable. Removed the input variable block
for simplicity.

**Testing:**
Tested atomic on Windows 10 VM Version 10.0.18362 Build 18362 with no issues.