### PR TITLE
New test for domain admin account enumeration

### DIFF
--- a/atomics/T1087.002/T1087.002.yaml
+++ b/atomics/T1087.002/T1087.002.yaml
@@ -163,4 +163,12 @@ atomic_tests:
     command: |
       #{adfind_path} -sc exchaddresses
     name: command_prompt
-
+- name: Enumerate Default Domain Admin Details (Domain)
+  description: |
+    This test will enumerate the details of the built-in domain admin account
+  supported_platforms:
+  - windows
+  executor:
+    command: |
+      net user administrator /domain
+    name: command_prompt


### PR DESCRIPTION
Quick test for default domain administrator account enumeration

**Details:**
In recent Ryuk campaigns this discovery method has been documented as being used.

**Testing:**
Invoke-AtomicTest T1087.002 -TestNumbers 9
