### PR TITLE
T1543.003: use different service name depending if cmd or psh is used to prevent name conflict

### DIFF
--- a/atomics/T1543.003/T1543.003.yaml
+++ b/atomics/T1543.003/T1543.003.yaml
@@ -35,7 +35,7 @@ atomic_tests:
     service_name:
       description: Name of the Service
       type: String
-      default: AtomicTestService
+      default: AtomicTestService_CMD
 
   dependency_executor_name: powershell
   dependencies:
@@ -70,7 +70,7 @@ atomic_tests:
     service_name:
       description: Name of the Service
       type: String
-      default: AtomicTestService
+      default: AtomicTestService_PowerShell
 
   dependency_executor_name: powershell
   dependencies:


### PR DESCRIPTION
**Details:**
If we want to run both T1050 tests 1 and 2, one after the other without any cleanup between we get an error:
```powershell
PS C:\Windows\system32> Invoke-AtomicTest T1050
PathToAtomicsFolder = C:\AtomicRedTeam\atomics

Executing test: T1050-1 Service Installation CMD
[SC] CreateService SUCCESS

SERVICE_NAME: AtomicTestService
        TYPE               : 10  WIN32_OWN_PROCESS
        STATE              : 2  START_PENDING
                                (NOT_STOPPABLE, NOT_PAUSABLE, IGNORES_SHUTDOWN)
        WIN32_EXIT_CODE    : 0  (0x0)
        SERVICE_EXIT_CODE  : 0  (0x0)
        CHECKPOINT         : 0x0
        WAIT_HINT          : 0x7d0
        PID                : 4572
        FLAGS              :
Done executing test: T1050-1 Service Installation CMD
Executing test: T1050-2 Service Installation PowerShell
New-Service : Service ' (AtomicTestService)' cannot be created due to the following error: The specified service already exists
At line:1 char:4
+ & {New-Service -Name "AtomicTestService" -BinaryPathName "C:\AtomicRe ...
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : PermissionDenied: (AtomicTestService:String) [New-Service], ServiceCommandException
    + FullyQualifiedErrorId : CouldNotNewService,Microsoft.PowerShell.Commands.NewServiceCommand

Done executing test: T1050-2 Service Installation PowerShell
```

The error comes from the fact that both services have the same name and we can't create a new service with the same name.
So I suggest appending to the service name, the type of command that created it, similar to T1136:
https://github.com/redcanaryco/atomic-red-team/blob/d8ffdf2ee657f317d8a2de6d1790bd92972e075e/atomics/T1136/T1136.yaml#L62-L64
https://github.com/redcanaryco/atomic-red-team/blob/d8ffdf2ee657f317d8a2de6d1790bd92972e075e/atomics/T1136/T1136.yaml#L86-L88

**Testing:**
Creation works fine:
![image](https://user-images.githubusercontent.com/550823/84059436-e63d2700-a9ba-11ea-8640-d9132decde17.png)

Cleanup is good too

**Associated Issues:**
None