### PR TITLE
lastlog is not supported in OSX, at least not in 10.14.6

### DIFF
--- a/atomics/T1087/T1087.md
+++ b/atomics/T1087/T1087.md
@@ -165,7 +165,7 @@ username=$(echo $HOME | awk -F'/' '{print $3}') && lsof -u $username
 ## Atomic Test #5 - Show if a user account has ever logged in remotely
 Show if a user account has ever logged in remotely
 
-**Supported Platforms:** Linux, macOS
+**Supported Platforms:** Linux
 
 
 

--- a/atomics/T1087/T1087.yaml
+++ b/atomics/T1087/T1087.yaml
@@ -67,7 +67,6 @@ atomic_tests:
     Show if a user account has ever logged in remotely
   supported_platforms:
     - linux
-    - macos
   input_arguments:
     output_file:
       description: Path where captured results will be placed


### PR DESCRIPTION
**Details:**
lastlog is not supported in 10.14.6, I don't have access to older OSX versions to test those. I will test if I can dig up some older versions

**Testing:**
<!-- Note any testing done, local or automated here. -->
made changes to atomic test 5, ran through the ART runner
validated using bin/validate-atomics.rb
