### PR TITLE
configurable host to scan

### DIFF
--- a/atomics/T1046/T1046.yaml
+++ b/atomics/T1046/T1046.yaml
@@ -59,27 +59,24 @@ atomic_tests:
   supported_platforms:
   - windows
   input_arguments:
-    file_name:
-      description: defining NMap install exe
-      type: path
-      default: $env:temp\nmap-7.80-setup.exe
     nmap_url:
-      description: defining nmap download url
+      description: NMap installer download URL
       type: url
       default: https://nmap.org/dist/nmap-7.80-setup.exe
+    host_to_scan:
+      description: The host to scan with NMap
+      type: string
+      default: 127.0.0.1
   dependency_executor_name: powershell
   dependencies:
   - description: |
-      NMap must be installed at #{file_name}
-    prereq_command: 'if (cmd /c "where nmap >nul 2>&1") {exit 0} else {exit 1}'
+      NMap must be installed
+    prereq_command: 'if (cmd /c nmap 2>nul) {exit 0} else {exit 1}'
     get_prereq_command: |
-      Invoke-WebRequest -OutFile "#{file_name}" #{nmap_url}
-      Start-Process #{file_name} /S
+      Invoke-WebRequest -OutFile $env:temp\nmap-7.80-setup.exe #{nmap_url}
+      Start-Process $env:temp\nmap-7.80-setup.exe /S
   executor:
     command: |-
-      nmap 127.0.0.1
-    cleanup_command: |-
-      try {Start-Process 'C:\Program Files (x86)\Nmap\Uninstall.exe' "/S"} catch{} 
-      Remove-Item #{file_name} -erroraction ignore
+      nmap #{host_to_scan}
     name: powershell
     elevation_required: true


### PR DESCRIPTION
Fix the prereq check which was broken and made the host to scan configurable. Remove the cleanup command that was uninstalling the prereq because the general rule of thumb is the cleanup does not remove prereqs, only removes temp files, restarts services, resets registry keys, etc.