### PR TITLE
T1166 - Fix absolute path, C code optimizations

### DIFF
--- a/atomics/T1166/T1166.yaml
+++ b/atomics/T1166/T1166.yaml
@@ -22,14 +22,13 @@ atomic_tests:
     elevation_required: true
     command: |
       cp #{payload} /tmp/hello.c
-      cd /tmp
-      sudo chown root hello.c
-      sudo make hello
-      sudo chown root hello
-      sudo chmod u+s hello
-      ./hello
+      sudo chown root /tmp/hello.c
+      sudo make /tmp/hello
+      sudo chown root /tmp/hello
+      sudo chmod u+s /tmp/hello
+      /tmp/hello
     cleanup_command: |
-      sudo rm ./hello
+      sudo rm /tmp/hello
       sudo rm /tmp/hello.c
 
 - name: Set a SetUID flag on file

--- a/atomics/T1166/src/hello.c
+++ b/atomics/T1166/src/hello.c
@@ -1,9 +1,9 @@
-#import <stdio.h>
-#import <unistd.h>
+#include <stdio.h>
+#include <unistd.h>
 int main()
 {
     printf("Hello\n");
-    sleep(60);
+    sleep(5);
     printf("Don't run random binaries!\n");
     return 0;
 }

--- a/atomics/T1215/T1215.yaml
+++ b/atomics/T1215/T1215.yaml
@@ -14,16 +14,21 @@ atomic_tests:
     kernel_module_file:
       description: KO object containing kernel module code.
       type: path
-      default: diamorphine.ko
+      default: hello.ko
     module_name:
       description: Kernel module name once loaded.
       type: string
-      default: diamorphine
+      default: hello
 
   executor:
     name: bash
     elevation_required: true # indicates whether command must be run with admin privileges. If the elevation_required attribute is not defined, the value is assumed to be false
     command: | # these are the actaul attack commands, at least one command must be provided
-      insmod #{kernel_module_file}
+      mkdir /tmp/T1215
+      cp PathToAtomicsFolder/T1215/src/* /tmp/T1215
+      cd /tmp/T1215; make
+      insmod /tmp/T1215/#{kernel_module_file}
+      dmesg | tail | grep "Atomic kernel"
     cleanup_command: | # you can remove the cleanup_command section if there are no cleanup commands
       rmmod #{module_name}
+      rm -rf /tmp/T1215

--- a/atomics/T1215/src/Makefile
+++ b/atomics/T1215/src/Makefile
@@ -1,0 +1,7 @@
+obj-m += hello.o
+
+all:
+	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) modules
+
+clean:
+	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) clean

--- a/atomics/T1215/src/hello.c
+++ b/atomics/T1215/src/hello.c
@@ -1,0 +1,21 @@
+/*  
+ * Source from https://linux.die.net/lkmpg/x121.html 
+ * hello.c - The simplest kernel module.
+ */
+#include <linux/module.h>	/* Needed by all modules */
+#include <linux/kernel.h>	/* Needed for KERN_INFO */
+
+int init_module(void)
+{
+	printk(KERN_INFO "Atomic kernel module loaded.\n");
+
+	/* 
+	 * A non 0 return means init_module failed; module can't be loaded. 
+	 */
+	return 0;
+}
+
+void cleanup_module(void)
+{
+	printk(KERN_INFO "Goodbye world 1.\n");
+}


### PR DESCRIPTION
**Details:**

- Replacing relative paths with absolute paths to avoid losing context when there is a direcotry change. The Python runner runs each command in a different sub-process and therefore `cd` command does not work. Another solution was to fix the `runner.py` to run all commands in a single `sh` session, like the Ruby runner, but it might break other stuff.

- hello.c uses `import` pre-processor statement which has been deprecated since gcc 3.4 and generates warning message during compilation:`#import is a deprecated GCC extension`. Replaced `import` with `include`. Another change was to modify the sleep command from 60 seconds to 5 seconds.


**Testing:**
Linux and MacOS

**Associated Issues:**
None