### PR TITLE
[OSCD] Added T1562.006 tests to emulate indicator blocking on Linux

### DIFF
--- a/atomics/T1562.006/T1562.006.yaml
+++ b/atomics/T1562.006/T1562.006.yaml
@@ -1,0 +1,95 @@
+attack_technique: T1562.006
+display_name: 'Impair Defenses: Indicator Blocking'
+atomic_tests:
+- name: 'Auditing Configuration Changes on Linux Host'
+  auto_generated_guid: 212cfbcf-4770-4980-bc21-303e37abd0e3
+  description: |
+    Emulates modification of auditd configuration files
+  supported_platforms:
+  - linux
+  input_arguments:
+    audisp_config_file_name:
+      description: The name of the audispd configuration file to be changed
+      type: string
+      default: audispd.conf
+    auditd_config_file_name:
+      description: The name of the auditd configuration file to be changed
+      type: string
+      default: auditd.conf
+    libaudit_config_file_name:
+      description: The name of the libaudit configuration file to be changed
+      type: string
+      default: libaudit.conf
+  dependency_executor_name: bash
+  dependencies:
+    - description: |
+        Checking if auditd service is running.
+      prereq_command: |
+        auditd_status="$(systemctl is-active auditd)"
+        if [[ $auditd_status == "active" ]]; then exit 1; else exit 2; fi;
+      get_prereq_command: |
+        echo "Auditd service inactive. Please run or install it."; exit 1;
+  executor:
+    command: |
+      sed -i '$ i #art_test' /etc/audisp/#{audisp_config_file_name}
+      if [ -f "/etc/#{auditd_config_file_name}" ]
+      then
+        sed -i '$ i #art_test' /etc/#{auditd_config_file_name}
+      else
+        sed -i '$ i #art_test' /etc/audit/#{auditd_config_file_name}
+      fi
+      sed -i '$ i #art_test' /etc/#{libaudit_config_file_name}
+    cleanup_command: |
+      sed -i '$ d' /etc/audisp/#{audisp_config_file_name}
+      if [ -f "/etc/#{auditd_config_file_name}" ]
+      then
+        sed -i '$ d' /etc/#{auditd_config_file_name}
+      else
+        sed -i '$ d' /etc/audit/#{auditd_config_file_name}
+      fi
+      sed -i '$ d' /etc/#{libaudit_config_file_name}
+    name: bash
+    elevation_required: true
+- name: 'Lgging Configuration Changes on Linux Host'
+  auto_generated_guid: 7d40bc58-94c7-4fbb-88d9-ebce9fcdb60c
+  description: |
+    Emulates modification of syslog configuration.
+  supported_platforms:
+  - linux
+  input_arguments:
+    syslog_config_file_name:
+      description: The name of the syslog configuration file to be changed
+      type: string
+      default: syslog.conf
+    rsyslog_config_file_name:
+      description: The name of the rsyslog configuration file to be changed
+      type: string
+      default: rsyslog.conf
+    syslog_ng_config_file_name:
+      description: The name of the syslog-ng configuration file to be changed
+      type: string
+      default: syslog-ng.conf
+  executor:
+    command: |
+      if [ -f "/etc/#{syslog_config_file_name}" ]; then
+        sed -i '$ i #art_test' /etc/#{syslog_config_file_name}
+      fi
+      if [ -f "/etc/#{rsyslog_config_file_name}" ]; then
+        sed -i '$ i #art_test' /etc/#{rsyslog_config_file_name}
+      fi
+      if [ -f "/etc/syslog-ng/#{syslog_ng_config_file_name}" ]; then
+        sed -i '$ i #art_test' /etc/syslog-ng/#{syslog_ng_config_file_name}
+      fi
+    cleanup_command: |
+      if [ -f "/etc/#{syslog_config_file_name}" ]; then
+        sed -i '$ d' /etc/#{syslog_config_file_name}
+      fi
+      if [ -f "/etc/#{rsyslog_config_file_name}" ]; then
+        sed -i '$ d' /etc/#{rsyslog_config_file_name}
+      fi
+      if [ -f "/etc/syslog-ng/#{syslog_ng_config_file_name}" ]; then
+        sed -i '$ d' /etc/syslog-ng/#{syslog_ng_config_file_name}
+      fi
+    name: bash
+    elevation_required: true
+  

--- a/atomics/T1562.006/T1562.006.yaml
+++ b/atomics/T1562.006/T1562.006.yaml
@@ -20,32 +20,19 @@ atomic_tests:
       description: The name of the libaudit configuration file to be changed
       type: string
       default: libaudit.conf
-  dependency_executor_name: bash
-  dependencies:
-    - description: |
-        Checking if auditd service is running.
-      prereq_command: |
-        auditd_status="$(systemctl is-active auditd)"
-        if [[ $auditd_status == "active" ]]; then exit 1; else exit 2; fi;
-      get_prereq_command: |
-        echo "Auditd service inactive. Please run or install it."; exit 1;
   executor:
     command: |
-      sed -i '$ i #art_test' /etc/audisp/#{audisp_config_file_name}
-      if [ -f "/etc/#{auditd_config_file_name}" ]
-      then
-        sed -i '$ i #art_test' /etc/#{auditd_config_file_name}
-      else
-        sed -i '$ i #art_test' /etc/audit/#{auditd_config_file_name}
-      fi
-      sed -i '$ i #art_test' /etc/#{libaudit_config_file_name}
+      sed -i '$ a #art_test_1562_006_1' /etc/audisp/#{audisp_config_file_name}
+      if [ -f "/etc/#{auditd_config_file_name}" ];
+      then sed -i '$ a #art_test_1562_006_1' /etc/#{auditd_config_file_name}
+      else sed -i '$ a #art_test_1562_006_1' /etc/audit/#{auditd_config_file_name}
+      fi 
+      sed -i '$ a #art_test_1562_006_1' /etc/#{libaudit_config_file_name}
     cleanup_command: |
       sed -i '$ d' /etc/audisp/#{audisp_config_file_name}
-      if [ -f "/etc/#{auditd_config_file_name}" ]
-      then
-        sed -i '$ d' /etc/#{auditd_config_file_name}
-      else
-        sed -i '$ d' /etc/audit/#{auditd_config_file_name}
+      if [ -f "/etc/#{auditd_config_file_name}" ];
+      then sed -i '$ d' /etc/#{auditd_config_file_name}
+      else sed -i '$ d' /etc/audit/#{auditd_config_file_name}
       fi
       sed -i '$ d' /etc/#{libaudit_config_file_name}
     name: bash
@@ -71,24 +58,24 @@ atomic_tests:
       default: syslog-ng.conf
   executor:
     command: |
-      if [ -f "/etc/#{syslog_config_file_name}" ]; then
-        sed -i '$ i #art_test' /etc/#{syslog_config_file_name}
+      if [ -f "/etc/#{syslog_config_file_name}" ];
+      then sed -i '$ a #art_test_1562_006_2' /etc/#{syslog_config_file_name}
       fi
-      if [ -f "/etc/#{rsyslog_config_file_name}" ]; then
-        sed -i '$ i #art_test' /etc/#{rsyslog_config_file_name}
+      if [ -f "/etc/#{rsyslog_config_file_name}" ];
+      then sed -i '$ a #art_test_1562_006_2' /etc/#{rsyslog_config_file_name}
       fi
-      if [ -f "/etc/syslog-ng/#{syslog_ng_config_file_name}" ]; then
-        sed -i '$ i #art_test' /etc/syslog-ng/#{syslog_ng_config_file_name}
+      if [ -f "/etc/syslog-ng/#{syslog_ng_config_file_name}" ];
+      then sed -i '$ a #art_test_1562_006_2' /etc/syslog-ng/#{syslog_ng_config_file_name}
       fi
     cleanup_command: |
-      if [ -f "/etc/#{syslog_config_file_name}" ]; then
-        sed -i '$ d' /etc/#{syslog_config_file_name}
+      if [ -f "/etc/#{syslog_config_file_name}" ];
+      then sed -i '$ d' /etc/#{syslog_config_file_name}
       fi
-      if [ -f "/etc/#{rsyslog_config_file_name}" ]; then
-        sed -i '$ d' /etc/#{rsyslog_config_file_name}
+      if [ -f "/etc/#{rsyslog_config_file_name}" ];
+      then sed -i '$ d' /etc/#{rsyslog_config_file_name}
       fi
-      if [ -f "/etc/syslog-ng/#{syslog_ng_config_file_name}" ]; then
-        sed -i '$ d' /etc/syslog-ng/#{syslog_ng_config_file_name}
+      if [ -f "/etc/syslog-ng/#{syslog_ng_config_file_name}" ];
+      then sed -i '$ d' /etc/syslog-ng/#{syslog_ng_config_file_name}
       fi
     name: bash
     elevation_required: true


### PR DESCRIPTION
This test covers one of the possible scenarios for implementing an attack on security systems, namely, the use of the [Indicator Blocking sub-technique](https://attack.mitre.org/techniques/T1562/006)

**Details:**
This test emulates the actions of attackers who make malicious changes to the audit and logging configuration files. Any unauthorized modification of these files requires investigation.

Explanations of the commands being executed:
 - command `sed -i '$ a sometext'` adds a line with the text "sometext" to the end of the file;
 - command `sed -i '$ d'` removes the last line from the file.

**Testing:**
Tested locally on Ubuntu 18.04.5 LTS system

**Associated Issues:**
OSCD second sprint task: https://github.com/redcanaryco/atomic-red-team/issues/1219