### PR TITLE
T1071 - Updated "example.com" default domain with resolvable domain name.

### DIFF
--- a/atomics/T1071/T1071.yaml
+++ b/atomics/T1071/T1071.yaml
@@ -76,7 +76,7 @@ atomic_tests:
     domain:
       description: Default domain to simulate against
       type: string
-      default: example.com
+      default: 127.0.0.1.xip.io
     subdomain:
       description: Subdomain prepended to the domain name
       type: string
@@ -106,7 +106,7 @@ atomic_tests:
     domain:
       description: Default domain to simulate against
       type: string
-      default: example.com
+      default: 127.0.0.1.xip.io
     subdomain:
       description: Subdomain prepended to the domain name
       type: string
@@ -145,7 +145,7 @@ atomic_tests:
     domain:
       description: Default domain to simulate against
       type: string
-      default: example.com
+      default: 127.0.0.1.xip.io
     subdomain:
       description: Subdomain prepended to the domain name (should be 63 characters to test maximum length)
       type: string


### PR DESCRIPTION
Adjusted the default domain from "example.com" to "127.0.0.1.xip.io" to allow the "Resolve-DnsName" cmdlet to work as expected. Should prevent extended runtime issues associated with NXDOMAIN.