### PR TITLE
Fix off-by-one and misspelling

### DIFF
--- a/execution-frameworks/contrib/python/runner.py
+++ b/execution-frameworks/contrib/python/runner.py
@@ -609,9 +609,9 @@ class AtomicRunner():
         # Gets Executors.
         executors = get_valid_executors(tech)
 
-        if len(executors) < position:
+        if len(executors) - 1 < position:
             print("The position '{}' couldn't be found.".format(position))
-            print("The teqhnique {} has {} available tests for the current platform. Skipping...".format(technique_name,len(executors)))
+            print("The technique {} has {} available tests for the current platform. Skipping...".format(technique_name,len(executors)))
             return False  
 
         print("================================================")


### PR DESCRIPTION
**Details:**
An off-by-one issue exists in the python execution framework when comparing the number of executors that exist for the technique with the executor position that was requested. This validation causes issues downstream, specifically with the `--dependency` flag which throws an `IndexError` when invoking the runner with an invalid executor index. This PR fixes the validation step so that invalid executors are served an error message.

**Testing:**
Prior to the PR, executing `runner.py` with an executor position larger than the number of available executors will throw an  `IndexError` exception in `check_dependencies()`
`python3.7 runner.py run T1053.003 7 --dependencies --cleanup`

Following the PR, this command will produce an error message:

```
The position '7' couldn't be found.
The technique T1053.003 has 2 available tests for the current platform. Skipping...
```