### PR TITLE
small correction to handle cmd/ps executors

### DIFF
--- a/atomics/T1027/T1027.yaml
+++ b/atomics/T1027/T1027.yaml
@@ -78,10 +78,6 @@ atomic_tests:
   supported_platforms:
   - windows
   input_arguments:
-    exe_payload:
-      description: EXE to execute
-      type: Path
-      default: '$env:temp\temp_T1027.zip\T1027.exe'
     url_path:
       description: url to download Exe
       type: url
@@ -89,16 +85,16 @@ atomic_tests:
   dependency_executor_name: powershell
   dependencies:
   - description: |
-      T1027.exe must exist on disk at #{exe_payload}
+      T1027.exe must exist on disk at $env:temp\temp_T1027.zip\T1027.exe
     prereq_command: |
-      if (Test-Path #{exe_payload}) {exit 0} else {exit 1}
+      if (Test-Path $env:temp\temp_T1027.zip\T1027.exe) {exit 0} else {exit 1}
     get_prereq_command: |
       [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
       Invoke-WebRequest "#{url_path}" -OutFile "$env:temp\T1027.zip"
       Expand-Archive -path "$env:temp\T1027.zip" -DestinationPath "$env:temp\temp_T1027.zip\" -Force
   executor:
     command: |
-      "#{exe_payload}"
+      "%temp%\temp_T1027.zip\T1027.exe"
     cleanup_command: |
       taskkill /f /im calculator.exe >nul 2>nul
       rmdir /S /Q %temp%\temp_T1027.zip >nul 2>nul


### PR DESCRIPTION
PR #1418 made a change to an input arg so that it would work with the powershell prereq commands but since the attack command executor is "command_prompt" and not "powershell" the change broke the attack command. There are multiple ways to address this mismatch in executors and still use environment variable but in this case I didn't see a great value in having the exe defined in an input arg and there were pieces of that path hard coded in the prereq and cleanup commands already so I removed the input arg altogether and use hard coded values which makes it easy to use $env:Temp for the PowerShell parts and %temp% for the command_prompt.