### PR TITLE
Fixed an issue where -CheckPrereqs could not create the required files.

### DIFF
--- a/atomics/T1030/T1030.yaml
+++ b/atomics/T1030/T1030.yaml
@@ -23,8 +23,7 @@ atomic_tests:
     prereq_command: |
       if [ ! -f #{folder_path}/#{file_name} ]; then exit 1; else exit 0; fi;
     get_prereq_command: |
-      if [ ! -d #{folder_path} ]; then mkdir -p #{folder_path}; touch #{folder_path}/safe_to_delete; fi;      
-      dd if=/dev/urandom of=#{folder_path}/#{file_name} bs=25000000 count=1
+      if [ ! -d #{folder_path} ]; then mkdir -p #{folder_path}; touch #{folder_path}/safe_to_delete; fi; dd if=/dev/urandom of=#{folder_path}/#{file_name} bs=25000000 count=1
   executor:
     command: |
       cd #{folder_path}; split -b 5000000 #{file_name}


### PR DESCRIPTION
**Details:**
Fixes the error: `/usr/bin/sh: 1: Syntax error: ";" unexpected` 
when running `Invoke-AtomicTest T1030 -GetPrereqs`

**Testing:**
Invoke-AtomicTest T1030 -GetPrereqs

**Associated Issues:**
<!-- Please link any issues that this pull request impacts or fixes. -->