### PR TITLE
Take 2 on making psexec a configurable dependency.

### DIFF
--- a/atomics/T1021.002/T1021.002.yaml
+++ b/atomics/T1021.002/T1021.002.yaml
@@ -1,0 +1,111 @@
+attack_technique: T1021.002
+display_name: 'Remote Services: SMB/Windows Admin Shares'
+atomic_tests:
+- name: Map admin share
+  auto_generated_guid: 3386975b-367a-4fbb-9d77-4dcf3639ffd3
+  description: |
+    Connecting To Remote Shares
+  supported_platforms:
+  - windows
+  input_arguments:
+    user_name:
+      description: Username
+      type: String
+      default: DOMAIN\Administrator
+    share_name:
+      description: Examples C$, IPC$, Admin$
+      type: String
+      default: C$
+    password:
+      description: Password
+      type: String
+      default: P@ssw0rd1
+    computer_name:
+      description: Target Computer Name
+      type: String
+      default: Target
+  executor:
+    command: |
+      cmd.exe /c "net use \\#{computer_name}\#{share_name} #{password} /u:#{user_name}"
+    name: command_prompt
+- name: Map Admin Share PowerShell
+  auto_generated_guid: 514e9cd7-9207-4882-98b1-c8f791bae3c5
+  description: |
+    Map Admin share utilizing PowerShell
+  supported_platforms:
+  - windows
+  input_arguments:
+    share_name:
+      description: Examples C$, IPC$, Admin$
+      type: String
+      default: C$
+    map_name:
+      description: Mapped Drive Letter
+      type: String
+      default: g
+    computer_name:
+      description: Target Computer Name
+      type: String
+      default: Target
+  executor:
+    command: |
+      New-PSDrive -name #{map_name} -psprovider filesystem -root \\#{computer_name}\#{share_name}
+    name: powershell
+- name: Copy and Execute File with PsExec
+  auto_generated_guid: 0eb03d41-79e4-4393-8e57-6344856be1cf
+  description: |
+    Copies a file to a remote host and executes it using PsExec. Requires the download of PsExec from [https://docs.microsoft.com/en-us/sysinternals/downloads/psexec](https://docs.microsoft.com/en-us/sysinternals/downloads/psexec).
+  supported_platforms:
+  - windows
+  input_arguments:
+    command_path:
+      description: File to copy and execute
+      type: Path
+      default: C:\Windows\System32\cmd.exe
+    remote_host:
+      description: Remote computer to receive the copy and execute the file
+      type: String
+      default: '\\localhost'
+    psexec_exe:
+      description: Path to PsExec
+      type: string
+      default: C:\PSTools\PsExec.exe
+  dependency_executor_name: powershell
+  dependencies:
+  - description: |
+      PsExec tool from Sysinternals must exist on disk at specified location (#{psexec_exe})
+    prereq_command: |
+      if (Test-Path "#{psexec_exe}") { exit 0} else { exit 1}
+    get_prereq_command: |
+      Invoke-WebRequest "https://download.sysinternals.com/files/PSTools.zip" -OutFile "$env:TEMP\PsTools.zip"
+      Expand-Archive $env:TEMP\PsTools.zip $env:TEMP\PsTools -Force
+      New-Item -ItemType Directory (Split-Path "#{psexec_exe}") -Force | Out-Null
+      Copy-Item $env:TEMP\PsTools\PsExec.exe "#{psexec_exe}" -Force
+  executor:
+    command: |
+      #{psexec_exe} #{remote_host} -accepteula -c #{command_path}
+    name: command_prompt
+    elevation_required: true
+- name: Execute command writing output to local Admin Share
+  auto_generated_guid: d41aaab5-bdfe-431d-a3d5-c29e9136ff46
+  description: |
+    Executes a command, writing the output to a local Admin Share.
+    This technique is used by post-exploitation frameworks.
+  supported_platforms:
+  - windows
+  input_arguments:
+    output_file:
+      description: Remote computer to receive the copy and execute the file
+      type: String
+      default: output.txt
+    command_to_execute:
+      description: Command to execute for output.
+      type: String
+      default: hostname
+  executor:
+    command: |
+      cmd.exe /Q /c #{command_to_execute} 1> \\127.0.0.1\ADMIN$\#{output_file} 2>&1
+    name: command_prompt
+    elevation_required: true
+
+


### PR DESCRIPTION
**Details:**
PSExec was required but not a defined dependency. This adds psexec as a configurable dependency.

**Testing:**
`bin/validate-atomics.rb` showed no errors. Tested and works fine in Windows Sandbox with Windows 10 2004.

**Associated Issues:**
