### PR TITLE
update nav layer version

### DIFF
--- a/bin/generate-atomic-docs.rb
+++ b/bin/generate-atomic-docs.rb
@@ -182,7 +182,7 @@ class AtomicRedTeamDocs
 
   def get_layer(techniques, layer_name)
     layer = {
-      "version" => "3.0",
+      "version" => "4.1",
       "name" => layer_name,
       "description" => layer_name + " MITRE ATT&CK Navigator Layer",
       "domain" => "mitre-enterprise",


### PR DESCRIPTION
I'v updated the version number listed in the navigator layer json files to avoid a version mismatch warning when loading the layer on the Mitre ATT&CK Navigator.