### PR TITLE
Typo in prereq_command

### DIFF
--- a/atomics/T1035/T1035.yaml
+++ b/atomics/T1035/T1035.yaml
@@ -50,7 +50,7 @@ atomic_tests:
     - description: |
         PsExec tool from Sysinternals must exist on disk at specified location (#{psexec_exe})
       prereq_command: |
-        if (Test-Path "#{psexec_exe}"") { exit 0} else { exit 1}
+        if (Test-Path "#{psexec_exe}") { exit 0} else { exit 1}
       get_prereq_command: |
         Invoke-WebRequest "https://download.sysinternals.com/files/PSTools.zip" -OutFile "$env:TEMP\PsTools.zip"
         Expand-Archive $env:TEMP\PsTools.zip $env:TEMP\PsTools -Force


### PR DESCRIPTION
**Details:**
<!-- There are two " in the prereq_command in T1035 leading to an error when running the CheckPrereqs flag. -->

**Testing:**
<!-- Removed the second " locally and it fixed the error-->