### PR TITLE
Directory clean-up (per spec.yaml) pass

### DIFF
--- a/atomics/T1059.004/T1059.004.yaml
+++ b/atomics/T1059.004/T1059.004.yaml
@@ -33,8 +33,8 @@ atomic_tests:
   - linux
   executor:
     command: |
-      curl -sS https://raw.githubusercontent.com/redcanaryco/atomic-red-team/master/atomics/T1059.004/echo-art-fish.sh | bash
-      wget --quiet -O - https://raw.githubusercontent.com/redcanaryco/atomic-red-team/master/atomics/T1059.004/echo-art-fish.sh | bash
+      curl -sS https://raw.githubusercontent.com/redcanaryco/atomic-red-team/master/atomics/T1059.004/src/echo-art-fish.sh | bash
+      wget --quiet -O - https://raw.githubusercontent.com/redcanaryco/atomic-red-team/master/atomics/T1059.004/src/echo-art-fish.sh | bash
     cleanup_command: |
       rm /tmp/art-fish.txt
     name: sh

--- a/atomics/T1059.004/echo-art-fish.sh
+++ b/atomics/T1059.004/echo-art-fish.sh
@@ -1,2 +1,0 @@
-#! /bin/bash
-echo So long, and thanks for all the fish! > /tmp/art-fish.txt

--- a/atomics/T1059.004/src/echo-art-fish.sh
+++ b/atomics/T1059.004/src/echo-art-fish.sh
@@ -1,0 +1,2 @@
+#! /bin/bash
+echo So long, and thanks for all the fish! > /tmp/art-fish.txt


### PR DESCRIPTION
**Details:**
1)- moved shell script to /src on test 2 [https://github.com/redcanaryco/atomic-red-team/tree/master/atomics/T1059.004]
 - confirmed bash syntax worked w/o quotes
 - confirmed /tmp (test 1) still a valid simlink to /var/tmp

2)- grepped current atomics folder for any other similar errors

3)- verified other folders previously noted to have clean-up issues are fixed or no-longer exist:
(  no longer exists  ) T1086
( also no longer exists   )  T1103
( fixed already   ) T1114
( no longer exists   ) T1117
(  no longer exists  ) T1166


**Testing:**
tested as mentioned above, otherwise only moved the 1 file and fixed references

**Associated Issues:**
n/a