### PR TITLE
T1053.005: execute remotely the cleanup command, after remote creation of scheduled task

### DIFF
--- a/atomics/T1053.005/T1053.005.yaml
+++ b/atomics/T1053.005/T1053.005.yaml
@@ -77,7 +77,7 @@ atomic_tests:
     command: |
       SCHTASKS /Create /S #{target} /RU #{user_name} /RP #{password} /TN "Atomic task" /TR "#{task_command}" /SC daily /ST #{time}
     cleanup_command: |
-      SCHTASKS /Delete /TN "Atomic task" /F >nul 2>&1
+      SCHTASKS /Delete /S #{target} /RU #{user_name} /RP #{password} /TN "Atomic task" /F >nul 2>&1
 
 - name: Powershell Cmdlet Scheduled Task
   auto_generated_guid: af9fd58f-c4ac-4bf2-a9ba-224b71ff25fd


### PR DESCRIPTION
**Details:**
This test creates remotely a scheduled task, so if we want to delete it during cleanup, then we have to do it remotely too :)

**Testing:**
I didn't test it but I just copied the code from the execution command above

**Associated Issues:**
Didn't create one