### PR TITLE
Use wildcard '*' for .NET path

### DIFF
--- a/atomics/T1003.001/T1003.001.yaml
+++ b/atomics/T1003.001/T1003.001.yaml
@@ -334,7 +334,7 @@ atomic_tests:
     createdump_exe:
       description: Path of createdump.exe executable
       type: Path
-      default: 'C:\Program Files\dotnet\shared\Microsoft.NETCore.App\5.0.3\createdump.exe'
+      default: 'C:\Program Files\dotnet\shared\Microsoft.NETCore.App\5.*.*\createdump.exe'
   dependency_executor_name: powershell
   dependencies:
   - description: |


### PR DESCRIPTION
This way the test will be valid for future release of .NET. 
It has already jump from 5.0.3 to 5.0.5 while I was building this test.

**Details:**
<!-- Insert details about this change here. Please include as much detail as possible -->

**Testing:**
<!-- Note any testing done, local or automated here. -->

**Associated Issues:**
<!-- Please link any issues that this pull request impacts or fixes. -->