### PR TITLE
Modifying T1214 to include TrickBot PuTTY Session enumeration

### DIFF
--- a/atomics/T1214/T1214.md
+++ b/atomics/T1214/T1214.md
@@ -27,6 +27,22 @@ reg query HKLM /f password /t REG_SZ /s
 reg query HKCU /f password /t REG_SZ /s
 ```
 
+- [Atomic Test #1 - Enumeration for PuTTY Cedentials in Registry](#atomic-test-2---enumeration-for-credentials-in-registry)
+
+
+<br/>
+
+## Atomic Test #2 - Enumeration for PuTTY Credentials in Registry
+Queries to enumerate for PuTTY credentials in the Registry. (Citation: TrendMicro Trickbot Analysis)
+
+**Supported Platforms:** Windows
+
+
+
+#### Attack Commands: Run with `command_prompt`! 
+```
+reg query HKCU\Software\SimonTatham\PuTTY\Sessions /t REG_SZ /s
+```
 
 
 

--- a/atomics/T1214/T1214.md
+++ b/atomics/T1214/T1214.md
@@ -10,7 +10,7 @@ Example commands to find Registry keys related to password information: (Citatio
 ## Atomic Tests
 
 - [Atomic Test #1 - Enumeration for Credentials in Registry](#atomic-test-1---enumeration-for-credentials-in-registry)
-- [Atomic Test #2 - Enumeration for PuTTY Cedentials in Registry](#atomic-test-2---enumeration-for-putty-credentials-in-registry)
+- [Atomic Test #2 - Enumeration for PuTTY Credentials in Registry](#atomic-test-2---enumeration-for-putty-credentials-in-registry)
 
 <br/>
 

--- a/atomics/T1214/T1214.md
+++ b/atomics/T1214/T1214.md
@@ -14,7 +14,7 @@ Example commands to find Registry keys related to password information: (Citatio
 
 <br/>
 
-## Atomic Test #1 - Enumeration for Credentials in Registry
+## Atomic Test #2 - Enumeration for Credentials in Registry
 Queries to enumerate for credentials in the Registry.
 
 **Supported Platforms:** Windows

--- a/atomics/T1214/T1214.md
+++ b/atomics/T1214/T1214.md
@@ -10,11 +10,11 @@ Example commands to find Registry keys related to password information: (Citatio
 ## Atomic Tests
 
 - [Atomic Test #1 - Enumeration for Credentials in Registry](#atomic-test-1---enumeration-for-credentials-in-registry)
-
+- [Atomic Test #1 - Enumeration for PuTTY Cedentials in Registry](#atomic-test-2---enumeration-for-putty-credentials-in-registry)
 
 <br/>
 
-## Atomic Test #2 - Enumeration for Credentials in Registry
+## Atomic Test #1 - Enumeration for Credentials in Registry
 Queries to enumerate for credentials in the Registry.
 
 **Supported Platforms:** Windows
@@ -27,7 +27,7 @@ reg query HKLM /f password /t REG_SZ /s
 reg query HKCU /f password /t REG_SZ /s
 ```
 
-- [Atomic Test #1 - Enumeration for PuTTY Cedentials in Registry](#atomic-test-2---enumeration-for-credentials-in-registry)
+
 
 
 <br/>

--- a/atomics/T1214/T1214.md
+++ b/atomics/T1214/T1214.md
@@ -10,7 +10,7 @@ Example commands to find Registry keys related to password information: (Citatio
 ## Atomic Tests
 
 - [Atomic Test #1 - Enumeration for Credentials in Registry](#atomic-test-1---enumeration-for-credentials-in-registry)
-- [Atomic Test #1 - Enumeration for PuTTY Cedentials in Registry](#atomic-test-2---enumeration-for-putty-credentials-in-registry)
+- [Atomic Test #2 - Enumeration for PuTTY Cedentials in Registry](#atomic-test-2---enumeration-for-putty-credentials-in-registry)
 
 <br/>
 

--- a/atomics/T1214/T1214.yaml
+++ b/atomics/T1214/T1214.yaml
@@ -16,3 +16,16 @@ atomic_tests:
     command: |
       reg query HKLM /f password /t REG_SZ /s
       reg query HKCU /f password /t REG_SZ /s
+
+- name: Enumeration for PuTTY Credentials in Registry
+  description: |
+    Queries to enumerate for PuTTY credentials in the Registry.
+
+  supported_platforms:
+    - windows
+
+  executor:
+    name: command_prompt
+    elevation_required: false
+    command: |
+      reg query HKCU\Software\SimonTatham\PuTTY\Sessions /t REG_SZ /s


### PR DESCRIPTION
…ckbot

**Details:**
TrickBot queries the registry for PuTTY session information to steal private keys.  This adds enumeration of these registry keys to T1214.

References:
[TrendMicro](https://blog.trendmicro.com/trendlabs-security-intelligence/trickbot-adds-remote-application-credential-grabbing-capabilities-to-its-repertoire/)

[MITRE](https://attack.mitre.org/software/S0266/)

**Testing:**
Tested on Win10 machines. If key does not exist, will produce an error, similar to other checks.

**Associated Issues:**
None