### PR TITLE
T1546.008: re-add cleanup command lost during transition to subtechnique

### DIFF
--- a/atomics/T1546.008/T1546.008.yaml
+++ b/atomics/T1546.008/T1546.008.yaml
@@ -38,6 +38,13 @@ atomic_tests:
           New-ItemProperty -Path $registryPath -Name $name -Value $Value
         }
       }
+    cleanup_command: |
+      $input_table = "#{parent_list}".split(",")
+      Foreach ($item in $input_table)
+      {
+        $item = $item.trim()
+        reg delete "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\$item" /v Debugger /f 2>&1 | Out-Null
+      }
     name: powershell
     elevation_required: true
 


### PR DESCRIPTION
I discovered by luck that the cleanup command was lost in transition to sub technique:
https://github.com/redcanaryco/atomic-red-team/commit/24549e3866407c3080b95b6afebf78e8acd23352#diff-11963178672457b3aab959974d0dff71L46-L52

I also added `2>&1` at its end because we prefer to hide error messages (based on what I see in other tests) when it tries to cleanup a key that doesn't exist.

I suggest checking if nothing else wasn't lost ;)