### PR TITLE
Update T1546.010.yaml

### DIFF
--- a/atomics/T1546.010/T1546.010.yaml
+++ b/atomics/T1546.010/T1546.010.yaml
@@ -26,6 +26,7 @@ atomic_tests:
     prereq_command: |
       if ((Test-Path #{registry_file}) -and (Test-Path #{registry_cleanup_file})) {exit 0} else {exit 1}
     get_prereq_command: |
+      [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
       New-Item -Type Directory (split-path #{registry_file}) -ErrorAction ignore | Out-Null
       Invoke-WebRequest "https://github.com/redcanaryco/atomic-red-team/raw/master/atomics/T1546.010/src/T1546.010.reg" -OutFile "#{registry_file}"
       Invoke-WebRequest "https://github.com/redcanaryco/atomic-red-team/raw/master/atomics/T1546.010/src/T1546.010-cleanup.reg" -OutFile "#{registry_cleanup_file}"


### PR DESCRIPTION
Add a line to include/force TLS1.2 in order for the prereq function to work on win2k16
All the credit to clr2of8 for sending me the string

**Details:**
<!-- Insert details about this change here. Please include as much detail as possible -->

**Testing:**
<!-- Note any testing done, local or automated here. -->

**Associated Issues:**
<!-- Please link any issues that this pull request impacts or fixes. -->