### PR TITLE
Fix platform incompatible executors in T1553.004 and T1518

### DIFF
--- a/atomics/T1518/T1518.yaml
+++ b/atomics/T1518/T1518.yaml
@@ -33,7 +33,7 @@ atomic_tests:
   supported_platforms:
     - macos
   executor:
-    name: command_prompt
+    name: sh
     elevation_required: false
     command: |
       /usr/libexec/PlistBuddy -c "print :CFBundleShortVersionString" /Applications/Safari.app/Contents/Info.plist

--- a/atomics/T1553.004/T1553.004.yaml
+++ b/atomics/T1553.004/T1553.004.yaml
@@ -44,7 +44,7 @@ atomic_tests:
       description: Key we create that is used to create the CA certificate
       type: Path
       default: rootCA.key
-  dependency_executor_name: command_prompt
+  dependency_executor_name: sh
   dependencies:
   - description: |
       Verify the certificate exists. It generates if not on disk.
@@ -74,7 +74,7 @@ atomic_tests:
       description: Key we create that is used to create the CA certificate
       type: Path
       default: rootCA.key
-  dependency_executor_name: command_prompt
+  dependency_executor_name: sh
   dependencies:
   - description: |
       Verify the certificate exists. It generates if not on disk.
@@ -86,7 +86,7 @@ atomic_tests:
   executor:
     command: |
       sudo security add-trusted-cert -d -r trustRoot -k "/Library/Keychains/System.keychain" "#{cert_filename}"
-    name: command_prompt
+    name: sh
     elevation_required: true
 - name: Install root CA on Windows
   auto_generated_guid: 76f49d86-5eb1-461a-a032-a480f86652f1


### PR DESCRIPTION
**Details:**
- test 53bcf8a0-1549-4b85-b919-010c56d724ff in T1553.004 had 'command_prompt' as its dependency_executor_name, but its dependency commands are written in sh.
- test cc4a0b8c-426f-40ff-9426-4e10e5bf4c49 in T1553.004 had 'command_prompt' as its dependency_executor_name and executor name, but its commands are written in sh.
- test c49978f6-bd6e-4221-ad2c-9e3e30cc1e3b in T1518 had 'command_prompt' as its executor name, but its commands are written in sh.

**Testing:**
None.

**Associated Issues:**
None.