### PR TITLE
T1021.002 fix dependencies

### DIFF
--- a/atomics/T1021.002/T1021.002.yaml
+++ b/atomics/T1021.002/T1021.002.yaml
@@ -66,11 +66,26 @@ atomic_tests:
       description: Remote computer to receive the copy and execute the file
       type: String
       default: '\\localhost'
+    psexec_exe:
+      description: Path to PsExec
+      type: string
+      default: C:\PSTools\PsExec.exe
   executor:
     command: |
-      psexec.exe #{remote_host} -accepteula -c #{command_path}
+      #{psexec_exe} #{remote_host} -accepteula -c #{command_path}
     name: command_prompt
     elevation_required: true
+  dependency_executor_name: powershell
+  dependencies:
+  - description: |
+      PsExec tool from Sysinternals must exist on disk at specified location (#{psexec_exe})
+    prereq_command: |
+      if (Test-Path "#{psexec_exe}") { exit 0} else { exit 1}
+    get_prereq_command: |
+      Invoke-WebRequest "https://download.sysinternals.com/files/PSTools.zip" -OutFile "$env:TEMP\PsTools.zip"
+      Expand-Archive $env:TEMP\PsTools.zip $env:TEMP\PsTools -Force
+      New-Item -ItemType Directory (Split-Path "#{psexec_exe}") -Force | Out-Null
+      Copy-Item $env:TEMP\PsTools\PsExec.exe "#{psexec_exe}" -Force
 - name: Execute command writing output to local Admin Share
   auto_generated_guid: d41aaab5-bdfe-431d-a3d5-c29e9136ff46
   description: |

--- a/atomics/T1036.002/T1036.002.yaml
+++ b/atomics/T1036.002/T1036.002.yaml
@@ -1,0 +1,36 @@
+---
+attack_technique: T1036.002
+display_name: Masquerading: Right-to-Left Override T1036.002
+
+atomic_tests:
+- name: TODO
+  description: |
+    TODO
+
+  supported_platforms:
+     - Linux
+     - macOS
+     - Windows
+    
+  input_arguments:
+    output_file:
+      description: TODO
+      type: todo
+      default: TODO
+
+  dependency_executor_name: powershell # (optional) The executor for the prereq commands, defaults to the same executor used by the attack commands
+  dependencies: # (optional)
+    - description: |
+        TODO
+      prereq_command: | # commands to check if prerequisites for running this test are met. For the "command_prompt" executor, if any command returns a non-zero exit code, the pre-requisites are not met. For the "powershell" executor, all commands are run as a script block and the script block must return 0 for success.
+        TODO
+      get_prereq_command: | # commands to meet this prerequisite or a message describing how to meet this prereq
+        TODO
+
+  executor:
+    name: command_prompt
+    elevation_required: true # indicates whether command must be run with admin privileges. If the elevation_required attribute is not defined, the value is assumed to be false
+    command: | # these are the actaul attack commands, at least one command must be provided
+      TODO
+    cleanup_command: | # you can remove the cleanup_command section if there are no cleanup commands
+      TODO


### PR DESCRIPTION
**Details:**
T1021.002 is dependent on psexec, but was not listed as a dependency and couldn't automatically be downloaded. Borrowed the code from T1569.002 to add the dependency and automatic download.

**Testing:**
`Invoke-AtomicTest T1021.002 -CheckPrereqs`
`Invoke-AtomicTest T1021.002 -GetPrereqs`
