### PR TITLE
Fix issue with non-executable bash file

### DIFF
--- a/atomics/T1154/T1154.yaml
+++ b/atomics/T1154/T1154.yaml
@@ -16,6 +16,6 @@ atomic_tests:
   executor:
     name: sh
     command: |
-      trap "nohup $PathToAtomicsFolder/T1154/src/echo-art-fish.sh | bash" EXIT
+      trap "nohup sh $PathToAtomicsFolder/T1154/src/echo-art-fish.sh | bash" EXIT
       exit
-      trap "nohup $PathToAtomicsFolder/T1154/src/echo-art-fish.sh | bash" SIGINt
+      trap "nohup sh $PathToAtomicsFolder/T1154/src/echo-art-fish.sh | bash" SIGINt


### PR DESCRIPTION
**Details:**
The `echo-art-fish.sh` file has to be marked as executable before it can be run when the signal is trapped. A user would normally clone the repository and then run the tests without manually changing the permissions of the files. Since the executable flag is not set when the test runs it fails with the following error:  `failed to run command '/home/user/src/atomic-red-team/atomics/T1154/../T1154/src/echo-art-fish.sh': Permission denied`. Running the script with `sh`  fixes the issue and doesn't require to manually set the flag before running the test.

**Testing:**
Run the test in interactive mode and non interactive mode with the python interpreter on linux (Ubuntu 19.10) and MacOS (Catalina 10.15.4).

**Associated Issues:**
None