### PR TITLE
T1105: add cleanup to tests 7 & 8

### DIFF
--- a/atomics/T1105/T1105.yaml
+++ b/atomics/T1105/T1105.yaml
@@ -187,6 +187,8 @@ atomic_tests:
   executor:
     command: |
       cmd /c certutil -urlcache -split -f #{remote_file} #{local_path}
+    cleanup_command: |
+      del #{local_path}
     name: command_prompt
 - name: certutil download (verifyctl)
   auto_generated_guid: ffd492e3-0455-4518-9fb1-46527c9f241b
@@ -205,11 +207,13 @@ atomic_tests:
       default: Atomic-license.txt
   executor:
     command: |
-      $datePath = "certutil-$(Get-Date -format yyyy_MM_dd_HH_mm)"
+      $datePath = "certutil-$(Get-Date -format yyyy_MM_dd)"
       New-Item -Path $datePath -ItemType Directory
       Set-Location $datePath
       certutil -verifyctl -split -f #{remote_file}
       Get-ChildItem | Where-Object {$_.Name -notlike "*.txt"} | Foreach-Object { Move-Item $_.Name -Destination #{local_path} }
+    cleanup_command: |
+      Remove-Item "certutil-$(Get-Date -format yyyy_MM_dd)" -Force -Recurse -ErrorAction Ignore
     name: powershell
 - name: Windows - BITSAdmin BITS Download
   auto_generated_guid: a1921cd3-9a2d-47d5-a891-f1d0f2a7a31b


### PR DESCRIPTION
**Details:**
T1105 tests 7 and 8 lack a cleanup command and I suggest to add it.

Note that the cleanup for `certutil -urlcache -split -f ...` is still incomplete because it creates a `<hash>.key` file. I could remove all `*.key` files but that could have undesired impact. I don't know if we could also hardcode the `<hash>` value...

For the PowerShell version, I chose to remove the hour and minute from the folder name to ensure we correctly delete the folder if the minute value changes between run and cleanup (the day could also change but that's less likely).
Another option would be to use a more static folder name, or to pass the generated folder name between execution and cleanup (I don't know if that's supported by ART)

**Testing:**
* Execution:
```powershell
PS C:\> Invoke-AtomicTest T1105 -TestNumbers 7,8
PathToAtomicsFolder = C:\AtomicRedTeam\atomics

Executing test: T1105-7 certutil download (urlcache)
****  Online  ****
CertUtil: -URLCache command completed successfully.
Done executing test: T1105-7 certutil download (urlcache)
Executing test: T1105-8 certutil download (verifyctl)


    Directory: C:\Users\user\AppData\Local\Temp


Mode                LastWriteTime         Length Name
----                -------------         ------ ----
d-----        6/16/2020   6:34 PM                certutil-2020_06_16
CertUtil: -verifyCTL command FAILED: 0x8009310b (ASN: 267 CRYPT_E_ASN1_BADTAG)
CertUtil: ASN1 bad tag value met.


Done executing test: T1105-8 certutil download (verifyctl)
PS C:\> ls $env:temp\*license*


    Directory: C:\Users\user\AppData\Local\Temp


Mode                LastWriteTime         Length Name
----                -------------         ------ ----
-a----        6/16/2020   6:34 PM           1078 Atomic-license.txt


PS C:\> ls $env:temp\*.key


    Directory: C:\Users\user\AppData\Local\Temp


Mode                LastWriteTime         Length Name
----                -------------         ------ ----
-a----        6/16/2020   6:34 PM           1078 2d2a313164ae3a724cc53b0c8e104dd6053f8402.key


PS C:\> ls $env:temp\certutil*


    Directory: C:\Users\user\AppData\Local\Temp


Mode                LastWriteTime         Length Name
----                -------------         ------ ----
d-----        6/16/2020   6:34 PM                certutil-2020_06_16
```

* Cleanup:
```powershell
PS C:\> Invoke-AtomicTest T1105 -TestNumbers 7,8 -Cleanup
PathToAtomicsFolder = C:\AtomicRedTeam\atomics

Executing cleanup for test: T1105-7 certutil download (urlcache)
Done executing cleanup for test: T1105-7 certutil download (urlcache)
Executing cleanup for test: T1105-8 certutil download (verifyctl)
Done executing cleanup for test: T1105-8 certutil download (verifyctl)
PS C:\> ls $env:temp\*license*
PS C:\> ls $env:temp\*.key


    Directory: C:\Users\user\AppData\Local\Temp


Mode                LastWriteTime         Length Name
----                -------------         ------ ----
-a----        6/16/2020   6:34 PM           1078 2d2a313164ae3a724cc53b0c8e104dd6053f8402.key


PS C:\> ls $env:temp\certutil*
PS C:\>
```

**Associated Issues:**
None