### PR TITLE
more verbose description and additional cleanup

### DIFF
--- a/atomics/Indexes/index.yaml
+++ b/atomics/Indexes/index.yaml
@@ -9421,8 +9421,10 @@ persistence:
     - name: Persist, Download, & Execute
       auto_generated_guid: 62a06ec5-5754-47d2-bcfc-123d8314c6ae
       description: |
-        This test simulates an adversary leveraging bitsadmin.exe to schedule a BITS transfer
-        and execute a payload in multiple steps. This job will remain in the BITS queue for 90 days by default if not removed.
+        This test simulates an adversary leveraging bitsadmin.exe to schedule a BITS transferand execute a payload in multiple steps.
+        Note that in this test, the file executed is not the one downloaded. The downloading of a random file is simply the trigger for getting bitsdamin to run an executable.
+        This has the interesting side effect of causing the executable (e.g. notepad) to run with an Initiating Process of "svchost.exe" and an Initiating Process Command Line of "svchost.exe -k netsvcs -p -s BITS"
+        This job will remain in the BITS queue until complete or for up to 90 days by default if not removed.
       supported_platforms:
       - windows
       input_arguments:
@@ -9450,9 +9452,9 @@ persistence:
           bitsadmin.exe /resume #{bits_job_name}
           timeout 5
           bitsadmin.exe /complete #{bits_job_name}
-        cleanup_command: 'del #{local_file} >nul 2>&1
-
-'
+        cleanup_command: |
+          del #{local_file} >nul 2>&1
+          bitsadmin.exe /cancel #{bits_job_name} >nul 2>&1
         name: command_prompt
     - name: Bits download using destktopimgdownldr.exe (cmd)
       auto_generated_guid: afb5e09e-e385-4dee-9a94-6ee60979d114
@@ -21405,8 +21407,10 @@ defense-evasion:
     - name: Persist, Download, & Execute
       auto_generated_guid: 62a06ec5-5754-47d2-bcfc-123d8314c6ae
       description: |
-        This test simulates an adversary leveraging bitsadmin.exe to schedule a BITS transfer
-        and execute a payload in multiple steps. This job will remain in the BITS queue for 90 days by default if not removed.
+        This test simulates an adversary leveraging bitsadmin.exe to schedule a BITS transferand execute a payload in multiple steps.
+        Note that in this test, the file executed is not the one downloaded. The downloading of a random file is simply the trigger for getting bitsdamin to run an executable.
+        This has the interesting side effect of causing the executable (e.g. notepad) to run with an Initiating Process of "svchost.exe" and an Initiating Process Command Line of "svchost.exe -k netsvcs -p -s BITS"
+        This job will remain in the BITS queue until complete or for up to 90 days by default if not removed.
       supported_platforms:
       - windows
       input_arguments:
@@ -21434,9 +21438,9 @@ defense-evasion:
           bitsadmin.exe /resume #{bits_job_name}
           timeout 5
           bitsadmin.exe /complete #{bits_job_name}
-        cleanup_command: 'del #{local_file} >nul 2>&1
-
-'
+        cleanup_command: |
+          del #{local_file} >nul 2>&1
+          bitsadmin.exe /cancel #{bits_job_name} >nul 2>&1
         name: command_prompt
     - name: Bits download using destktopimgdownldr.exe (cmd)
       auto_generated_guid: afb5e09e-e385-4dee-9a94-6ee60979d114

--- a/atomics/T1197/T1197.md
+++ b/atomics/T1197/T1197.md
@@ -94,8 +94,10 @@ Remove-Item #{local_file} -ErrorAction Ignore
 <br/>
 
 ## Atomic Test #3 - Persist, Download, & Execute
-This test simulates an adversary leveraging bitsadmin.exe to schedule a BITS transfer
-and execute a payload in multiple steps. This job will remain in the BITS queue for 90 days by default if not removed.
+This test simulates an adversary leveraging bitsadmin.exe to schedule a BITS transferand execute a payload in multiple steps.
+Note that in this test, the file executed is not the one downloaded. The downloading of a random file is simply the trigger for getting bitsdamin to run an executable.
+This has the interesting side effect of causing the executable (e.g. notepad) to run with an Initiating Process of "svchost.exe" and an Initiating Process Command Line of "svchost.exe -k netsvcs -p -s BITS"
+This job will remain in the BITS queue until complete or for up to 90 days by default if not removed.
 
 **Supported Platforms:** Windows
 
@@ -126,6 +128,7 @@ bitsadmin.exe /complete #{bits_job_name}
 #### Cleanup Commands:
 ```cmd
 del #{local_file} >nul 2>&1
+bitsadmin.exe /cancel #{bits_job_name} >nul 2>&1
 ```
 
 

--- a/atomics/T1197/T1197.yaml
+++ b/atomics/T1197/T1197.yaml
@@ -50,8 +50,10 @@ atomic_tests:
 - name: Persist, Download, & Execute
   auto_generated_guid: 62a06ec5-5754-47d2-bcfc-123d8314c6ae
   description: |
-    This test simulates an adversary leveraging bitsadmin.exe to schedule a BITS transfer
-    and execute a payload in multiple steps. This job will remain in the BITS queue for 90 days by default if not removed.
+    This test simulates an adversary leveraging bitsadmin.exe to schedule a BITS transferand execute a payload in multiple steps.
+    Note that in this test, the file executed is not the one downloaded. The downloading of a random file is simply the trigger for getting bitsdamin to run an executable.
+    This has the interesting side effect of causing the executable (e.g. notepad) to run with an Initiating Process of "svchost.exe" and an Initiating Process Command Line of "svchost.exe -k netsvcs -p -s BITS"
+    This job will remain in the BITS queue until complete or for up to 90 days by default if not removed.
   supported_platforms:
   - windows
   input_arguments:
@@ -81,6 +83,7 @@ atomic_tests:
       bitsadmin.exe /complete #{bits_job_name}
     cleanup_command: |
       del #{local_file} >nul 2>&1
+      bitsadmin.exe /cancel #{bits_job_name} >nul 2>&1
     name: command_prompt
 - name: Bits download using destktopimgdownldr.exe (cmd)
   auto_generated_guid: afb5e09e-e385-4dee-9a94-6ee60979d114


### PR DESCRIPTION
Add cleanup command to remove the job in case it doesn't get removed automatically (such as if the job didn't complete within the timeout). Also, added more clarification in the description.