### PR TITLE
Update RegKey AppInit_DLLs Path

### DIFF
--- a/atomics/T1546.010/src/T1546.010.reg
+++ b/atomics/T1546.010/src/T1546.010.reg
@@ -1,6 +1,6 @@
 Windows Registry Editor Version 5.00
 
 [HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Windows]
-"AppInit_DLLs"="C:\\Tools\\T1103.dll,C:\\Tools\\T1103x86.dll"
+"AppInit_DLLs"="C:\\Tools\\T1546.010.dll,C:\\Tools\\T1546.010x86.dll"
 "LoadAppInit_DLLs"=dword:00000001
 "RequireSignedAppInit_DLLs"=dword:00000000


### PR DESCRIPTION
Details:
Changed reg file AppInit_DLLs path from C:\Tools\T1103.dll + T1103x86.dll to C:\Tools\T1546.010 + T1546.010x86.dll
This Atomic Use Case was broken after sub-technique conformity.

Testing:
Validated the T1546.010 use-case worked locally after modifying.
Cleanup task wipes the AppInit_DLLs and LoadAppInit_DLLs after usage.

Associated Issues:
N/A