### PR TITLE
Update T1027.yaml

### DIFF
--- a/atomics/T1027/T1027.yaml
+++ b/atomics/T1027/T1027.yaml
@@ -93,6 +93,7 @@ atomic_tests:
     prereq_command: |
       if (Test-Path #{exe_payload}) {exit 0} else {exit 1}
     get_prereq_command: |
+      [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
       Invoke-WebRequest "#{url_path}" -OutFile "$env:temp\T1027.zip"
       Expand-Archive -path "$env:temp\T1027.zip" -DestinationPath "$env:temp\temp_T1027.zip\" -Force
   executor:


### PR DESCRIPTION
Add a line to include/force TLS1.2 in order for the prereq function to work on win2k16
All the credit to clr2of8 for sending me the string

**Details:**
<!-- Insert details about this change here. Please include as much detail as possible -->

**Testing:**
<!-- Note any testing done, local or automated here. -->

**Associated Issues:**
<!-- Please link any issues that this pull request impacts or fixes. -->