### PR TITLE
T1015, set default input args to be a list of executables

### DIFF
--- a/atomics/T1015/T1015.yaml
+++ b/atomics/T1015/T1015.yaml
@@ -5,17 +5,18 @@ display_name: Accessibility Features
 atomic_tests:
 - name: Attaches Command Prompt as a Debugger to a List of Target Processes
   description: |
-    This allows adversaries to execute the attached process
-    Attaches cmd.exe to osk.exe by default. Other useful values to include in parent_list include: 'sethc.exe, utilman.exe, magnify.exe, narrator.exe, DisplaySwitch.exe, atbroker.exe'.
+    Attaches cmd.exe to a list of processes. Configure your own Input arguments to a different executable or list of executables.
   supported_platforms:
     - windows
   input_arguments:
     parent_list:
-      description: Comma separated list of system binaries to which you want to attach each #{attached_process}. Default: "osk.exe"
+      description: |
+        Comma separated list of system binaries to which you want to attach each #{attached_process}. Default: "osk.exe"
       type: String
-      default: osk.exe
+      default: osk.exe, sethc.exe, utilman.exe, magnify.exe, narrator.exe, DisplaySwitch.exe, atbroker.exe
     attached_process:
-      description: "Full path to process to attach to target in #{parent_list}. Default: cmd.exe"
+      description: |
+        Full path to process to attach to target in #{parent_list}. Default: cmd.exe
       type: Path
       default: C:\windows\system32\cmd.exe
 


### PR DESCRIPTION
T1015, set default input args to be a list of executables

This matches what this T# was doing previously using multiple individual tests. Users can specify a subset of the list or just one executable if they desire.