### PR TITLE
Assume Yes for pre-req installation via aptitude

### DIFF
--- a/atomics/Indexes/index.yaml
+++ b/atomics/Indexes/index.yaml
@@ -52375,7 +52375,7 @@ collection:
         prereq_command: 'if import --version; then exit 0; else exit 1; fi
 
 '
-        get_prereq_command: 'sudo apt-get install imagemagick
+        get_prereq_command: 'sudo apt-get -y install imagemagick
 
 '
       executor:

--- a/atomics/T1113/T1113.md
+++ b/atomics/T1113/T1113.md
@@ -154,7 +154,7 @@ if import --version; then exit 0; else exit 1; fi
 ```
 ##### Get Prereq Commands:
 ```bash
-sudo apt-get install imagemagick
+sudo apt-get -y install imagemagick
 ```
 
 

--- a/atomics/T1113/T1113.yaml
+++ b/atomics/T1113/T1113.yaml
@@ -70,7 +70,7 @@ atomic_tests:
     prereq_command: |
       if import --version; then exit 0; else exit 1; fi
     get_prereq_command: |
-      sudo apt-get install imagemagick
+      sudo apt-get -y install imagemagick
   executor:
     command: |
       import -window root #{output_file}


### PR DESCRIPTION
**Details:**
Adding `-y` to `apt-get install` to enable unattended installs.

**Testing:**
Tested by running and observing successful install of Imagemagic via a remote invocation.

**Associated Issues:**
Issue raised https://github.com/redcanaryco/atomic-red-team/issues/1279