### PR TITLE
Create file to delete as part of attack cmds

### DIFF
--- a/atomics/T1485/T1485.yaml
+++ b/atomics/T1485/T1485.yaml
@@ -27,14 +27,9 @@ atomic_tests:
       Invoke-WebRequest "https://download.sysinternals.com/files/SDelete.zip" -OutFile "$env:TEMP\SDelete.zip"
       Expand-Archive $env:TEMP\SDelete.zip $env:TEMP\Sdelete -Force
       Remove-Item $env:TEMP\SDelete.zip -Force
-  - description: |
-      The file to delete must exist at #{file_to_delete}
-    prereq_command: |
-      if (Test-Path #{file_to_delete}) { exit 0 } else { exit 1 }
-    get_prereq_command: |
-      New-Item #{file_to_delete} -Force | Out-Null
   executor:
     command: |
+      if (-not (Test-Path $env:TEMP\T1485.txt)) { New-Item $env:TEMP\T1485.txt -Force }
       Invoke-Expression -Command "#{sdelete_exe} -accepteula #{file_to_delete}"
     name: powershell
 - name: macOS/Linux - Overwrite file with DD
@@ -58,4 +53,18 @@ atomic_tests:
     command: |
       dd of=#{file_to_overwrite} if=#{overwrite_source}
     name: bash
-
+    
+- name: My new test
+  description: desc
+  supported_platforms:
+  - windows
+  input_arguments:
+    outfile:
+      description: the file to write
+      type: String
+      default: 'c:\users\art\desktop\hi.txt '
+  executor:
+    command: 'echo hi >  #{outfile}'
+    cleanup_command: 'del #{outfile} >nul 2>&1'
+    name: command_prompt
+    elevation_required: true

--- a/atomics/T1485/T1485.yaml
+++ b/atomics/T1485/T1485.yaml
@@ -53,18 +53,3 @@ atomic_tests:
     command: |
       dd of=#{file_to_overwrite} if=#{overwrite_source}
     name: bash
-    
-- name: My new test
-  description: desc
-  supported_platforms:
-  - windows
-  input_arguments:
-    outfile:
-      description: the file to write
-      type: String
-      default: 'c:\users\art\desktop\hi.txt '
-  executor:
-    command: 'echo hi >  #{outfile}'
-    cleanup_command: 'del #{outfile} >nul 2>&1'
-    name: command_prompt
-    elevation_required: true


### PR DESCRIPTION
Instead of needing to rerun prereqs before each execution, prereq is now part of attack commands