### PR TITLE
Fix broken MITRE ATT&CK URLs

### DIFF
--- a/atomic_red_team/atomic_doc_template.md.erb
+++ b/atomic_red_team/atomic_doc_template.md.erb
@@ -1,6 +1,6 @@
 # <%= technique['identifier'] %> - <%= technique['name'] -%>
 
-## [Description from ATT&CK](https://attack.mitre.org/wiki/Technique/<%= technique['identifier'] %>)
+## [Description from ATT&CK](https://attack.mitre.org/techniques/<%= technique['identifier'].gsub(/\./, '/') %>)
 <blockquote><%= technique['description'] %></blockquote>
 
 ## Atomic Tests


### PR DESCRIPTION
**Details:**
Fixed a URL formatting issue where all links to MITRE ATT&CK descriptions were broken (returned 404).

**Testing:**
Ran `bin/generate-atomic-docs.rb` and verified that the URLs are correctly linked to the corresponding techniques.

**Associated Issues:**
None