### PR TITLE
T1015: Fix incorrect reg value type

### DIFF
--- a/atomics/T1015/T1015.yaml
+++ b/atomics/T1015/T1015.yaml
@@ -25,7 +25,7 @@ atomic_tests:
       IF(!(Test-Path $registryPath))
        {
         New-Item -Path $registryPath -Force
-        New-ItemProperty -Path $registryPath -Name $name -Value $Value -PropertyType DWORD -Force
+        New-ItemProperty -Path $registryPath -Name $name -Value $Value -PropertyType STRING -Force
        }
       ELSE
        {
@@ -57,7 +57,7 @@ atomic_tests:
       IF(!(Test-Path $registryPath))
        {
         New-Item -Path $registryPath -Force
-        New-ItemProperty -Path $registryPath -Name $name -Value $Value -PropertyType DWORD -Force
+        New-ItemProperty -Path $registryPath -Name $name -Value $Value -PropertyType STRING -Force
        }
       ELSE
        {
@@ -88,7 +88,7 @@ atomic_tests:
       IF(!(Test-Path $registryPath))
        {
         New-Item -Path $registryPath -Force
-        New-ItemProperty -Path $registryPath -Name $name -Value $Value -PropertyType DWORD -Force
+        New-ItemProperty -Path $registryPath -Name $name -Value $Value -PropertyType STRING -Force
        }
       ELSE
        {
@@ -119,7 +119,7 @@ atomic_tests:
       IF(!(Test-Path $registryPath))
        {
         New-Item -Path $registryPath -Force
-        New-ItemProperty -Path $registryPath -Name $name -Value $Value -PropertyType DWORD -Force
+        New-ItemProperty -Path $registryPath -Name $name -Value $Value -PropertyType STRING -Force
        }
       ELSE
        {
@@ -150,7 +150,7 @@ atomic_tests:
       IF(!(Test-Path $registryPath))
        {
         New-Item -Path $registryPath -Force
-        New-ItemProperty -Path $registryPath -Name $name -Value $Value -PropertyType DWORD -Force
+        New-ItemProperty -Path $registryPath -Name $name -Value $Value -PropertyType STRING -Force
        }
       ELSE
        {
@@ -182,7 +182,7 @@ atomic_tests:
       IF(!(Test-Path $registryPath))
        {
         New-Item -Path $registryPath -Force
-        New-ItemProperty -Path $registryPath -Name $name -Value $Value -PropertyType DWORD -Force
+        New-ItemProperty -Path $registryPath -Name $name -Value $Value -PropertyType STRING -Force
        }
       ELSE
        {
@@ -214,7 +214,7 @@ atomic_tests:
       IF(!(Test-Path $registryPath))
        {
         New-Item -Path $registryPath -Force | Out-Null
-        New-ItemProperty -Path $registryPath -Name $name -Value $Value -PropertyType DWORD -Force
+        New-ItemProperty -Path $registryPath -Name $name -Value $Value -PropertyType STRING -Force
        }
       ELSE
        {


### PR DESCRIPTION
**Details:**
After the latest change to these tests, they are now failing with the following error:

```
New-ItemProperty : Cannot convert value "C:\windows\system32\cmd.exe" to type "System.UInt32". Error: "Input string
was not in a correct format."
At line:7 char:9
+         New-ItemProperty -Path $registryPath -Name $name -Value $Valu ...
+         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : WriteError: (HKEY_LOCAL_MACH...Options\osk.exe:String) [New-ItemProperty], PSInvalidCast
   Exception
    + FullyQualifiedErrorId : System.Management.Automation.PSInvalidCastException,Microsoft.PowerShell.Commands.NewIte
   mPropertyCommand
```

This is due to incorrect reg value type DWORD being used where it should be STRING.

**Testing:**
Tested with new STRING type value and the appropriate reg keys were being created.
