### PR TITLE
remove markdown files from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,5 +24,3 @@ docs/.sass-cache/
 docs/_site/
 **/Invoke-AtomicTest-ExecutionLog.csv
 techniques_hash.db
-
-atomics/*/*.md


### PR DESCRIPTION
Accidentally pushed a change to gitignore markdown files which causes the md files not to be generated by Circle CI