### PR TITLE
T1140: use different name for 2nd test to allow executing both in sequence

### DIFF
--- a/atomics/T1140/T1140.yaml
+++ b/atomics/T1140/T1140.yaml
@@ -19,7 +19,7 @@ atomic_tests:
       certutil -decode %temp%\T1140_calc.txt %temp%\T1140_calc_decoded.exe
     cleanup_command: |
       del %temp%\T1140_calc.txt >nul 2>&1
-      del %temp%T1140_calc_decoded.exe >nul 2>&1
+      del %temp%\T1140_calc_decoded.exe >nul 2>&1
     name: command_prompt
 - name: Certutil Rename and Decode
   auto_generated_guid: 71abc534-3c05-4d0c-80f7-cbe93cb2aa94
@@ -35,11 +35,11 @@ atomic_tests:
   executor:
     command: |
       copy %windir%\system32\certutil.exe %temp%\tcm.tmp
-      %temp%\tcm.tmp -encode #{executable} %temp%\T1140_calc.txt
-      %temp%\tcm.tmp -decode %temp%\T1140_calc.txt %temp%\T1140_calc_decoded.exe
+      %temp%\tcm.tmp -encode #{executable} %temp%\T1140_calc2.txt
+      %temp%\tcm.tmp -decode %temp%\T1140_calc2.txt %temp%\T1140_calc2_decoded.exe
     cleanup_command: |
       del %temp%\tcm.tmp >nul 2>&1
-      del %temp%\T1140_calc.txt >nul 2>&1
-      del %temp%T1140_calc_decoded.exe >nul 2>&1
+      del %temp%\T1140_calc2.txt >nul 2>&1
+      del %temp%\T1140_calc2_decoded.exe >nul 2>&1
     name: command_prompt
 


### PR DESCRIPTION
**Details:**

We get an error if execute the two tests at once because they use the same name for files (notice "The file exists" errors):
```powershell
Invoke-AtomicTest T1140
PathToAtomicsFolder = C:\AtomicRedTeam\atomics

Executing test: T1140-1 Deobfuscate/Decode Files Or Information



Input Length = 38072
Output Length = 27648
CertUtil: -decode command completed successfully.
Done executing test: T1140-1 Deobfuscate/Decode Files Or Information
Executing test: T1140-2 Certutil Rename and Decode
        1 file(s) copied.
(null)
error The file exists. 0x80070050 (WIN32: 80 ERROR_FILE_EXISTS)
(null)
CertUtil: The file exists.
(null)
error The file exists. 0x80070050 (WIN32: 80 ERROR_FILE_EXISTS)
(null)
CertUtil: The file exists.
Done executing test: T1140-2 Certutil Rename and Decode
```

I suggest renaming the files used for the 2nd test to prevent this.

I also found that the cleanup code didn't work for the .exe file in both tests due to missing '\'

**Testing:**
It works fine after:
```powershell
Invoke-AtomicTest T1140
PathToAtomicsFolder = C:\AtomicRedTeam\atomics

Executing test: T1140-1 Deobfuscate/Decode Files Or Information
Input Length = 27648
Output Length = 38072
CertUtil: -encode command completed successfully.
Input Length = 38072
Output Length = 27648
CertUtil: -decode command completed successfully.
Done executing test: T1140-1 Deobfuscate/Decode Files Or Information
Executing test: T1140-2 Certutil Rename and Decode
        1 file(s) copied.
(null)
(null)
(null)
(null)
(null)
(null)
Done executing test: T1140-2 Certutil Rename and Decode
```

And the cleanup is good:
```powershell
PS C:\> Invoke-AtomicTest T1140 -Cleanup
PathToAtomicsFolder = C:\AtomicRedTeam\atomics

Executing cleanup for test: T1140-1 Deobfuscate/Decode Files Or Information
Done executing cleanup for test: T1140-1 Deobfuscate/Decode Files Or Information
Executing cleanup for test: T1140-2 Certutil Rename and Decode
Done executing cleanup for test: T1140-2 Certutil Rename and Decode
PS C:\> ls $env:temp\T1140*
PS C:\>
```

**Associated Issues:**
Didn't create one