### PR TITLE
Move CI generation of GUIDs and docs to master branch only

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,51 +6,18 @@ defaults: &defaults
 
 workflows:
   version: 2
-  validate-then-generate-docs:
+  validate:
     jobs:
-      - generate_and_commit_guids
-      - validate_atomics:
-          requires:
-            - generate_and_commit_guids
-      - generate_and_commit_docs:
-          requires:
-            - generate_and_commit_guids
+      - validate_atomics
+
+  generate-guids-and-docs:
+    jobs:
+      - generate_and_commit_guids_and_docs:
+          filters:
+            branches:
+              only: master
 
 jobs:
-  generate_and_commit_guids:
-    <<: *defaults
-    steps:
-      - checkout
-      - add_ssh_keys
-
-      - run:
-          name: Generate unique GUIDs for each atomic test
-          command: |
-            bin/generate-guids.rb
-            
-            echo ""
-            echo ""
-            git status
-            echo ""
-            echo ""
-            git diff-index HEAD --
-
-            if git diff-index --quiet HEAD -- ; then
-              echo "Not committing GUID changes because there are no changes"
-            #elif [[ "${CIRCLE_BRANCH}" == "master" ]]; then
-            #  echo "Not committing GUID changes because we are on master and GUID changes should be part of pull request branches"
-            elif [[ $(echo "$CIRCLE_BRANCH" | grep -c "pull") -gt 0 ]]; then
-              echo "Not committing GUID changes because we are on a pull request branch that we don't have push permissions to"
-            else
-              git config credential.helper 'cache --timeout=120'
-              git config user.email "<email>"
-              git config user.name "CircleCI Atomic Red Team GUID generator"
-
-              git add atomics
-              git commit -am "Generate GUIDs from job=$CIRCLE_JOB branch=$CIRCLE_BRANCH"
-              git push -u origin $CIRCLE_BRANCH
-            fi
-
   validate_atomics:
     <<: *defaults
     steps:
@@ -61,15 +28,39 @@ jobs:
           name: Validate the format of atomic tests against the spec
           command: |
             bin/validate-atomics.rb
-  
-  generate_and_commit_docs:
+
+  generate_and_commit_guids_and_docs:
     <<: *defaults
     steps:
       - checkout
       - add_ssh_keys
 
       - run:
-          name: Generate nice markdown document for atomics
+          name: Generate and commit unique GUIDs for each atomic test
+          command: |
+            bin/generate-guids.rb
+
+            echo ""
+            echo ""
+            git status
+            echo ""
+            echo ""
+            git diff-index HEAD --
+
+            if git diff-index --quiet HEAD -- ; then
+              echo "Not committing GUID changes because there are no changes"
+            else
+              git config credential.helper 'cache --timeout=120'
+              git config user.email "<email>"
+              git config user.name "CircleCI Atomic Red Team GUID generator"
+
+              git add atomics
+              git commit -am "Generate GUIDs from job=$CIRCLE_JOB branch=$CIRCLE_BRANCH [skip ci]"
+              git push -u origin $CIRCLE_BRANCH
+            fi
+
+      - run:
+          name: Generate and commit nice markdown documents for atomics
           command: |
             bin/generate-atomic-docs.rb
 
@@ -82,16 +73,12 @@ jobs:
 
             if git diff-index --quiet HEAD -- ; then
               echo "Not committing documentation because there are no changes"
-            #elif [[ "${CIRCLE_BRANCH}" == "master" ]]; then
-            #  echo "Not committing documentation because we are on master and doc changes should be part of pull request branches"
-            elif [[ $(echo "$CIRCLE_BRANCH" | grep -c "pull") -gt 0 ]]; then
-              echo "Not committing documentation because we are on a pull request branch that we don't have push permissions to"
             else
               git config credential.helper 'cache --timeout=120'
               git config user.email "<email>"
               git config user.name "CircleCI Atomic Red Team doc generator"
 
               git add atomics
-              git commit -am "Generate docs from job=$CIRCLE_JOB branch=$CIRCLE_BRANCH"
+              git commit -am "Generate docs from job=$CIRCLE_JOB branch=$CIRCLE_BRANCH [skip ci]"
               git push -u origin $CIRCLE_BRANCH
             fi


### PR DESCRIPTION
Moves the GUID and doc generation and commit CI steps to the master branch, leaving only test validation on the PR branch.

As specified by https://github.com/redcanaryco/atomic-red-team/issues/1336