### PR TITLE
Update T1555.003.yaml

### DIFF
--- a/atomics/T1555.003/T1555.003.yaml
+++ b/atomics/T1555.003/T1555.003.yaml
@@ -23,6 +23,7 @@ atomic_tests:
     prereq_command: |
       if (Test-Path #{file_path}\SysInternals) {exit 0} else {exit 1}
     get_prereq_command: |
+      [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
       Invoke-WebRequest "https://github.com/mitre-attack/attack-arsenal/raw/66650cebd33b9a1e180f7b31261da1789cdceb66/adversary_emulation/APT29/CALDERA_DIY/evals/payloads/Modified-SysInternalsSuite.zip" -OutFile "#{file_path}\Modified-SysInternalsSuite.zip"
       Expand-Archive #{file_path}\Modified-SysInternalsSuite.zip #{file_path}\sysinternals -Force
       Remove-Item #{file_path}\Modified-SysInternalsSuite.zip -Force


### PR DESCRIPTION
Add a line to include/force TLS1.2 in order for the prereq function to work on win2k16
All the credit to clr2of8 for sending me the string

**Details:**
<!-- Insert details about this change here. Please include as much detail as possible -->

**Testing:**
<!-- Note any testing done, local or automated here. -->

**Associated Issues:**
<!-- Please link any issues that this pull request impacts or fixes. -->