### PR TITLE
T1059 ART test is Mac/Linux only, shouldn't be in Windows Index

### DIFF
--- a/atomics/Indexes/Indexes-Markdown/windows-index.md
+++ b/atomics/Indexes/Indexes-Markdown/windows-index.md
@@ -594,7 +594,7 @@
 - [T1191 CMSTP](../../T1191/T1191.md)
   - Atomic Test #1: CMSTP Executing Remote Scriptlet [windows]
   - Atomic Test #2: CMSTP Executing UAC Bypass [windows]
-- [T1059 Command-Line Interface](../../T1059/T1059.md)
+- T1059 Command-Line Interface [CONTRIBUTE A TEST](https://atomicredteam.io/contributing)
 - [T1223 Compiled HTML File](../../T1223/T1223.md)
   - Atomic Test #1: Compiled HTML Help Local Payload [windows]
   - Atomic Test #2: Compiled HTML Help Remote Payload [windows]


### PR DESCRIPTION
The link for Command-Line Interface T1059 led to Mac/Linux only ART test. I reverted T1059 to format where an ART test doesn't exist as this is the Windows index.

**Details:**
<!-- Insert details about this change here. Please include as much detail as possible -->

**Testing:**
<!-- Note any testing done, local or automated here. -->

**Associated Issues:**
<!-- Please link any issues that this pull request impacts or fixes. -->