### PR TITLE
Fix docs template carriage return issue

### DIFF
--- a/atomic_red_team/atomic_doc_template.md.erb
+++ b/atomic_red_team/atomic_doc_template.md.erb
@@ -35,6 +35,7 @@ end.join(', ') %>
 
 <%- if test['executor']['name'] == 'manual' -%>
 #### Run it with these steps! <%- if test['executor']['elevation_required'] -%> Elevation Required (e.g. root or admin) <%- end -%>
+
 <%= test['executor']['steps'] %>
 <%- else -%>
 


### PR DESCRIPTION
**Details:**
Fixed an issue in the markdown documentation files where the first step is merged in with the section header. 

**Testing:**
I ran `bin/generate-atomic-docs.rb` and verified that the markdown files had the expected carriage return.

**Associated Issues:**
https://github.com/redcanaryco/atomic-red-team/pull/835 is related. I created a separate PR for this issue and I'll let that other PR focus on the issue of the XML file not getting rendered properly.