### PR TITLE
[OSCD] Add test for T1006 Direct Volume Access

### DIFF
--- a/atomics/T1006/T1006.yaml
+++ b/atomics/T1006/T1006.yaml
@@ -1,0 +1,30 @@
+attack_technique: T1006
+display_name: Direct Volume Access
+atomic_tests:
+- name: Read volume boot sector via DOS device path (PowerShell)
+  description: |-
+    This test uses PowerShell to open a handle on the drive volume via the `\\.\` [DOS device path specifier](https://docs.microsoft.com/en-us/dotnet/standard/io/file-path-formats#dos-device-paths) and perform direct access read of the first few bytes of the volume.
+    On success, a hex dump of the first 11 bytes of the volume is displayed.
+
+    For a NTFS volume, it should correspond to the following sequence ([NTFS partition boot sector](https://en.wikipedia.org/wiki/NTFS#Partition_Boot_Sector_(VBR))):
+    ```
+               00 01 02 03 04 05 06 07 08 09 0A 0B 0C 0D 0E 0F
+
+    00000000   EB 52 90 4E 54 46 53 20 20 20 20                 ëR?NTFS
+    ```
+  supported_platforms:
+  - windows
+  input_arguments:
+    volume:
+      description: Drive letter of the volume to access
+      type: string
+      default: 'C:'
+  executor:
+    command: |
+      $buffer = New-Object byte[] 11
+      $handle = New-Object IO.FileStream "\\.\#{volume}", 'Open', 'Read', 'ReadWrite'
+      $handle.Read($buffer, 0, $buffer.Length)
+      $handle.Close()
+      Format-Hex -InputObject $buffer
+    name: powershell
+    elevation_required: true


### PR DESCRIPTION
**Details:**
This test has been written as part of the OSCD Initiative sprint (#1220).
The goal was to have a test for this sigma rule (task 1 in the sprint backlog):

- [sysmon_raw_disk_access_using_illegitimate_tools.yml](https://github.com/Neo23x0/sigma/blob/master/rules/windows/sysmon/sysmon_raw_disk_access_using_illegitimate_tools.yml)

**Testing:**
Manually tested on Windows 10 by running the tests then inspecting the Sysmon event log.