### PR TITLE
Update T1095.yaml

### DIFF
--- a/atomics/T1095/T1095.yaml
+++ b/atomics/T1095/T1095.yaml
@@ -50,6 +50,7 @@ atomic_tests:
     prereq_command: |
       if( Test-Path "#{ncat_exe}") {exit 0} else {exit 1}
     get_prereq_command: |
+      [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
       New-Item -ItemType Directory -Force -Path #{ncat_path} | Out-Null
       $parentpath = Split-Path (Split-Path "#{ncat_exe}"); $zippath = "$parentpath\nmap.zip"
       Invoke-WebRequest  "https://nmap.org/dist/nmap-7.80-win32.zip" -OutFile "$zippath"


### PR DESCRIPTION
Add a line to include/force TLS1.2 in order for the prereq function to work on win2k16
All the credit to clr2of8 for sending me the string

**Details:**
<!-- Insert details about this change here. Please include as much detail as possible -->

**Testing:**
<!-- Note any testing done, local or automated here. -->

**Associated Issues:**
<!-- Please link any issues that this pull request impacts or fixes. -->