### PR TITLE
T1053.005: in remote schtasks, we need username and password for authentication

### DIFF
--- a/atomics/T1053.005/T1053.005.yaml
+++ b/atomics/T1053.005/T1053.005.yaml
@@ -64,20 +64,20 @@ atomic_tests:
       type: String
       default: localhost
     user_name:
-      description: Username DOMAIN\User
+      description: 'Username to authenticate with, format: DOMAIN\User'
       type: String
       default: DOMAIN\user
     password:
-      description: Password
+      description: Password to authenticate with
       type: String
       default: At0micStrong
   executor:
     name: command_prompt
     elevation_required: true
     command: |
-      SCHTASKS /Create /S #{target} /RU #{user_name} /RP #{password} /TN "Atomic task" /TR "#{task_command}" /SC daily /ST #{time}
+      SCHTASKS /Create /S #{target} /U #{user_name} /P #{password} /TN "Atomic task" /TR "#{task_command}" /SC daily /ST #{time}
     cleanup_command: |
-      SCHTASKS /Delete /S #{target} /RU #{user_name} /RP #{password} /TN "Atomic task" /F >nul 2>&1
+      SCHTASKS /Delete /S #{target} /U #{user_name} /P #{password} /TN "Atomic task" /F >nul 2>&1
 
 - name: Powershell Cmdlet Scheduled Task
   auto_generated_guid: af9fd58f-c4ac-4bf2-a9ba-224b71ff25fd


### PR DESCRIPTION
**Details:**
/RU and /RP are credentials for "runas" when running the task, not for remote auth when creating it

**Testing:**
Before I used "user_name" and "password" to specify a user with remote admin rights. However it failed and I didn't understand why... It was because it used my current user auth, instead of the specified credentials, for remote auth.
After it works fine and the task runs as the same user as used to authenticate

**Associated Issues:**
Didn't create one