### PR TITLE
Added auditpol based config clear atomics

### DIFF
--- a/atomics/T1562.002/T1562.002.yaml
+++ b/atomics/T1562.002/T1562.002.yaml
@@ -6,6 +6,8 @@ atomic_tests:
   description: |
     Disables HTTP logging on a Windows IIS web server as seen by Threat Group 3390 (Bronze Union).
     This action requires HTTP logging configurations in IIS to be unlocked.
+
+    Use the cleanup commands to restore some default auditpol settings (your original settings will be lost)
   supported_platforms:
   - windows
   input_arguments:

--- a/atomics/T1562.002/T1562.002.yaml
+++ b/atomics/T1562.002/T1562.002.yaml
@@ -60,3 +60,19 @@ atomic_tests:
       auditpol /set /category:"Logon/Logoff" /success:enable /failure:enable
     name: command_prompt
     elevation_required: true
+- name: 'Clear Windows Audit Policy Config'
+  auto_generated_guid: 913c0e4e-4b37-4b78-ad0b-90e7b25010f6
+  description: >-
+    Clear the Windows audit policy using auditpol utility. This action would stop certain audit events from being recorded in the security log.
+  supported_platforms:
+    - windows
+  executor:
+    command: |
+      auditpol /clear /y
+      auditpol /remove /allusers
+    cleanup_command: |
+      auditpol /set /category:"Account Logon" /success:enable /failure:enable
+      auditpol /set /category:"Detailed Tracking" /success:enable
+      auditpol /set /category:"Logon/Logoff" /success:enable /failure:enable
+    name: command_prompt
+    elevation_required: true


### PR DESCRIPTION
Included remove and clear switches for auditpol based logging impairment.

**Details:**
Threat actor can clear the Windows audit policy configuration using remove or clear switches in the auditpo utility.

**Testing:**
Locally tested.