### PR TITLE
Delete TeamViewer Log Files

### DIFF
--- a/atomics/T1107/T1107.yaml
+++ b/atomics/T1107/T1107.yaml
@@ -176,7 +176,7 @@ atomic_tests:
     This test just places the files in a non-TeamViewer folder, a detection would just check for a deletion event matching the TeamViewer
     log file format of TeamViewerXX_Logfile.log
     https://twitter.com/SBousseaden/status/1197524463304290305?s=20
-  supported_platforms: |
+  supported_platforms:
     - windows
     - macos
   executor:

--- a/atomics/T1107/T1107.yaml
+++ b/atomics/T1107/T1107.yaml
@@ -169,3 +169,28 @@ atomic_tests:
     elevation_required: true
     command: |
       Remove-Item -Path (Join-Path "$Env:SystemRoot\prefetch\" (Get-ChildItem -Path "$Env:SystemRoot\prefetch\*.pf" -Name)[0])
+
+- name: Delete TeamViewer Log Files
+  description: |
+    Adversaries may delete TeamViewer log files to hide activity. This should provide a high true-positive alert ration.
+    This test just places the files in a non-TeamViewer folder, a detection would just check for a deletion event matching the TeamViewer
+    log file format of TeamViewerXX_Logfile.log
+    https://twitter.com/SBousseaden/status/1197524463304290305?s=20
+  supported_platforms: |
+    - windows
+    - macos
+  executor:
+    name: powershell
+    elevation_required: false
+    command: |
+      if ($env:os -eq "Windows_NT") {
+        New-Item $env:TEMP\TeamViewer_54.log
+      } else {
+        New-Item $env:HOME\TeamViewer_54.log
+      }
+    cleanup_command: |
+      if ($env:os -eq "Windows_NT") {
+        Remove-Item $env:TEMP\TeamViewer_54.log
+      } else {
+        Remove-Item $env:HOME\TeamViewer_54.log
+      }

--- a/atomics/T1107/T1107.yaml
+++ b/atomics/T1107/T1107.yaml
@@ -185,12 +185,8 @@ atomic_tests:
     command: |
       if ($env:os -eq "Windows_NT") {
         New-Item $env:TEMP\TeamViewer_54.log
-      } else {
-        New-Item $env:HOME\TeamViewer_54.log
-      }
-    cleanup_command: |
-      if ($env:os -eq "Windows_NT") {
         Remove-Item $env:TEMP\TeamViewer_54.log
       } else {
+        New-Item $env:HOME\TeamViewer_54.log
         Remove-Item $env:HOME\TeamViewer_54.log
       }


### PR DESCRIPTION
**Details:**
Adversaries may delete TeamViewer log files to hide activity. This should provide a high true-positive alert ration. This test just places the files in a non-TeamViewer folder, a detection would just check for a deletion event matching the TeamViewer log file format of TeamViewerXX_Logfile.log
https://twitter.com/SBousseaden/status/1197524463304290305?s=20

**Testing:**
Windows 10, Mac