### PR TITLE
T1036 file extension masquerading fix

### DIFF
--- a/atomics/T1036/T1036.yaml
+++ b/atomics/T1036/T1036.yaml
@@ -182,7 +182,6 @@ atomic_tests:
       del C:\lsm.exe >nul 2>&1
 
 - name: File Extension Masquerading
-  auto_generated_guid: c7fa0c3b-b57f-4cba-9118-863bf4e653fc
   description: |
     download and execute a file masquerading as images or Office files. Upon execution 3 calc instances and 3 vbs windows will be launched.
 
@@ -205,35 +204,35 @@ atomic_tests:
       default: PathToAtomicsFolder\T1036\src\T1036_masquerading.ps1
 
   executor:
-    name: powershell
+    name: command_prompt
     elevation_required: false
     command: |
-      Copy-Item #{exe_path} -Destination $env:TEMP\T1036_masquerading.docx.exe -Force
-      Copy-Item #{exe_path} -Destination $env:TEMP\T1036_masquerading.pdf.exe -Force
-      Copy-Item #{exe_path} -Destination $env:TEMP\T1036_masquerading.ps1.exe -Force
-      Copy-Item #{vbs_path} -Destination $env:TEMP\T1036_masquerading.xls.vbs -Force
-      Copy-Item #{vbs_path} -Destination $env:TEMP\T1036_masquerading.xlsx.vbs -Force
-      Copy-Item #{vbs_path} -Destination $env:TEMP\T1036_masquerading.png.vbs -Force
-      Copy-Item #{ps1_path} -Destination $env:TEMP\T1036_masquerading.vbs.ps1 -Force
-      Copy-Item #{ps1_path} -Destination $env:TEMP\T1036_masquerading.exe.ps1 -Force
-      Copy-Item #{ps1_path} -Destination $env:TEMP\T1036_masquerading.js.ps1 -Force
-      Invoke-Expression $env:TEMP\T1036_masquerading.docx.exe
-      Invoke-Expression $env:TEMP\T1036_masquerading.pdf.exe
-      Invoke-Expression $env:TEMP\T1036_masquerading.ps1.exe
-      Invoke-Expression $env:TEMP\T1036_masquerading.xls.vbs
-      Invoke-Expression $env:TEMP\T1036_masquerading.xlsx.vbs
-      Invoke-Expression $env:TEMP\T1036_masquerading.png.vbs
-      Invoke-Expression $env:TEMP\T1036_masquerading.vbs.ps1
-      Invoke-Expression $env:TEMP\T1036_masquerading.exe.ps1
-      Invoke-Expression $env:TEMP\T1036_masquerading.js.ps1
+      copy #{exe_path} %temp%\T1036_masquerading.docx.exe /Y
+      copy #{exe_path} %temp%\T1036_masquerading.pdf.exe /Y
+      copy #{exe_path} %temp%\T1036_masquerading.ps1.exe /Y
+      copy #{vbs_path} %temp%\T1036_masquerading.xls.vbs /Y
+      copy #{vbs_path} %temp%\T1036_masquerading.xlsx.vbs /Y
+      copy #{vbs_path} %temp%\T1036_masquerading.png.vbs /Y
+      copy #{ps1_path} %temp%\T1036_masquerading.doc.ps1 /Y
+      copy #{ps1_path} %temp%\T1036_masquerading.pdf.ps1 /Y
+      copy #{ps1_path} %temp%\T1036_masquerading.rtf.ps1 /Y
+      %temp%\T1036_masquerading.docx.exe
+      %temp%\T1036_masquerading.pdf.exe
+      %temp%\T1036_masquerading.ps1.exe
+      %temp%\T1036_masquerading.xls.vbs
+      %temp%\T1036_masquerading.xlsx.vbs
+      %temp%\T1036_masquerading.png.vbs
+      C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -File %temp%\T1036_masquerading.doc.ps1
+      C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -File %temp%\T1036_masquerading.pdf.ps1
+      C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -File %temp%\T1036_masquerading.rtf.ps1
 
     cleanup_command: |
-      Remove-Item $env:TEMP\T1036_masquerading.docx.exe -Force -ErrorAction Ignore | Out-Null
-      Remove-Item $env:TEMP\T1036_masquerading.pdf.exe -Force -ErrorAction Ignore | Out-Null
-      Remove-Item $env:TEMP\T1036_masquerading.ps1.exe -Force -ErrorAction Ignore | Out-Null
-      Remove-Item $env:TEMP\T1036_masquerading.xls.vbs -Force -ErrorAction Ignore | Out-Null
-      Remove-Item $env:TEMP\T1036_masquerading.xlsx.vbs -Force -ErrorAction Ignore | Out-Null
-      Remove-Item $env:TEMP\T1036_masquerading.png.vbs -Force -ErrorAction Ignore | Out-Null
-      Remove-Item $env:TEMP\T1036_masquerading.vbs.ps1 -Force -ErrorAction Ignore | Out-Null
-      Remove-Item $env:TEMP\T1036_masquerading.exe.ps1 -Force -ErrorAction Ignore | Out-Null
-      Remove-Item $env:TEMP\T1036_masquerading.js.ps1 -Force -ErrorAction Ignore | Out-Null
+      del /f %temp%\T1036_masquerading.docx.exe > nul 2>&1
+      del /f %temp%\T1036_masquerading.pdf.exe > nul 2>&1
+      del /f %temp%\T1036_masquerading.ps1.exe > nul 2>&1
+      del /f %temp%\T1036_masquerading.xls.vbs > nul 2>&1
+      del /f %temp%\T1036_masquerading.xlsx.vbs > nul 2>&1
+      del /f %temp%\T1036_masquerading.png.vbs > nul 2>&1
+      del /f %temp%\T1036_masquerading.doc.ps1 > nul 2>&1
+      del /f %temp%\T1036_masquerading.pdf.ps1 > nul 2>&1
+      del /f %temp%\T1036_masquerading.rtf.ps1 > nul 2>&1

--- a/atomics/T1036/T1036.yaml
+++ b/atomics/T1036/T1036.yaml
@@ -182,6 +182,7 @@ atomic_tests:
       del C:\lsm.exe >nul 2>&1
 
 - name: File Extension Masquerading
+  auto_generated_guid: c7fa0c3b-b57f-4cba-9118-863bf4e653fc
   description: |
     download and execute a file masquerading as images or Office files. Upon execution 3 calc instances and 3 vbs windows will be launched.
 

--- a/atomics/T1036/src/T1036_masquerading.ps1
+++ b/atomics/T1036/src/T1036_masquerading.ps1
@@ -1,1 +1,1 @@
-exit
+Exit-PSSession

--- a/atomics/T1036/src/T1036_masquerading.vbs
+++ b/atomics/T1036/src/T1036_masquerading.vbs
@@ -1,2 +1,1 @@
-Wscript.Echo "T1036_maquerading"
-Wscript.Quit 1
+Wscript.Quit


### PR DESCRIPTION
**Details:**
Change the the executer to command prompt. this made it easier to filter out false positives without filtering out the Atomic itself

**Testing:**
Windows 10 VM