### PR TITLE
Fix to Cleanup Command for T1003.002 Test Number 3

### DIFF
--- a/atomics/T1003.002/T1003.002.yaml
+++ b/atomics/T1003.002/T1003.002.yaml
@@ -78,7 +78,8 @@ atomic_tests:
       esentutl.exe /y /vss #{file_path} /d #{copy_dest}/#{file_name}
     name: command_prompt
     elevation_required: true
-    cleanup_command: del #{copy_dest}\#{file_name} >nul 2>&1
+    cleanup_command: |
+      del #{copy_dest}\#{file_name} >nul 2>&1
     
 - name: PowerDump Registry dump of SAM for hashes and usernames
   auto_generated_guid: 804f28fc-68fc-40da-b5a2-e9d0bce5c193


### PR DESCRIPTION
The cleanup command was missing the pipe symbol so part of the command was being treated as a comment.