### PR TITLE
T1074: add missing quote around path containing a space character

### DIFF
--- a/atomics/T1074.001/src/Discovery.bat
+++ b/atomics/T1074.001/src/Discovery.bat
@@ -14,10 +14,10 @@ reg query HKLM\Software\Microsoft\Windows\CurrentVersion\RunServicesOnce
 reg query HKCU\Software\Microsoft\Windows\CurrentVersion\RunServicesOnce
 reg query HKLM\Software\Microsoft\Windows\CurrentVersion\RunServices
 reg query HKCU\Software\Microsoft\Windows\CurrentVersion\RunServices
-reg query HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon\Notify
-reg query HKLM\Software\Microsoft\Windows NT\CurrentVersion\Winlogon\Userinit
-reg query HKCU\Software\Microsoft\Windows NT\CurrentVersion\Winlogon\\Shell
-reg query HKLM\Software\Microsoft\Windows NT\CurrentVersion\Winlogon\\Shell
+reg query "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon\Notify"
+reg query "HKLM\Software\Microsoft\Windows NT\CurrentVersion\Winlogon\Userinit"
+reg query "HKCU\Software\Microsoft\Windows NT\CurrentVersion\Winlogon\Shell"
+reg query "HKLM\Software\Microsoft\Windows NT\CurrentVersion\Winlogon\Shell"
 reg query HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\ShellServiceObjectDelayLoad
 reg query HKLM\Software\Microsoft\Windows\CurrentVersion\RunOnce
 reg query HKLM\Software\Microsoft\Windows\CurrentVersion\RunOnceEx


### PR DESCRIPTION
**Details:**
Current code fails due to presence of space in unquoted path, ex. (on a French system, error is "syntax error"):
```
c:\>reg query HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon\Notify
ERREUR : syntaxe incorrecte.
Entrez "REG QUERY /?" pour afficher la syntaxe.
```

**Testing:**
After it works (except that this key doesn't exist, but the error is normal this time):
```
c:\>reg query "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon\Notify"
Erreur : Erreur : le système n’a pas trouvé la clé ou la valeur de Registre spécifiée.
```

**Associated Issues:**
Didn't find nor create one