### PR TITLE
Update T1037: Atomics "Logon Scripts" and "Startup Folder Script"

### DIFF
--- a/atomics/T1037/T1037.yaml
+++ b/atomics/T1037/T1037.yaml
@@ -29,6 +29,7 @@ atomic_tests:
     cleanup_command: |
       REG.exe DELETE HKCU\Environment /v UserInitMprLogonScript /f
       del #{script_path}
+      del "%USERPROFILE%\desktop\T1037-log.txt"
 
 - name: Startup Folder Script
   description: |
@@ -57,6 +58,7 @@ atomic_tests:
     cleanup_command: |
       Remove-Item "$env:APPDATA\Microsoft\Windows\Start Menu\Programs\Startup\T1037.bat"
       Remove-Item "$env:ProgramData\Microsoft\Windows\Start Menu\Programs\Startup\T1037.bat"
+      Remove-Item "$env:USERPROFILE\desktop\T1037-log.txt"
 
 - name: Scheduled Task Startup Script
   description: |

--- a/atomics/T1037/T1037.yaml
+++ b/atomics/T1037/T1037.yaml
@@ -5,38 +5,55 @@ display_name: Logon Scripts
 atomic_tests:
 - name: Logon Scripts
   description: |
-    Added Via Reg.exe
+    Adds a registry value to run batch script created in the C:\Windows\Temp directory.
 
   supported_platforms:
     - windows
 
   input_arguments:
+    script_path:
+      description: Path to .bat file
+      type: String
+      default: $env:SystemRoot\Temp\art.bat
     script_command:
       description: Command To Execute
       type: String
-      default: cmd.exe /c calc.exe
+      default: echo Art "Logon Script" atomic test was successful. >> %USERPROFILE%\desktop\T1037-log.txt 
 
   executor:
     name: command_prompt
     elevation_required: false
     command: |
-      REG.exe ADD HKCU\Environment /v UserInitMprLogonScript /t REG_MULTI_SZ /d "#{script_command}"
+      echo cmd /c "#{script_command}" > #{script_path}
+      REG.exe ADD HKCU\Environment /v UserInitMprLogonScript /t REG_SZ /d "#{script_path}"
     cleanup_command: |
       REG.exe DELETE HKCU\Environment /v UserInitMprLogonScript /f
+      del #{script_path}
 
-- name: Starup Folder Script
+- name: Startup Folder Script
   description: |
-    A batch file on startup when placed in the start menu folder
+    A batch file created to run on startup when placed in the start menu folder
   supported_platforms:
     - windows
+
+  input_arguments:
+    user_command:
+      description: Path to .bat file
+      type: String
+      default: echo Art `"Startup Folder Script`" atomic test for $env:USERNAME was successful. >> $env:USERPROFILE\desktop\T1037-log.txt
+    system_command:
+      description: Command To Execute
+      type: String
+      default: echo Art `"Startup Folder Script`" atomic test for $env:COMPUTERNAME was successful. >> $env:USERPROFILE\desktop\T1037-log.txt
+
   executor:
     name: powershell
-    elevation_required: false
+    elevation_required: true
     command: |
-      New-Item "$env:APPDATA\Microsoft\Windows\Start Menu\Programs\Startup\T1037.bat"
-      Set-Content "$env:APPDATA\Microsoft\Windows\Start Menu\Programs\Startup\T1037.bat" "echo T1037"
-      New-Item "$env:ProgramData\Microsoft\Windows\Start Menu\Programs\Startup\T1037.bat"
-      Set-Content "$env:ProgramData\Microsoft\Windows\Start Menu\Programs\Startup\T1037.bat" "echo T1037"
+      New-Item "$env:APPDATA\Microsoft\Windows\Start Menu\Programs\Startup\T1037.bat" -force
+      Set-Content "$env:APPDATA\Microsoft\Windows\Start Menu\Programs\Startup\T1037.bat" "cmd /c #{user_command}"
+      New-Item "$env:ProgramData\Microsoft\Windows\Start Menu\Programs\Startup\T1037.bat" -force
+      Set-Content "$env:ProgramData\Microsoft\Windows\Start Menu\Programs\Startup\T1037.bat" "cmd /c #{system_command}"
     cleanup_command: |
       Remove-Item "$env:APPDATA\Microsoft\Windows\Start Menu\Programs\Startup\T1037.bat"
       Remove-Item "$env:ProgramData\Microsoft\Windows\Start Menu\Programs\Startup\T1037.bat"


### PR DESCRIPTION
**Details:**
The Atomic tests "Logon Scripts" and Startup Folder Script" were updated with additional input arguments. The first test required a fix to the string type for the registry entry to allow it to function correctly. Added a log file write command for each test to record if the commands ran at startup correctly. Other minor syntax and description updates.

**Testing:**
Tested successfully on Windows 10 VM Version 10.0.18362 Build 18362