### PR TITLE
 T1569.002: add quotes around binPath to fix bug

### DIFF
--- a/atomics/T1569.002/T1569.002.yaml
+++ b/atomics/T1569.002/T1569.002.yaml
@@ -4,9 +4,9 @@ atomic_tests:
 - name: Execute a Command as a Service
   auto_generated_guid: 2382dee2-a75f-49aa-9378-f52df6ed3fb1
   description: |
-    Creates a service specifying an aribrary command and executes it. When executing commands such as PowerShell, the service will report that it did not start correctly even when code executes properly.
+    Creates a service specifying an arbitrary command and executes it. When executing commands such as PowerShell, the service will report that it did not start correctly even when code executes properly.
 
-    Upon successful execution, cmd.exe create a new service using sc.exe create that will start powershell.exe to create a new file `art-marker.txt`
+    Upon successful execution, cmd.exe creates a new service using sc.exe that will start powershell.exe to create a new file `art-marker.txt`
   supported_platforms:
   - windows
   input_arguments:
@@ -20,7 +20,7 @@ atomic_tests:
       default: '%COMSPEC% /c powershell.exe -nop -w hidden -command New-Item -ItemType File C:\art-marker.txt'
   executor:
     command: |
-      sc.exe create #{service_name} binPath= #{executable_command}
+      sc.exe create #{service_name} binPath= "#{executable_command}"
       sc.exe start #{service_name}
       sc.exe delete #{service_name}
     name: command_prompt


### PR DESCRIPTION
**Details:**
Here is the error I got before (I'm still running the previous version before introduction of ATT&CK sub techniques, but I think the issue remains in master):
```powershell
PS C:\Windows\system32> Invoke-AtomicTest T1035 -TestNumbers 1
PathToAtomicsFolder = C:\AtomicRedTeam\atomics

Executing test: T1035-1 Execute a Command as a Service
DESCRIPTION:
        Creates a service entry in the registry and Service Database.
USAGE:
        sc <server> create [service name] [binPath= ] <option1> <option2>...

OPTIONS:
NOTE: The option name includes the equal sign.
      A space is required between the equal sign and the value.
 type= <own|share|interact|kernel|filesys|rec|userown|usershare>
       (default = own)
 start= <boot|system|auto|demand|disabled|delayed-auto>
       (default = demand)
 error= <normal|severe|critical|ignore>
       (default = normal)
 binPath= <BinaryPathName to the .exe file>
 group= <LoadOrderGroup>
 tag= <yes|no>
 depend= <Dependencies(separated by / (forward slash))>
 obj= <AccountName|ObjectName>
       (default = LocalSystem)
 DisplayName= <display name>
 password= <password>
[SC] StartService: OpenService FAILED 1060:
```

**Testing:**
I fixed it by adding quotes around `binPath`.
```powershell
PS C:\Windows\system32> Invoke-AtomicTest T1035 -TestNumbers 1
PathToAtomicsFolder = C:\AtomicRedTeam\atomics

Executing test: T1035-1 Execute a Command as a Service
[SC] CreateService SUCCESS
[SC] StartService FAILED 1053:

The service did not respond to the start or control request in a timely fashion.

[SC] DeleteService SUCCESS
Done executing test: T1035-1 Execute a Command as a Service
PS C:\Windows\system32> ls C:\art-marker.txt


    Directory: C:\


Mode                LastWriteTime         Length Name
----                -------------         ------ ----
-a----        6/19/2020   5:10 PM              0 art-marker.txt
```

**Associated Issues:**
Didn't create one