### PR TITLE
Update T1204.002.yaml

### DIFF
--- a/atomics/T1204.002/T1204.002.yaml
+++ b/atomics/T1204.002/T1204.002.yaml
@@ -6,7 +6,6 @@ atomic_tests:
   description: |
     This Test uses a VBA macro to create and execute #{jse_path} with cscript.exe. Upon execution, the .jse file launches wscript.exe.
     Execution is handled by [Invoke-MalDoc](https://github.com/redcanaryco/invoke-atomicredteam/blob/master/Public/Invoke-MalDoc.ps1) to load and execute VBA code into Excel or Word documents.
-
     This is a known execution chain observed by the OSTap downloader commonly used in TrickBot campaigns
     References:
       https://www.computerweekly.com/news/252470091/TrickBot-Trojan-switches-to-stealthy-Ostap-downloader
@@ -23,26 +22,29 @@ atomic_tests:
       type: String
       default: Word
     ms_office_version:
-      description: Microsoft Office version number found in "HKEY_CURRENT_USER\SOFTWARE\Microsoft\Office"
+      description: Microsoft Office version number found in "HKEY_CURRENT_USER\SOFTWARE\Microsoft\Office". Default latest version.
       type: String
-      default: "16.0"
+      default: ((Get-ChildItem Registry::HKEY_CURRENT_USER\Software\Microsoft\Office -Name | select-string -pattern "^\d+\.\d+$").line.foreach({[decimal]$_}) | Sort-Object -desc)[0]
   dependency_executor_name: powershell
   dependencies:
   - description: |
       Test Requires MS Office to be installed and have been run previously. Run -GetPrereqs to run msword and build dependant registry keys
     prereq_command: |
-      If (Test-Path HKCU:SOFTWARE\Microsoft\Office\#{ms_office_version}) { exit 0 } else { exit 1 }
+      $ms_office_version = #{ms_office_version}
+      If (Test-Path HKCU:SOFTWARE\Microsoft\Office\$ms_office_version) { exit 0 } else { exit 1 }
     get_prereq_command: |
       $msword = New-Object -ComObject word.application
       Stop-Process -Name WINWORD
   executor:
     command: |
       IEX (iwr "https://raw.githubusercontent.com/redcanaryco/invoke-atomicredteam/master/Public/Invoke-MalDoc.ps1")
+      $ms_office_version = #{ms_office_version}
       $macrocode = "   Open `"#{jse_path}`" For Output As #1`n   Write #1, `"WScript.Quit`"`n   Close #1`n   Shell`$ `"cscript.exe #{jse_path}`"`n"
-      Invoke-MalDoc $macrocode "#{ms_office_version}" "#{ms_product}"
+      Invoke-MalDoc $macrocode "$ms_office_version" "#{ms_product}"
     cleanup_command: |
       if (Test-Path #{jse_path}) { Remove-Item #{jse_path} }
-      Remove-ItemProperty -Path 'HKCU:\Software\Microsoft\Office\#{ms_office_version}\#{ms_product}\Security\' -Name 'AccessVBOM' -ErrorAction Ignore
+      $ms_office_version = #{ms_office_version}
+      Remove-ItemProperty -Path 'HKCU:\Software\Microsoft\Office\$ms_office_version\#{ms_product}\Security\' -Name 'AccessVBOM' -ErrorAction Ignore
     name: powershell
 - name: OSTap Payload Download
   auto_generated_guid: 3f3af983-118a-4fa1-85d3-ba4daa739d80
@@ -79,31 +81,33 @@ atomic_tests:
       type: String
       default: Word
     ms_office_version:
-      description: Microsoft Office version number found in "HKEY_CURRENT_USER\SOFTWARE\Microsoft\Office"
+      description: Microsoft Office version number found in "HKEY_CURRENT_USER\SOFTWARE\Microsoft\Office". Default latest version.
       type: String
-      default: "16.0"
+      default: ((Get-ChildItem Registry::HKEY_CURRENT_USER\Software\Microsoft\Office -Name | select-string -pattern "^\d+\.\d+$").line.foreach({[decimal]$_}) | Sort-Object -desc)[0]
   dependency_executor_name: powershell
   dependencies:
   - description: |
       Test Requires MS Office to be installed and have been run previously. Run -GetPrereqs to run msword and build dependant registry keys
     prereq_command: |
-      If (Test-Path HKCU:SOFTWARE\Microsoft\Office\#{ms_office_version}) { exit 0 } else { exit 1 }
+      $ms_office_version = #{ms_office_version}
+      If (Test-Path HKCU:SOFTWARE\Microsoft\Office\$ms_office_version) { exit 0 } else { exit 1 }
     get_prereq_command: |
       $msword = New-Object -ComObject word.application
       Stop-Process -Name WINWORD
   executor:
     command: |
       IEX (iwr "https://raw.githubusercontent.com/redcanaryco/invoke-atomicredteam/master/Public/Invoke-MalDoc.ps1")
+      $ms_office_version = #{ms_office_version}
       $macrocode = "  a = Shell(`"cmd.exe /c choice /C Y /N /D Y /T 3`", vbNormalFocus)"
-      Invoke-MalDoc $macrocode "#{ms_office_version}" "#{ms_product}"
+      Invoke-MalDoc $macrocode "$ms_office_version" "#{ms_product}"
     cleanup_command: |
-      Remove-ItemProperty -Path 'HKCU:\Software\Microsoft\Office\#{ms_office_version}\#{ms_product}\Security\' -Name 'AccessVBOM' -ErrorAction Ignore
+      $ms_office_version = #{ms_office_version}
+      Remove-ItemProperty -Path 'HKCU:\Software\Microsoft\Office\$ms_office_version\#{ms_product}\Security\' -Name 'AccessVBOM' -ErrorAction Ignore
     name: powershell
 - name: OSTAP JS version
   auto_generated_guid: add560ef-20d6-4011-a937-2c340f930911
   description: |
     Malicious JavaScript executing CMD which spawns wscript.exe //e:jscript
-
     Execution is handled by [Invoke-MalDoc](https://github.com/redcanaryco/invoke-atomicredteam/blob/master/Public/Invoke-MalDoc.ps1) to load and execute VBA code into Excel or Word documents.
   supported_platforms:
   - windows
@@ -117,26 +121,29 @@ atomic_tests:
       type: String
       default: Word
     ms_office_version:
-      description: Microsoft Office version number found in "HKEY_CURRENT_USER\SOFTWARE\Microsoft\Office"
+      description: Microsoft Office version number found in "HKEY_CURRENT_USER\SOFTWARE\Microsoft\Office". Default latest version.
       type: String
-      default: "16.0"
+      default: ((Get-ChildItem Registry::HKEY_CURRENT_USER\Software\Microsoft\Office -Name | select-string -pattern "^\d+\.\d+$").line.foreach({[decimal]$_}) | Sort-Object -desc)
   dependency_executor_name: powershell
   dependencies:
   - description: |
       Test Requires MS Office to be installed and have been run previously. Run -GetPrereqs to run msword and build dependant registry keys
     prereq_command: |
-      If (Test-Path HKCU:SOFTWARE\Microsoft\Office\#{ms_office_version}) { exit 0 } else { exit 1 }
+      $ms_office_version = #{ms_office_version}
+      If (Test-Path HKCU:SOFTWARE\Microsoft\Office\$ms_office_version) { exit 0 } else { exit 1 }
     get_prereq_command: |
       $msword = New-Object -ComObject word.application
       Stop-Process -Name WINWORD
   executor:
     command: |
       IEX (iwr "https://raw.githubusercontent.com/redcanaryco/invoke-atomicredteam/master/Public/Invoke-MalDoc.ps1")
+      $ms_office_version = #{ms_office_version}
       $macrocode = "   Open `"#{jse_path}`" For Output As #1`n   Write #1, `"WScript.Quit`"`n   Close #1`n   a = Shell(`"cmd.exe /c wscript.exe //E:jscript #{jse_path}`", vbNormalFocus)`n"
-      Invoke-MalDoc $macrocode "#{ms_office_version}" "#{ms_product}"
+      Invoke-MalDoc $macrocode "$ms_office_version" "#{ms_product}"
     cleanup_command: |
+      $ms_office_version = #{ms_office_version}
       if (Test-Path #{jse_path}) { Remove-Item #{jse_path} }
-      Remove-ItemProperty -Path 'HKCU:\Software\Microsoft\Office\#{ms_office_version}\#{ms_product}\Security\' -Name 'AccessVBOM' -ErrorAction Ignore
+      Remove-ItemProperty -Path 'HKCU:\Software\Microsoft\Office\$ms_office_version\#{ms_product}\Security\' -Name 'AccessVBOM' -ErrorAction Ignore
     name: powershell
 
 - name: Office launching .bat file from AppData
@@ -149,7 +156,7 @@ atomic_tests:
       type: String
       default: $env:temp+"\art1204.bat"
     ms_office_version:
-      description: Microsoft Office version number found in "HKEY_CURRENT_USER\SOFTWARE\Microsoft\Office"
+      description: Microsoft Office version number found in "HKEY_CURRENT_USER\SOFTWARE\Microsoft\Office". Default latest version.
       type: string
       default: ((Get-ChildItem Registry::HKEY_CURRENT_USER\Software\Microsoft\Office -Name | select-string -pattern "^\d+\.\d+$").line.foreach({[decimal]$_}) | Sort-Object -desc)[0]
     ms_product:
@@ -173,4 +180,8 @@ atomic_tests:
       $bat_path = #{bat_path}
       $macrocode = "   Open `"$bat_path`" For Output As #1`n   Write #1, `"calc.exe`"`n   Close #1`n   a = Shell(`"cmd.exe /c $bat_path `", vbNormalFocus)`n"
       Invoke-MalDoc $macrocode "$ms_office_version" "#{ms_product}"
+    cleanup_command: |
+      $ms_office_version = #{ms_office_version}
+      if (Test-Path (#{bat_path})) { Remove-Item (#{bat_path}) }
+      Remove-ItemProperty -Path 'HKCU:\Software\Microsoft\Office\$ms_office_version\#{ms_product}\Security\' -Name 'AccessVBOM' -ErrorAction Ignore
     name: powershell


### PR DESCRIPTION
**Details:**
Changed the ms_office_version argument on test 1-4 to pull the latest version of office from registry instead of defaulting to 16.0
Added cleanup commands to test 5
Changed commands in tests 1-4 to account for changes in ms_office_version

**Testing:**
Windows 10 1903
