### PR TITLE
[OSCD] split Linux and macOS tests for T1518.001; update processes list

### DIFF
--- a/atomics/T1518.001/T1518.001.yaml
+++ b/atomics/T1518.001/T1518.001.yaml
@@ -43,19 +43,7 @@ atomic_tests:
   - macos
   executor:
     command: |
-      ps -ef | grep Little\ Snitch | grep -v grep
-      ps aux | grep CbOsxSensorService
-      ps aux | grep falcond
-      ps aux | grep nessusd
-      ps aux | grep santad
-      ps aux | grep CbDefense
-      ps aux | grep td-agent
-      ps aux | grep packetbeat
-      ps aux | grep filebeat
-      ps aux | grep auditbeat
-      ps aux | grep osqueryd
-      ps aux | grep BlockBlock
-      ps aux | grep LuLu
+      ps aux | egrep 'Little\ Snitch|CbOsxSensorService|falcond|nessusd|santad|CbDefense|td-agent|packetbeat|filebeat|auditbeat|osqueryd|BlockBlock|LuLu'
     name: sh
 - name: Security Software Discovery - ps (Linux)
   description: |
@@ -65,14 +53,7 @@ atomic_tests:
   - linux
   executor:
     command: |
-      ps aux | grep falcond
-      ps aux | grep nessusd
-      ps aux | grep cbagentd
-      ps aux | grep td-agent
-      ps aux | grep packetbeat
-      ps aux | grep filebeat
-      ps aux | grep auditbeat
-      ps aux | grep osqueryd
+      ps aux | egrep 'falcond|nessusd|cbagentd|td-agent|packetbeat|filebeat|auditbeat|osqueryd'
     name: sh
 - name: Security Software Discovery - Sysmon Service
   auto_generated_guid: fe613cf3-8009-4446-9a0f-bc78a15b66c9

--- a/atomics/T1518.001/T1518.001.yaml
+++ b/atomics/T1518.001/T1518.001.yaml
@@ -34,19 +34,46 @@ atomic_tests:
       get-process | ?{$_.Description -like "*defender*"}
       get-process | ?{$_.Description -like "*cylance*"}
     name: powershell
-- name: Security Software Discovery - ps
+- name: Security Software Discovery - ps (macOS)
   auto_generated_guid: ba62ce11-e820-485f-9c17-6f3c857cd840
   description: |
     Methods to identify Security Software on an endpoint
-    when sucessfully executed, command shell  is going to display AV software it is running( Little snitch or carbon black ).
+    when sucessfully executed, command shell  is going to display AV/Security software it is running.
   supported_platforms:
-  - linux
   - macos
   executor:
     command: |
       ps -ef | grep Little\ Snitch | grep -v grep
       ps aux | grep CbOsxSensorService
       ps aux | grep falcond
+      ps aux | grep nessusd
+      ps aux | grep santad
+      ps aux | grep CbDefense
+      ps aux | grep td-agent
+      ps aux | grep packetbeat
+      ps aux | grep filebeat
+      ps aux | grep auditbeat
+      ps aux | grep osqueryd
+      ps aux | grep BlockBlock
+      ps aux | grep LuLu
+    name: sh
+- name: Security Software Discovery - ps (Linux)
+  auto_generated_guid: ba62ce11-e820-485f-9c17-6f3c857cd840
+  description: |
+    Methods to identify Security Software on an endpoint
+    when sucessfully executed, command shell  is going to display AV/Security software it is running.
+  supported_platforms:
+  - linux
+  executor:
+    command: |
+      ps aux | grep falcond
+      ps aux | grep nessusd
+      ps aux | grep cbagentd
+      ps aux | grep td-agent
+      ps aux | grep packetbeat
+      ps aux | grep filebeat
+      ps aux | grep auditbeat
+      ps aux | grep osqueryd
     name: sh
 - name: Security Software Discovery - Sysmon Service
   auto_generated_guid: fe613cf3-8009-4446-9a0f-bc78a15b66c9

--- a/atomics/T1518.001/T1518.001.yaml
+++ b/atomics/T1518.001/T1518.001.yaml
@@ -58,7 +58,6 @@ atomic_tests:
       ps aux | grep LuLu
     name: sh
 - name: Security Software Discovery - ps (Linux)
-  auto_generated_guid: ba62ce11-e820-485f-9c17-6f3c857cd840
   description: |
     Methods to identify Security Software on an endpoint
     when sucessfully executed, command shell  is going to display AV/Security software it is running.


### PR DESCRIPTION
**Details:**

- split macOS and Linux tests for T1518.001
- update processes lists

**Testing:**
Tested on a local machine

**Associated Issues:**
Here are the relevant Sigma rules:

- https://github.com/Neo23x0/sigma/blob/6f3ac02cb363b0fc68ebe3f762b3b6e6385fa568/rules/linux/lnx_security_software_discovery.yml
- https://github.com/Neo23x0/sigma/blob/5a8c7cd3f9291ac010f2f0e94037b0304d5cf458/rules/linux/macos_security_software_discovery.yml