### PR TITLE
"Get Started!" link leads to a 404.

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -46,4 +46,4 @@ used, which makes the community working together essential to making us all bett
 
 ![Markdown example](assets/images/list-of-tests.png)
 
-### Ready to start testing? [Get started!](https://github.com/redcanaryco/atomic-red-team/blob/master/testing)
+### Ready to start testing? [Get started!](https://atomicredteam.io/testing)


### PR DESCRIPTION
The "Get started!" link at the bottom of the atomicredteam.io page is broken. I suggested updating it so it leads to the testing section of the .io site (https://atomicredteam.io/testing)

**Details:**
<!-- Insert details about this change here. Please include as much detail as possible -->

**Testing:**
<!-- Note any testing done, local or automated here. -->

**Associated Issues:**
<!-- Please link any issues that this pull request impacts or fixes. -->