### PR TITLE
[OSCD] Create atomic test for T1113 for Windows

### DIFF
--- a/atomics/T1113/T1113.yaml
+++ b/atomics/T1113/T1113.yaml
@@ -70,4 +70,27 @@ atomic_tests:
     cleanup_command: |
       rm #{output_file}
     name: bash
-
+- name: Windows Screencapture
+  description: |
+    Use Psr.exe binary to collect screenshots of user display. Test will do left mouse click to simulate user behaviour
+  supported_platforms:
+    - windows
+  input_arguments:
+    output_file:
+      description: Output file path
+      type: Path
+      default: c:\temp\T1113_desktop.zip
+    recording_time:
+      description: Time to take screenshots
+      type: String
+      default: 5
+  executor:
+    name: powershell
+    elevation_required: false
+    command: |
+      cmd /c start /b psr.exe /start /output #{output_file} /sc 1 /gui 0 /stopevent 12
+      Add-Type -MemberDefinition '[DllImport("user32.dll")] public static extern void mouse_event(int flags, int dx, int dy, int cButtons, int info);' -Name U32 -Namespace W;
+      [W.U32]::mouse_event(0x02 -bor 0x04 -bor 0x01, 0, 0, 0, 0);
+      cmd /c "timeout #{recording_time} > NULL && psr.exe /stop"
+    cleanup_command: |
+      rm #{output_file}


### PR DESCRIPTION
**Details:**
These tests have been written as part of the OSCD Initiative sprint (#1220).
The initial goal was to have a test for this sigma rule (task 7 in the sprint backlog):

https://github.com/Neo23x0/sigma/blob/master/rules/windows/process_creation/win_susp_psr_capture_screenshots.yml

**Testing:**
Tested on local machine

**Associated Issues:**
https://github.com/redcanaryco/atomic-red-team/issues/1220