### PR TITLE
fix prereq bug for multi-line powershell

### DIFF
--- a/execution-frameworks/Invoke-AtomicRedTeam/Invoke-AtomicRedTeam/Private/Invoke-CheckPrereqs.ps1
+++ b/execution-frameworks/Invoke-AtomicRedTeam/Invoke-AtomicRedTeam/Private/Invoke-CheckPrereqs.ps1
@@ -6,7 +6,7 @@ function Invoke-CheckPrereqs ($test, $isElevated, $customInputArgs, $PathToAtomi
     foreach ($dep in $test.dependencies) {
         $executor = Get-PrereqExecutor $test
         $final_command = Merge-InputArgs $dep.prereq_command $test $customInputArgs $PathToAtomicsFolder
-        $final_command = ($final_Command.trim()).Replace("`n", " && ")
+        if($executor -ne "powershell") { $final_command = ($final_Command.trim()).Replace("`n", " && ") }
         $res = Invoke-ExecuteCommand $final_command $executor $TimeoutSeconds
         $description = Merge-InputArgs $dep.description $test $customInputArgs $PathToAtomicsFolder
         if ($res -ne 0) {

--- a/execution-frameworks/Invoke-AtomicRedTeam/Invoke-AtomicRedTeam/Public/Invoke-AtomicTest.ps1
+++ b/execution-frameworks/Invoke-AtomicRedTeam/Invoke-AtomicRedTeam/Public/Invoke-AtomicTest.ps1
@@ -202,7 +202,7 @@ function Invoke-AtomicTest {
                             $description = (Merge-InputArgs $dep.description $test $InputArgs $PathToAtomicsFolder).trim()
                             Write-KeyValue  "Attempting to satisfy prereq: " $description
                             $final_command_prereq = Merge-InputArgs $dep.prereq_command $test $InputArgs $PathToAtomicsFolder
-                            $final_command_prereq = ($final_command_prereq.trim()).Replace("`n", " && ")
+                            if($executor -ne "powershell") { $final_command_prereq = ($final_command_prereq.trim()).Replace("`n", " && ") }
                             $final_command_get_prereq = Merge-InputArgs $dep.get_prereq_command $test $InputArgs $PathToAtomicsFolder
                             $res = Invoke-ExecuteCommand $final_command_prereq $executor $TimeoutSeconds
 


### PR DESCRIPTION
When the dependencies included a multi-line powershell script, Invoke-AtomicTest was giving an error. This fixes it.