### PR TITLE
Update T1127.001.yaml

### DIFF
--- a/atomics/T1127.001/T1127.001.yaml
+++ b/atomics/T1127.001/T1127.001.yaml
@@ -12,6 +12,14 @@ atomic_tests:
       description: Location of the project file
       type: Path
       default: PathToAtomicsFolder\T1127.001\src\T1127.001.csproj
+    msbuildpath:
+      description: Default location of MSBuild
+      type: Path
+      default: C:\Windows\Microsoft.NET\Framework\v4.0.30319
+    msbuildname:
+      description: Default name of MSBuild
+      type: Path
+      default: msbuild.exe
   dependency_executor_name: powershell
   dependencies:
   - description: |
@@ -23,6 +31,5 @@ atomic_tests:
       Invoke-WebRequest "https://github.com/redcanaryco/atomic-red-team/raw/master/atomics/T1127.001/src/T1127.001.csproj" -OutFile "#{filename}"
   executor:
     command: |
-      C:\Windows\Microsoft.NET\Framework\v4.0.30319\msbuild.exe #{filename}
+      #{msbuildpath}\#{msbuildname} #{filename}
     name: command_prompt
-


### PR DESCRIPTION
Modified Atomic Test to allow for more granular control of input arguments.

What we want to test:

- Renamed msbuild
- New msbuild filepath
- Change of file extension

How this modification assists (mostly in rename/moved msbuild):

```
copy-item -Path C:\windows\microsoft.net\Framework\v4.0.30319\MSBuild.exe -Destination C:\Temp\notmsbuild.exe
copy-item -Path C:\AtomicRedTeam\atomics\T1127.001\src\T1127.001.csproj -Destination C:\Temp\T1127.001.txt

$myArgs = @{ "filename" = "c:\Temp\T1127.001.txt"; "msbuildpath" = "C:\Temp\"; "msbuildname" = "notmsbuild.exe" }
Invoke-AtomicTest T1127.001 -InputArgs $myArgs
```

![image](https://user-images.githubusercontent.com/5632822/103701148-beb73880-4f62-11eb-978e-09078bd525b2.png)


Confirmed operational on Win10 and Server 2016.