### PR TITLE
T1047 documentation

### DIFF
--- a/atomics/T1047/T1047.yaml
+++ b/atomics/T1047/T1047.yaml
@@ -66,7 +66,7 @@ atomic_tests:
 - name: WMI Execute Local Process
   description: |
     This test uses wmic.exe to execute a process on the local host.
-    When the test completes , a new process will be started localy .A notepad application will be started when input is left on default.
+    When the test completes , a new process will be started locally .A notepad application will be started when input is left on default.
 
   supported_platforms:
     - windows

--- a/atomics/T1047/T1047.yaml
+++ b/atomics/T1047/T1047.yaml
@@ -14,8 +14,7 @@ atomic_tests:
     elevation_required: false
     command: |
       wmic useraccount get /ALL /format:csv
-    cleanup_command: |
-      cls
+    
 - name: WMI Reconnaissance Processes
   description: |
     An adversary might use WMI to list Processes running on the compromised host.
@@ -27,8 +26,7 @@ atomic_tests:
     elevation_required: false
     command: |
       wmic process get caption,executablepath,commandline /format:csv
-    cleanup_command: |
-      cls
+    
 - name: WMI Reconnaissance Software
   description: |
     An adversary might use WMI to list installed Software hotfix and patches.
@@ -40,8 +38,7 @@ atomic_tests:
     elevation_required: false
     command: |
       wmic qfe get description,installedOn /format:csv
-    cleanup_command: |
-      cls
+    
 - name: WMI Reconnaissance List Remote Services
   description: |
     An adversary might use WMI to check if a certain Remote Service is running on a device on the same network. 

--- a/atomics/T1047/T1047.yaml
+++ b/atomics/T1047/T1047.yaml
@@ -41,8 +41,8 @@ atomic_tests:
     
 - name: WMI Reconnaissance List Remote Services
   description: |
-    An adversary might use WMI to check if a certain Remote Service is running on a device on the same network. 
-    When the test complets, a service information will be displayed on the screen if it exist.
+    An adversary might use WMI to check if a certain Remote Service is running on a remote device. 
+    When the test completes, a service information will be displayed on the screen if it exists.
     A common feedback message is that "No instance(s) Available" if the service queried is not running.
     A common error message is "Node - (provided IP or default)  ERROR Description =The RPC server is unavailable" 
     if the provided remote host is unreacheable
@@ -84,9 +84,9 @@ atomic_tests:
 
 - name: WMI Execute Remote Process
   description: |
-    This test uses wmic.exe to execute a process on a remote host. Use -PromptInputArgs to provide a reacheable Ip to test
+    This test uses wmic.exe to execute a process on a remote host. Specify a valid value for remote IP using the node parameter.
     To clean up, provide the same node input as the one provided to run the test
-    A common error message is "Node - (provided IP or default)  ERROR Description =The RPC server is unavailable" if the defualt or provided IP is unreachable 
+    A common error message is "Node - (provided IP or default)  ERROR Description =The RPC server is unavailable" if the default or provided IP is unreachable 
 
   supported_platforms:
     - windows

--- a/atomics/T1047/T1047.yaml
+++ b/atomics/T1047/T1047.yaml
@@ -5,27 +5,34 @@ display_name: Windows Management Instrumentation
 atomic_tests:
 - name: WMI Reconnaissance Users
   description: |
-    WMI List User Accounts
+    An adversary might use WMI to list all local User Accounts. 
+    When the test completes , there should be local user accounts information displayed on the command line.
   supported_platforms:
     - windows
   executor:
     name: command_prompt
     elevation_required: false
     command: |
-      wmic useraccount get /ALL
+      wmic useraccount get /ALL /format:csv
+    cleanup_command: |
+      cls
 - name: WMI Reconnaissance Processes
   description: |
-    WMI List Processes
+    An adversary might use WMI to list Processes running on the compromised host.
+    When the test completes , there should be running processes listed on the command line.
   supported_platforms:
     - windows
   executor:
     name: command_prompt
     elevation_required: false
     command: |
-      wmic process get caption,executablepath,commandline
+      wmic process get caption,executablepath,commandline /format:csv
+    cleanup_command: |
+      cls
 - name: WMI Reconnaissance Software
   description: |
-    WMI List Software
+    An adversary might use WMI to list installed Software hotfix and patches.
+    When the test completes, there should be a list of installed patches and when they were installed.
   supported_platforms:
     - windows
   executor:
@@ -33,26 +40,31 @@ atomic_tests:
     elevation_required: false
     command: |
       wmic qfe get description,installedOn /format:csv
+    cleanup_command: |
+      cls
 - name: WMI Reconnaissance List Remote Services
   description: |
-    WMI List Remote Services
-
+    An adversary might use WMI to check if a certain Remote Service is running on a device on the same network. 
+    When the test complets, a service information will be displayed on the screen if it exist.
+    A common feedback message is that "No instance(s) Available" if the service queried is not running.
+    A common error message is "Node - (provided IP or default)  ERROR Description =The RPC server is unavailable" 
+    if the provided remote host is unreacheable
   supported_platforms:
     - windows
   input_arguments:
     node:
       description: Ip Address
       type: String
-      default: 192.168.0.1
+      default: 127.0.0.1
     service_search_string:
       description: Name Of Service
       type: String
-      default: sql server
+      default: Spooler
   executor:
     name: command_prompt
     elevation_required: false
     command: |
-      wmic /node:"#{node}" service where (caption like "%#{service_search_string} (%")
+      wmic /node:"#{node}" service where (caption like "%#{service_search_string}%")
   
 - name: WMI Execute Local Process
   description: |
@@ -64,16 +76,20 @@ atomic_tests:
     process_to_execute:
       description: Name or path of process to execute.
       type: String
-      default: calc.exe
+      default: notepad.exe
   executor:
     name: command_prompt
     elevation_required: false
     command: |
       wmic process call create #{process_to_execute}
+    cleanup_command: |
+      wmic process where name='#{process_to_execute}' delete
 
 - name: WMI Execute Remote Process
   description: |
-    This test uses wmic.exe to execute a process on a remote host.
+    This test uses wmic.exe to execute a process on a remote host. Use -PromptInputArgs to provide a reacheable Ip to test
+    To clean up, provide the same node input as the one provided to run the test
+    A common error message is "Node - (provided IP or default)  ERROR Description =The RPC server is unavailable" if the defualt or provided IP is unreachable 
 
   supported_platforms:
     - windows
@@ -81,13 +97,16 @@ atomic_tests:
     node:
       description: Ip Address
       type: String
-      default: 192.168.0.1
+      default: 127.0.0.1
     process_to_execute:
       description: Name or path of process to execute.
       type: String
-      default: calc.exe
+      default: notepad.exe
   executor:
     name: command_prompt
     elevation_required: false
     command: |
       wmic /node:"#{node}" process call create #{process_to_execute}
+    cleanup_command: |
+      wmic /node:"#{node}" process where name='#{process_to_execute}' delete
+    

--- a/atomics/T1047/T1047.yaml
+++ b/atomics/T1047/T1047.yaml
@@ -66,6 +66,7 @@ atomic_tests:
 - name: WMI Execute Local Process
   description: |
     This test uses wmic.exe to execute a process on the local host.
+    When the test completes , a new process will be started localy .A notepad application will be started when input is left on default.
 
   supported_platforms:
     - windows


### PR DESCRIPTION
**Details:**
Added documentation to specify what to look for when a test is successful. 
Added clean up commands for Tests 5,6.
Replaced default ip-> localhost, default process-> notepad.exe , default service:->spooler to use items available by default in the windows environment.

**Testing:**
Invoke-AtomicTest T1047 -TestNumbers  1  # works up to test 6
Invoke-AtomicTest T1047 -TestNumbers  5 -cleanup #works on test 6 as well.
**Associated Issues:**
<!-- Please link any issues that this pull request impacts or fixes. -->