### PR TITLE
rundll32 spawning mshta and wscript

### DIFF
--- a/atomics/T1218.011/T1218.011.yaml
+++ b/atomics/T1218.011/T1218.011.yaml
@@ -112,6 +112,7 @@ atomic_tests:
     command: |
       rundll32.exe syssetup.dll,SetupInfObjectInstallAction DefaultInstall 128 .\#{inf_to_execute}
     name: command_prompt
+
 - name: Rundll32 setupapi.dll Execution
   auto_generated_guid: 71d771cd-d6b3-4f34-bc76-a63d47a10b19
   description: |
@@ -139,3 +140,18 @@ atomic_tests:
       rundll32.exe setupapi.dll,InstallHinfSection DefaultInstall 128 .\#{inf_to_execute}
     name: command_prompt
 
+- name: Execution of HTA and VBS Files using Rundll32 and URL.dll
+  description: |
+    IcedID uses this TTP as follows:
+      rundll32.exe url.dll,OpenURL %PUBLIC%\index.hta
+    Trickbot uses this TTP as follows:
+      rundll32.exe URL.dll,FileProtocolHandler C:\\..\\Detail\\akteullen.vbs
+    
+    In this atomic, the sample hta file opens the calculator and the vbs file show a message dialog with "rundll32 spawned wscript"
+  supported_platforms:
+  - windows
+  executor:
+    command: |
+      rundll32.exe url.dll,OpenURL PathToAtomicsFolder\T1218.011\src\index.hta
+      rundll32.exe URL.dll,FileProtocolHandler PathToAtomicsFolder\T1218.011\src\akteullen.vbs
+    name: command_prompt

--- a/atomics/T1218.011/T1218.011.yaml
+++ b/atomics/T1218.011/T1218.011.yaml
@@ -147,7 +147,7 @@ atomic_tests:
     Trickbot uses this TTP as follows:
       rundll32.exe URL.dll,FileProtocolHandler C:\\..\\Detail\\akteullen.vbs
     
-    In this atomic, the sample hta file opens the calculator and the vbs file show a message dialog with "rundll32 spawned wscript"
+    In this atomic, the sample hta file opens the calculator and the vbs file shows a message dialog with "rundll32 spawned wscript"
   supported_platforms:
   - windows
   executor:

--- a/atomics/T1218.011/src/akteullen.vbs
+++ b/atomics/T1218.011/src/akteullen.vbs
@@ -1,0 +1,1 @@
+WScript.Echo "rundll32 spawned wscript"

--- a/atomics/T1218.011/src/index.hta
+++ b/atomics/T1218.011/src/index.hta
@@ -1,0 +1,12 @@
+<html>
+<head>
+<HTA:APPLICATION ID="AtomicRedTeam">
+<script language="jscript">
+        var c = "cmd.exe /c calc.exe"; 
+        new ActiveXObject('WScript.Shell').Run(c);
+</script>
+</head>
+<body>
+<script>self.close();</script>
+</body>
+</html>


### PR DESCRIPTION
Execution of HTA and VBS Files using Rundll32 and URL.dll

IcedID uses this TTP as follows:
      rundll32.exe url.dll,OpenURL %PUBLIC%\index.hta
Trickbot uses this TTP as follows:
      rundll32.exe URL.dll,FileProtocolHandler C:\\..\\Detail\\akteullen.vbs
    
    In this atomic, the sample hta file opens the calculator and the vbs file shows a message dialog with "rundll32 spawned wscript"