### PR TITLE
T1531 - Removed the need for dependencies on tests 1 and 2 

### DIFF
--- a/atomics/T1531/T1531.yaml
+++ b/atomics/T1531/T1531.yaml
@@ -21,15 +21,9 @@ atomic_tests:
       description: New password for the specified account.
       type: string
       default: HuHuHUHoHo283283@dJD
-  dependencies:
-  - description: |
-      User account to change password of must exist (User: #{user_account})
-    prereq_command: |
-      net user #{user_account}
-    get_prereq_command: |
-      net user #{user_account} #{new_user_password} /add
   executor:
     command: |
+      net user #{user_account} #{new_user_password} /add
       net.exe user #{user_account} #{new_password}
     cleanup_command: |
       net.exe user #{user_account} /delete >nul 2>&1

--- a/atomics/T1531/T1531.yaml
+++ b/atomics/T1531/T1531.yaml
@@ -50,15 +50,9 @@ atomic_tests:
       description: User account to be deleted.
       type: string
       default: AtomicUser
-  dependencies:
-  - description: |
-      User account to delete must exist (User: #{user_account})
-    prereq_command: |
-      net user #{user_account}
-    get_prereq_command: |
-      net user #{user_account} #{new_user_password} /add
   executor:
     command: |
+      net user #{user_account} #{new_user_password} /add
       net.exe user #{user_account} /delete
     name: command_prompt
     elevation_required: true


### PR DESCRIPTION
Removed the need for dependencies on "Change User Password - Windows" and "Delete User - Windows" by adding the account creation command to the executor. Tested successfully.