### PR TITLE
Update to T1040.yaml test 3 "Packet capture windows command prompt"

### DIFF
--- a/atomics/T1040/T1040.yaml
+++ b/atomics/T1040/T1040.yaml
@@ -59,20 +59,36 @@ atomic_tests:
   auto_generated_guid: a5b2f6a0-24b4-493e-9590-c699f75723ca
   description: |
     Perform a packet capture using the windows command prompt. This will require a host that has Wireshark/Tshark
-    installed, along with WinPCAP. Windump will require the windump executable.
+    installed.
 
-    Upon successful execution, tshark will execute and capture 5 packets on interface Ethernet0.
+    Upon successful execution, tshark will execute and capture 5 packets on interface "Ethernet".
   supported_platforms:
   - windows
   input_arguments:
     interface:
       description: Specify interface to perform PCAP on.
       type: String
-      default: Ethernet0
+      default: Ethernet
+    wireshark_url:
+      description: wireshark installer download URL
+      type: url
+      default: https://2.na.dl.wireshark.org/win64/Wireshark-win64-3.2.6.exe
+    tshark_path:
+      description: path to tshark.exe 
+      type: path
+      default: c:\program files\wireshark\tshark.exe
+  dependency_executor_name: powershell
+  dependencies:
+    - description: |
+       tshark must be installed and in the default path of "c:\Program Files\Wireshark\Tshark.exe".
+      prereq_command:
+        if (test-path "#{tshark_path}") {exit 0} else {exit 1}
+      get_prereq_command: |
+        Invoke-WebRequest -OutFile $env:temp\wireshark_installer.exe #{wireshark_url}
+        Start-Process $env:temp\wireshark_installer.exe /S
   executor:
     command: |
       "c:\Program Files\Wireshark\tshark.exe" -i #{interface} -c 5
-      c:\windump.exe
     name: command_prompt
     elevation_required: true
     


### PR DESCRIPTION
Removed windump from the executor commands as it is not necessary to get a successful end result from this test.
Added dependencies to check for Tshark in correct path, and to download and install Wireshark/Tshark if it is not already present.
Edited description to match the changes made.
Changed the default interface to "ethernet" in order to test.
Tested successfully.