### PR TITLE
T1551.003-Space-Before-Name

### DIFF
--- a/atomics/T1551.003/T1551.003.yaml
+++ b/atomics/T1551.003/T1551.003.yaml
@@ -82,3 +82,13 @@ atomic_tests:
       . ~/.bashrc
       history -c
     name: sh
+- name:  Disable Bash History Logging Using Space Before Name
+  description: |
+    Using a space before a command, the command will not be logged in the Bash History file
+  supported_platforms:
+  - linux
+  - macos
+  executor:
+    command: |
+       set +o history
+    name: sh


### PR DESCRIPTION
**Details:**
Using a a space before a disable logging command, the command will not be logged in the Bash History file

**Testing:**
Linux

**Associated Issues:**
<!-- Please link any issues that this pull request impacts or fixes. -->