### PR TITLE
Add cloud platforms to support_platforms

### DIFF
--- a/atomic_red_team/atomic_red_team.rb
+++ b/atomic_red_team/atomic_red_team.rb
@@ -108,7 +108,7 @@ class AtomicRedTeam
       raise("`atomic_tests[#{i}].supported_platforms` element is required") unless atomic.has_key?('supported_platforms')
       raise("`atomic_tests[#{i}].supported_platforms` element must be an Array (was a #{atomic['supported_platforms'].class.name})") unless atomic['supported_platforms'].is_a?(Array)
   
-      valid_supported_platforms = ['windows', 'macos', 'linux']
+      valid_supported_platforms = ['windows', 'macos', 'linux', 'aws', 'azure', 'gcp']
       atomic['supported_platforms'].each do |platform|
         if !valid_supported_platforms.include?(platform)
           raise("`atomic_tests[#{i}].supported_platforms` '#{platform}' must be one of #{valid_supported_platforms.join(', ')}")

--- a/atomic_red_team/atomic_test_template.yaml
+++ b/atomic_red_team/atomic_test_template.yaml
@@ -11,6 +11,9 @@ atomic_tests:
     - windows
     - macos
     - linux
+    - aws
+    - azure
+    - gcp
 
   input_arguments:
     output_file:


### PR DESCRIPTION
This allows an Atomic Red Team test to support (or target) a cloud platform.

**Details:**
This change extends supported_platforms to include cloud platforms. 

**Testing:**
I have done no testing. The most likely impact of this change is that we find something is ingesting tests and expecting supported_platforms to be one of the three original values, as opposed to simply looking for one of the three original values.

**Associated Issues:**
* https://github.com/redcanaryco/atomic-red-team/issues/1481