### PR TITLE
T1569.002-1: add cleanup

### DIFF
--- a/atomics/T1569.002/T1569.002.yaml
+++ b/atomics/T1569.002/T1569.002.yaml
@@ -23,6 +23,8 @@ atomic_tests:
       sc.exe create #{service_name} binPath= "#{executable_command}"
       sc.exe start #{service_name}
       sc.exe delete #{service_name}
+    cleanup_command: |
+      del C:\art-marker.txt >nul 2>&1
     name: command_prompt
     elevation_required: true
 - name: Use PsExec to execute a command on a remote host


### PR DESCRIPTION
**Details:**
Add cleanup command. Actually the best would be to transform 'c:\art-marker.txt' into an input itself and re-use it in the command, but I think this is still a step forward :)

**Testing:**
N/A

**Associated Issues:**
Didn't create one