### PR TITLE
[OSCD] T1136.002: Domain Account - 2 tests

### DIFF
--- a/atomics/T1136.002/T1136.002.yaml
+++ b/atomics/T1136.002/T1136.002.yaml
@@ -1,0 +1,50 @@
+attack_technique: T1136.002
+display_name: 'Create Account: Domain Account'
+atomic_tests:
+- name: Create a new Windows domain admin user
+  description: |
+    Creates a new domain admin user in a command prompt.
+  supported_platforms:
+  - windows
+  input_arguments:
+    username:
+      description: Username of the user to create
+      type: String
+      default: T1136.002_Admin
+    password:
+      description: Password of the user to create
+      type: String
+      default: T1136_pass123!
+    group:
+      description: Domain administrator group to which add the user to
+      type: String
+      default: Domain Admins
+  executor:
+    command: |
+      net user "#{username}" "#{password}" /add /domain
+      net group "#{group}" "#{username}" /add /domain
+    cleanup_command: |
+      net user "#{username}" >nul 2>&1 /del /domain
+    name: command_prompt
+    elevation_required: false  # Requires a user to be a Domain Admin!
+- name: Create a new account similar to ANONYMOUS LOGON
+  description: |
+    Create a new account similar to ANONYMOUS LOGON in a command prompt.
+  supported_platforms:
+  - windows
+  input_arguments:
+    username:
+      description: Username of the user to create
+      type: String
+      default: ANONYMOUS  LOGON
+    password:
+      description: Password of the user to create
+      type: String
+      default: T1136_pass123!
+  executor:
+    command: |
+      net user "#{username}" "#{password}" /add /domain
+    cleanup_command: |
+      net user "#{username}" >nul 2>&1 /del /domain
+    name: command_prompt
+    elevation_required: false  # Requires a user to be a Domain Admin!


### PR DESCRIPTION
**Details:**
These tests have been written as part of the OSCD Initiative sprint (#1220).
The initial goal was to have a test for this sigma rule (task 10 in the sprint backlog):

* https://github.com/Neo23x0/sigma/blob/master/rules/windows/builtin/win_susp_local_anon_logon_created.yml

But I also have adopted the test from .001 subtechnique related to adding local (domain in .002 subtechnique) admin account

**Testing:**
I have launched both tests using ART invoke framework on my local AD lab. Both work as expected including cleanup commands.