### PR TITLE
Add T1120

### DIFF
--- a/atomics/T1120/T1120.yaml
+++ b/atomics/T1120/T1120.yaml
@@ -1,0 +1,14 @@
+attack_technique: T1120
+display_name: Peripheral Device Discovery
+atomic_tests:
+- name: Win32_PnPEntity Hardware Inventory
+  description: Perform peripheral device discovery using Get-WMIObject Win32_PnPEntity
+  supported_platforms:
+  - windows
+  executor:
+    command: |-
+      Get-WMIObject Win32_PnPEntity | Format-Table Name, Description, Manufacturer > $env:TEMP\T1120_collection.txt
+      $Space,$Heading,$Break,$Data = Get-Content $env:TEMP\T1120_collection.txt
+      @($Heading; $Break; $Data |Sort-Object -Unique) | ? {$_.trim() -ne "" } |Set-Content $env:TEMP\T1120_collection.txt
+    cleanup_command: Remove-Item $env:TEMP\T1120_collection.txt -ErrorAction Ignore
+    name: powershell


### PR DESCRIPTION
Adding new atomic for T1120 - Peripheral Device Discovery
Uses the Windows PowerShell command 'Get-WMIObject Win32_PnPEntity' to extract peripheral data.
Additionally, data is deduplicated and written to a file in the temp directory.

Confirmed operational on Windows 10.