### PR TITLE
T1490 - WBAdmin

### DIFF
--- a/atomics/T1490/T1490.yaml
+++ b/atomics/T1490/T1490.yaml
@@ -37,7 +37,7 @@ atomic_tests:
       wmic.exe shadowcopy delete
     name: command_prompt
     elevation_required: true
-- name: Windows - Delete Windows Backup Catalog
+- name: Windows - wbadmin Delete Windows Backup Catalog
   auto_generated_guid: 263ba6cb-ea2b-41c9-9d4e-b652dadd002c
   description: |
     Deletes Windows Backup Catalog. This technique is used by numerous ransomware families and APT malware such as Olympic Destroyer. Upon execution,
@@ -91,4 +91,14 @@ atomic_tests:
       del /s /f /q c:\*.VHD c:\*.bac c:\*.bak c:\*.wbcat c:\*.bkf c:\Backup*.* c:\backup*.* c:\*.set c:\*.win c:\*.dsk
     name: command_prompt
     elevation_required: true
-
+- name: Windows - wbadmin Delete systemstatebackup
+  description: |
+    Deletes the Windows systemstatebackup using wbadmin.exe. This technique is used by numerous ransomware families. Upon execution,
+    "The backup catalog has been successfully deleted." will be displayed in the PowerShell session.
+  supported_platforms:
+  - windows
+  executor:
+    command: |
+      wbadmin.exe delete systemstatebackup -keepVersions:0
+    name: command_prompt
+    elevation_required: true

--- a/atomics/T1490/T1490.yaml
+++ b/atomics/T1490/T1490.yaml
@@ -46,7 +46,7 @@ atomic_tests:
   - windows
   executor:
     command: |
-      wbadmin.exe delete catalog -quiet
+      wbadmin delete catalog -quiet
     name: command_prompt
     elevation_required: true
 - name: Windows - Disable Windows Recovery Console Repair
@@ -93,12 +93,11 @@ atomic_tests:
     elevation_required: true
 - name: Windows - wbadmin Delete systemstatebackup
   description: |
-    Deletes the Windows systemstatebackup using wbadmin.exe. This technique is used by numerous ransomware families. Upon execution,
-    "The backup catalog has been successfully deleted." will be displayed in the PowerShell session.
+    Deletes the Windows systemstatebackup using wbadmin.exe. This technique is used by numerous ransomware families. This may only be successful on server platforms that have Windows Backup enabled.
   supported_platforms:
   - windows
   executor:
     command: |
-      wbadmin.exe delete systemstatebackup -keepVersions:0
+      wbadmin delete systemstatebackup -keepVersions:0
     name: command_prompt
     elevation_required: true


### PR DESCRIPTION
- Modified Windows Backup Admin tests. 
- Added new test for `WBadmin.exe wbadmin delete systemstatebackup -keepVersions:0`

Confirmed operational on server 2016 with Windows backup installed. I also found that wbadmin may not work unless the feature is installed. I didn't dig in much further, but I may modify this in the future with a pre-req to install it.

`Install-WindowsFeature -Name Windows-Server-Backup`
