### PR TITLE
make verifyhash function available to prereq

### DIFF
--- a/atomics/T1003/T1003.yaml
+++ b/atomics/T1003/T1003.yaml
@@ -78,6 +78,7 @@ atomic_tests:
         if (Test-Path #{wce_exe}) {exit 0} else {exit 1}
       get_prereq_command: |
         $parentpath = Split-Path "#{wce_exe}"; $zippath = "$parentpath\wce.zip"
+        IEX(IWR "https://raw.githubusercontent.com/redcanaryco/invoke-atomicredteam/master/Public/Invoke-WebRequestVerifyHash.ps1")
         if(Invoke-WebRequestVerifyHash "#{wce_url}" "$zippath" #{wce_zip_hash}){
           Expand-Archive $zippath $parentpath\wce -Force
           Move-Item $parentpath\wce\wce.exe "#{wce_exe}"


### PR DESCRIPTION
Importing the Invoke-WebRequestVerifyHash function from its online source to ensure that it available for use in newly spawned PowerShell processes such as those that are created during Invoke-AtomicTest. 

Previous to this change, if you didn't have the Invoke-AtomicRedTeam module as an import statement in your PowerShell profile you would receive and error that "The term 'Invoke-WebRequestVerifyHash' is not recognized as the name of a cmdlet, function, script file, or operable program."