### PR TITLE
add nav score for parent technique

### DIFF
--- a/bin/generate-atomic-docs.rb
+++ b/bin/generate-atomic-docs.rb
@@ -215,8 +215,14 @@ class AtomicRedTeamDocs
           "score" => 100,
           "enabled" => true
         }
+        techniqueParent =  {
+          "techniqueID" => atomic_yaml['attack_technique'].split('.')[0],
+          "score" => 100,
+          "enabled" => true
+        }
 
         techniques.push(technique)
+        techniques.push(techniqueParent) unless techniques.include?(techniqueParent)
         has_windows_tests = false
         has_macos_tests = false
         has_linux_tests = false


### PR DESCRIPTION
The navigator layer coloring was showing an under-representation of which techniques had at least one atomic test. The navigator layer will now be generated such that any parent technique with one or more atomics in one of its sub-techniques will also be colored.

Old view

![image](https://user-images.githubusercontent.com/22311332/96743563-5f915100-1381-11eb-85b9-3208eb2c1f1a.png)

New view

![image](https://user-images.githubusercontent.com/22311332/96743647-75067b00-1381-11eb-9f25-00909a6b753f.png)
