### PR TITLE
Adding RemoteFXvGPUDisablement.exe LOLBin coverage

### DIFF
--- a/atomics/T1218/T1218.yaml
+++ b/atomics/T1218/T1218.yaml
@@ -182,22 +182,22 @@ atomic_tests:
   description: |
     RemoteFXvGPUDisablement.exe is an abusable, signed PowerShell host executable that was introduced in Windows 10 and Server 2019 (OS Build 17763.1339).
 
-    One of the PowerShell functions called by RemoteFXvGPUDisablement.exe is Get-VMRemoteFXPhysicalVideoAdapter, a part of the Hyper-V module. This atomic test influences RemoteFXvGPUDisablement.exe to execute custom PowerShell code by using a technique referred to as "PowerShell module load-order hijacking" where a module containing, in this case, an implementation of the Get-VMRemoteFXPhysicalVideoAdapter is loaded first by way of introducing a temporary module into the first directory listed in the %PSModulePath% environment variable.
+    One of the PowerShell functions called by RemoteFXvGPUDisablement.exe is Get-VMRemoteFXPhysicalVideoAdapter, a part of the Hyper-V module. This atomic test influences RemoteFXvGPUDisablement.exe to execute custom PowerShell code by using a technique referred to as "PowerShell module load-order hijacking" where a module containing, in this case, an implementation of the Get-VMRemoteFXPhysicalVideoAdapter is loaded first by way of introducing a temporary module into the first directory listed in the %PSModulePath% environment variable or within a user-specified module directory outside of %PSModulePath%. Upon execution the temporary module is deleted.
 
     Invoke-ATHRemoteFXvGPUDisablementCommand is used in this test to demonstrate how a PowerShell host executable can be directed to user-supplied PowerShell code without needing to supply anything at the command-line. PowerShell code execution is triggered when supplying the "Disable" argument to RemoteFXvGPUDisablement.exe.
+    
+    The Invoke-ATHRemoteFXvGPUDisablementCommand function outputs all relevant execution-related artifacts.
+    
+    Reference: https://github.com/redcanaryco/AtomicTestHarnesses/blob/master/TestHarnesses/T1218_SignedBinaryProxyExecution/InvokeRemoteFXvGPUDisablementCommand.ps1
   supported_platforms:
   - windows
   input_arguments:
-    RemoteFXvGPUDisablementFilePath_file_path:
-      description: path of RemoteFXvGPUDisablement
-      type: path
-      default: "$Env:windir\\System32\\RemoteFXvGPUDisablement.exe"
     module_name:
-      description: Module name to use
+      description: Specifies a temporary module name to use. If -ModuleName is not supplied, a 16-character random temporary module name is used. A PowerShell module can have any name. Because Get-VMRemoteFXPhysicalVideoAdapter abuses module load order, a module name must be specified.
       type: string
       default: foo
     module_path:
-      description: Module path to use
+      description: Specifies an alternate, non-default PowerShell module path for RemoteFXvGPUDisablement.exe. If -ModulePath is not specified, the first entry in %PSModulePath% will be used. Typically, this is %USERPROFILE%\Documents\WindowsPowerShell\Modules.
       type: string
       default: $PWD
   dependencies:
@@ -209,5 +209,5 @@ atomic_tests:
     get_prereq_command: |
       Install-Module -Name AtomicTestHarnesses -Scope CurrentUser -Force
   executor:
-    command: 'Invoke-ATHRemoteFXvGPUDisablementCommand -RemoteFXvGPUDisablementFilePath #{RemoteFXvGPUDisablementFilePath_file_path} -ModuleName #{module_name} -ModulePath #{module_path}'
+    command: 'Invoke-ATHRemoteFXvGPUDisablementCommand -ModuleName #{module_name} -ModulePath #{module_path}'
     name: powershell

--- a/atomics/T1218/T1218.yaml
+++ b/atomics/T1218/T1218.yaml
@@ -178,3 +178,31 @@ atomic_tests:
       #{renamed_binary} #{xml_payload} output.txt
     name: powershell
     elevation_required: false
+- name: Invoke-ATHRemoteFXvGPUDisablementCommand base test
+  description: Base Atomic Test using Invoke-ATHRemoteFXvGPUDisablementCommand
+  supported_platforms:
+  - windows
+  input_arguments:
+    RemoteFXvGPUDisablementFilePath_file_path:
+      description: path of RemoteFXvGPUDisablement
+      type: path
+      default: "$Env:windir\\System32\\RemoteFXvGPUDisablement.exe"
+    module_name:
+      description: Module name to use
+      type: string
+      default: foo
+    module_path:
+      description: Module path to use
+      type: string
+      default: $PWD
+  dependencies:
+  - description: The AtomicTestHarnesses module must be installed and Invoke-ATHRemoteFXvGPUDisablementCommand must be exported in the module.
+    prereq_command: |-
+      $RequiredModule = Get-Module -Name AtomicTestHarnesses -ListAvailable
+      if (-not $RequiredModule) {exit 1}
+      if (-not $RequiredModule.ExportedCommands['Invoke-ATHRemoteFXvGPUDisablementCommand']) {exit 1} else {exit 0}
+    get_prereq_command: |
+      Install-Module -Name AtomicTestHarnesses -Scope CurrentUser -Force
+  executor:
+    command: 'Invoke-ATHRemoteFXvGPUDisablementCommand -RemoteFXvGPUDisablementFilePath #{RemoteFXvGPUDisablementFilePath_file_path} -ModuleName #{module_name} -ModulePath #{module_path}'
+    name: powershell

--- a/atomics/T1218/T1218.yaml
+++ b/atomics/T1218/T1218.yaml
@@ -179,7 +179,12 @@ atomic_tests:
     name: powershell
     elevation_required: false
 - name: Invoke-ATHRemoteFXvGPUDisablementCommand base test
-  description: Base Atomic Test using Invoke-ATHRemoteFXvGPUDisablementCommand
+  description: |
+    RemoteFXvGPUDisablement.exe is an abusable, signed PowerShell host executable that was introduced in Windows 10 and Server 2019 (OS Build 17763.1339).
+
+    One of the PowerShell functions called by RemoteFXvGPUDisablement.exe is Get-VMRemoteFXPhysicalVideoAdapter, a part of the Hyper-V module. This atomic test influences RemoteFXvGPUDisablement.exe to execute custom PowerShell code by using a technique referred to as "PowerShell module load-order hijacking" where a module containing, in this case, an implementation of the Get-VMRemoteFXPhysicalVideoAdapter is loaded first by way of introducing a temporary module into the first directory listed in the %PSModulePath% environment variable.
+
+    Invoke-ATHRemoteFXvGPUDisablementCommand is used in this test to demonstrate how a PowerShell host executable can be directed to user-supplied PowerShell code without needing to supply anything at the command-line. PowerShell code execution is triggered when supplying the "Disable" argument to RemoteFXvGPUDisablement.exe.
   supported_platforms:
   - windows
   input_arguments:


### PR DESCRIPTION
Adding RemoteFXvGPUDisablement.exe LOLBIN coverage via AtomicTestHarnesses to T1218. Thanks for writing up this atomic test, @MHaggis!

**Details:**
RemoteFXvGPUDisablement.exe is an abusable built-in, signed PowerShell host binary. This test implements the `Invoke-ATHRemoteFXvGPUDisablementCommand` in `AtomicTestHarnesses` to supply coverage.

**Testing:**
Atomic test was tested locally. [Corresponding AtomicTestHarnesses tests](https://github.com/redcanaryco/AtomicTestHarnesses/blob/master/TestHarnesses/T1218_SignedBinaryProxyExecution/InvokeRemoteFXvGPUDisablementCommand.Tests.ps1) also ran without issue.

**Associated Issues:**
N/A