### PR TITLE
Update T1105.yaml

### DIFF
--- a/atomics/T1105/T1105.yaml
+++ b/atomics/T1105/T1105.yaml
@@ -298,4 +298,29 @@ atomic_tests:
       del C:\\svchost.exe >nul 2>&1
     name: command_prompt
     elevation_required: true
-
+- name: MpCmdRun DownloadFile
+  description: LOLB to download a file using Windows Defender that will put Atomic-license.txt in temp directory using this version 4.18.2007.8-0
+  supported_platforms:
+  - windows
+  input_arguments:
+    local_path:
+      description: Local path to place file
+      type: String
+      default: '%temp%\Atomic-license.txt'
+    remote_file:
+      description: URL of file to copy
+      type: url
+      default: https://raw.githubusercontent.com/redcanaryco/atomic-red-team/master/LICENSE.txt
+  dependency_executor_name: powershell
+  dependencies:
+  - description: Must have Specific Versions and this just tests for one of them
+    prereq_command: "if ((Test-Path \"C:\\ProgramData\\Microsoft\\Windows Defender\\Platform\\4.18.2007.8-0\") -or (Test-Path \"C:\\ProgramData\\Microsoft\\Windows Defender\\Platform\\4.18.2007.9\") -or (Test-Path \"C:\\ProgramData\\Microsoft\\Windows Defender\\Platform\\4.18.2009.9\")) {Write-Host \"You Got one of the versions\" -fore green} else {Write-Host \"You Don't have it\" -fore red}\n		 \n		 "
+    get_prereq_command: Write-Host "If You Don't have this version 4.18.2007.8-0 you can't run this atomic-test without manually changing to the other versions" -fore green
+  executor:
+    command: |-
+      cd %temp%
+      "C:\ProgramData\Microsoft\Windows Defender\platform\4.18.2007.8-0\MpCmdRun.exe" -DownloadFile -url #{remote_file} -path #{local_path}
+    cleanup_command: |-
+      del #{local_path} >nul 2>&1
+      del %temp%\MpCmdRun.log >nul 2>&1
+    name: command_prompt


### PR DESCRIPTION
Added MpCmdRun.exe (Windows Defender) LOLB Atomic-Test
Added CleanUp commands
Added PreReqs for a couple of versions
Attack cmd for one version at the moment

**Details:**
This downloads an arbitrary file using LOLB reference: https://www.bleepingcomputer.com/news/microsoft/microsoft-defender-can-ironically-be-used-to-download-malware/

**Testing:**
Local Test

**Associated Issues:**
 This only can run the test for one of the LOLB versions as I don't know how to run a test for multiples yet. Using this version 4.18.2007.8-0