### PR TITLE
Update T1113.yaml

### DIFF
--- a/atomics/T1113/T1113.yaml
+++ b/atomics/T1113/T1113.yaml
@@ -53,10 +53,10 @@ atomic_tests:
     cleanup_command: |
       rm #{output_file}
     name: bash
-- name: Import
+- name: Capture Linux Desktop using Import Tool
   auto_generated_guid: 9cd1cccb-91e4-4550-9139-e20a586fcea1
   description: |
-    Use import command to collect a full desktop screenshot
+    Use import command from ImageMagick to collect a full desktop screenshot
   supported_platforms:
   - linux
   input_arguments:
@@ -64,6 +64,13 @@ atomic_tests:
       description: Output file path
       type: Path
       default: /tmp/T1113_desktop.png
+      dependencies:
+- description: |
+    ImageMagick must be installed
+  prereq_command: |
+    if import --version; then exit 0; else exit 1; fi
+  get_prereq_command: |
+    sudo apt-get install imagemagick
   executor:
     command: |
       import -window root #{output_file}

--- a/atomics/T1113/T1113.yaml
+++ b/atomics/T1113/T1113.yaml
@@ -64,13 +64,13 @@ atomic_tests:
       description: Output file path
       type: Path
       default: /tmp/T1113_desktop.png
-      dependencies:
-- description: |
-    ImageMagick must be installed
-  prereq_command: |
-    if import --version; then exit 0; else exit 1; fi
-  get_prereq_command: |
-    sudo apt-get install imagemagick
+  dependencies:
+  - description: |
+      ImageMagick must be installed
+    prereq_command: |
+      if import --version; then exit 0; else exit 1; fi
+    get_prereq_command: |
+      sudo apt-get install imagemagick
   executor:
     command: |
       import -window root #{output_file}


### PR DESCRIPTION
Update test #4 to include a prereq that downloads ImageMagik, updated test #4's name, and updated test #4's description.

**Details:**
Added a prereq that enables ImageMagik to install when get prereq command is entered. 

**Associated Issues:**
Fixes test #4, allowing the command to run properly with commands using ImageMagik