### PR TITLE
[OSCD] T1036.004: Masquerade Task or Service - 2 tests

### DIFF
--- a/atomics/T1036.004/T1036.004.yaml
+++ b/atomics/T1036.004/T1036.004.yaml
@@ -1,0 +1,27 @@
+attack_technique: T1036.004
+display_name: Masquerade Task or Service
+atomic_tests:
+- name: Creating W32Time similar named service using schtasks
+  description: Creating W32Time similar named service (win32times) using schtasks just like threat actor dubbed "Operation Wocao"
+  supported_platforms:
+  - windows
+  executor:
+    command: |
+      schtasks /create /ru system /sc daily /tr "cmd /c powershell.exe -ep bypass -file c:\T1036.004_NonExistingScript.ps1" /tn win32times /f
+      schtasks /query /tn win32times
+    cleanup_command: |
+      schtasks /tn win32times /delete /f
+    name: command_prompt
+    elevation_required: true
+- name: Creating W32Time similar named service using sc
+  description: Creating W32Time similar named service (win32times) using sc just like threat actor dubbed "Operation Wocao"
+  supported_platforms:
+  - windows
+  executor:
+    command: |
+      sc create win32times binPath= "cmd /c start c:\T1036.004_NonExistingScript.ps1"
+      sc qc win32times
+    cleanup_command: |
+      sc delete win32times
+    name: command_prompt
+    elevation_required: true

--- a/atomics/T1036.004/T1036.004.yaml
+++ b/atomics/T1036.004/T1036.004.yaml
@@ -1,5 +1,5 @@
 attack_technique: T1036.004
-display_name: Masquerade Task or Service
+display_name: 'Masquerading: Masquerade Task or Service'
 atomic_tests:
 - name: Creating W32Time similar named service using schtasks
   description: Creating W32Time similar named service (win32times) using schtasks just like threat actor dubbed "Operation Wocao"


### PR DESCRIPTION
**Details:**
These tests have been written as part of the OSCD Initiative sprint (#1220).
The initial goal was to have a test for this sigma rule (task 2 in the sprint backlog):

* https://github.com/Neo23x0/sigma/blob/master/rules/windows/process_creation/win_apt_wocao.yml

But it only mentions `sc` used to create a service (`create win32times binPath=`). I have also found in the [FoxIt report](https://resources.fox-it.com/rs/170-CAK-271/images/201912_Report_Operation_Wocao.pdf) that this threat actor also uses `schtasks` to create a service so I also implemented a test about that.

**Testing:**
I have launched both tests using ART invoke framework on my local AD lab. Both work as expected including cleanup commands when launched with administrator privs. `elevated_required` is set to `true` for both tests.

**Associated Issues:**
#1220