### PR TITLE
Create T1078.001 and yaml

### DIFF
--- a/atomics/T1078.001/T1078.001.yaml
+++ b/atomics/T1078.001/T1078.001.yaml
@@ -1,5 +1,5 @@
 attack_technique: T1078.001
-display_name: Valid Accounts: Default Accounts
+display_name: 'Valid Accounts: Default Accounts'
 atomic_tests:
 - name: Enable Guest account
   description: After execution the Default Guest account will be enabled (Active) and added to Administrators Group

--- a/atomics/T1078.001/T1078.001.yaml
+++ b/atomics/T1078.001/T1078.001.yaml
@@ -1,5 +1,5 @@
 attack_technique: T1078.001
-display_name: Valid Accounts Default Accounts
+display_name: Valid Accounts: Default Accounts
 atomic_tests:
 - name: Enable Guest account
   description: After execution the Default Guest account will be enabled (Active) and added to Administrators Group

--- a/atomics/T1078.001/T1078.001.yaml
+++ b/atomics/T1078.001/T1078.001.yaml
@@ -1,0 +1,17 @@
+attack_technique: T1078.001
+display_name: Valid Accounts Default Accounts
+atomic_tests:
+- name: Enable Guest account
+  description: After execution the Default Guest account will be enabled (Active) and added to Administrators Group
+  supported_platforms:
+  - windows
+  executor:
+    command: |
+      net user guest /active:yes
+      net user guest Paswword123!
+      net localgroup administrators guest /add
+    cleanup_command: |-
+      net user guest /active:no
+      net localgroup administrators guest /delete
+    name: command_prompt
+    elevation_required: true


### PR DESCRIPTION
Creating Folder for sub technique and yaml for .001

**Details:**
Adding Folder for subtechnique Default Accounts under Valid Accounts, under Persistence Tactic
This is enabling (activate) the default Guest account and adding it to administrators group

**Testing:**
Used my own (new) repo first and then used start-atomicGUI and ran PS C:\Tools\AtomicRedTeam> Invoke-AtomicTest T1078.001 -PathToAtomicsFolder C:\Users\jesse\Documents\GitHub\atomic-red-team\atomics\ -ShowDetailsBrief

**Associated Issues:**
Add sub technique where there wasn't any before