### PR TITLE
MSbuild inline task using Visual Basic

### DIFF
--- a/atomics/T1127.001/T1127.001.yaml
+++ b/atomics/T1127.001/T1127.001.yaml
@@ -1,7 +1,7 @@
 attack_technique: T1127.001
 display_name: 'Trusted Developer Utilities Proxy Execution: MSBuild'
 atomic_tests:
-- name: MSBuild Bypass Using Inline Tasks
+- name: MSBuild Bypass Using Inline Tasks (C#)
   auto_generated_guid: 58742c0f-cb01-44cd-a60b-fb26e8871c93
   description: |
     Executes the code in a project file using msbuild.exe. The default C# project example file (T1127.001.csproj) will simply print "Hello From a Code Fragment" and "Hello From a Class." to the screen.
@@ -29,6 +29,38 @@ atomic_tests:
     get_prereq_command: |
       New-Item -Type Directory (split-path #{filename}) -ErrorAction ignore | Out-Null
       Invoke-WebRequest "https://github.com/redcanaryco/atomic-red-team/raw/master/atomics/T1127.001/src/T1127.001.csproj" -OutFile "#{filename}"
+  executor:
+    command: |
+      #{msbuildpath}\#{msbuildname} #{filename}
+    name: command_prompt
+
+- name: MSBuild Bypass Using Inline Tasks (VB)
+  description: |
+    Executes the code in a project file using msbuild.exe. The default Visual Basic example file (vb.xml) will simply print "Hello from a Visual Basic inline task!" to the screen.
+  supported_platforms:
+  - windows
+  input_arguments:
+    filename:
+      description: Location of the project file
+      type: Path
+      default: PathToAtomicsFolder\T1127.001\src\vb.xml
+    msbuildpath:
+      description: Default location of MSBuild
+      type: Path
+      default: C:\Windows\Microsoft.NET\Framework\v4.0.30319
+    msbuildname:
+      description: Default name of MSBuild
+      type: Path
+      default: msbuild.exe
+  dependency_executor_name: powershell
+  dependencies:
+  - description: |
+      Project file must exist on disk at specified location (#{filename})
+    prereq_command: |
+      if (Test-Path #{filename}) {exit 0} else {exit 1}
+    get_prereq_command: |
+      New-Item -Type Directory (split-path #{filename}) -ErrorAction ignore | Out-Null
+      Invoke-WebRequest "https://github.com/redcanaryco/atomic-red-team/raw/master/atomics/T1127.001/src/vb.xml" -OutFile "#{filename}"
   executor:
     command: |
       #{msbuildpath}\#{msbuildname} #{filename}

--- a/atomics/T1127.001/src/vb.xml
+++ b/atomics/T1127.001/src/vb.xml
@@ -6,7 +6,7 @@
   <Target Name="Hello">
    <HelloWorld />
   </Target>
-  <!-- This simple inline task displays "Hello, world!" -->
+  <!-- This simple inline task displays "Hello from a Visual Basic inline task!" -->
   <UsingTask
     TaskName="HelloWorld"
     TaskFactory="CodeTaskFactory"

--- a/atomics/T1127.001/src/vb.xml
+++ b/atomics/T1127.001/src/vb.xml
@@ -1,0 +1,26 @@
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!-- This inline task executes c# code. -->
+  <!-- C:\Windows\Microsoft.NET\Framework64\v4.0.30319\msbuild.exe vb.xml -->
+  <!-- Slight modification of an original script by Casey Smith, Twitter: @subTee -->
+  <!-- License: BSD 3-Clause -->
+  <Target Name="Hello">
+   <HelloWorld />
+  </Target>
+  <!-- This simple inline task displays "Hello, world!" -->
+  <UsingTask
+    TaskName="HelloWorld"
+    TaskFactory="CodeTaskFactory"
+    AssemblyFile="C:\Windows\Microsoft.Net\Framework\v4.0.30319\Microsoft.Build.Tasks.v4.0.dll" >
+    <ParameterGroup />
+    <Task>
+      <Reference Include="System.Xml"/>
+      <Using Namespace="System"/>
+      <Using Namespace="System.IO"/>
+      <Code Type="Fragment" Language="vb">
+<![CDATA[
+System.Console.WriteLine("Hello from a Visual Basic inline task!")
+]]>
+      </Code>
+    </Task>
+  </UsingTask>
+</Project>


### PR DESCRIPTION
Adding an msbuld inline task that uses Visual Basic in addition to the already existing atomic test using C#. The telemetry you see here will be MSBuild.exe spawning vbc.exe (VB compiler), whereas if the inline task uses C#, you would see MSBuild.exe spawning csc.exe (C# compiler).