### PR TITLE
remove macOS from /etc/passwd test

### DIFF
--- a/atomics/T1087.001/T1087.001.md
+++ b/atomics/T1087.001/T1087.001.md
@@ -34,7 +34,7 @@ Commands such as <code>net user</code> and <code>net localgroup</code> of the [N
 ## Atomic Test #1 - Enumerate all accounts (Local)
 Enumerate all accounts by copying /etc/passwd to another file
 
-**Supported Platforms:** Linux, macOS
+**Supported Platforms:** Linux
 
 
 

--- a/atomics/T1087.001/T1087.001.yaml
+++ b/atomics/T1087.001/T1087.001.yaml
@@ -7,7 +7,6 @@ atomic_tests:
     Enumerate all accounts by copying /etc/passwd to another file
   supported_platforms:
   - linux
-  - macos
   input_arguments:
     output_file:
       description: Path where captured results will be placed


### PR DESCRIPTION
macOS has an /etc/passwd file, but it doesn't actually use it (with a rare exception) and user accounts are not listed there. It's just a standard default file that never changes.

As the header for the file states: 
```
# Note that this file is consulted directly only when the system is running
# in single-user mode.  At other times this information is provided by
# Open Directory.
```

**Details:**
just removing macOS from the list of supported OS's for getting a list of users via cat /etc/passwd
**Testing:**
none except for cat'ing my own /etc/passwd to confirm
**Associated Issues:**
not aware of any