### PR TITLE
Fixes #873

### DIFF
--- a/execution-frameworks/contrib/python/runner.py
+++ b/execution-frameworks/contrib/python/runner.py
@@ -530,7 +530,7 @@ class AtomicRunner():
         tech = self.techniques[technique_name]
 
         # Gets Executors.
-        executors = get_executors(tech)
+        executors = get_valid_executors(tech)
 
         try:
             # Get executor at given position.


### PR DESCRIPTION
https://github.com/redcanaryco/atomic-red-team/issues/873

**Details:**
When running the python execution framework in non interactive mode (with python code) the executors doesn't get filtered by the platform and that makes some inconsistencies between the executor numbers for a same technique.
More info in this issue:
https://github.com/redcanaryco/atomic-red-team/issues/873

**Testing:**
Tested manually.

**Associated Issues:**
https://github.com/redcanaryco/atomic-red-team/issues/873