### PR TITLE
generat-atomic-docs.rb Cast to to_s.strip

### DIFF
--- a/atomic_red_team/atomic_doc_template.md.erb
+++ b/atomic_red_team/atomic_doc_template.md.erb
@@ -29,7 +29,7 @@ end.join(', ') %>
 | Name | Description | Type | Default Value | 
 |------|-------------|------|---------------|
 <% test['input_arguments'].each do |arg_name, arg_options| -%>
-| <%= arg_name %> | <%= arg_options['description'] %> | <%= arg_options['type'] %> | <%= arg_options['default'] %>|
+| <%= arg_name.to_s.strip %> | <%= arg_options['description'].to_s.strip %> | <%= arg_options['type'].to_s.strip %> | <%= arg_options['default'].to_s.strip %>|
 <% end -%>
 <% end -%>
 


### PR DESCRIPTION
**Details:**
this will fix an error in markdown generation for multi line and Unicode errors in Input Argument values.

**Testing:**
running .\bin\generate-atomic-docs.rb makes changes to T1158-8 (to_s fixed Unicode character) , T1015-1 (removes newline in arg description), T1204 (removes newline in arg description).

**Associated Issues:**
<!-- Please link any issues that this pull request impacts or fixes. -->