### PR TITLE
Update T1218 Test 5

### DIFF
--- a/atomics/T1218/T1218.yaml
+++ b/atomics/T1218/T1218.yaml
@@ -122,4 +122,4 @@ atomic_tests:
     name: command_prompt
     elevation_required: false
     command: |
-      #{microsoft_wordpath}\protocolhandler.exe "ms-word:nft|u|#{remote_url}"
+      "#{microsoft_wordpath}\protocolhandler.exe" "ms-word:nft|u|#{remote_url}"


### PR DESCRIPTION
**Details:**
default path contains a space and the command needs to be surrounded by quotes.

**Testing:**
Windows 10 1903
