### PR TITLE
adds test for enumerating unconstrained delegation

### DIFF
--- a/atomics/T1087.002/T1087.002.yaml
+++ b/atomics/T1087.002/T1087.002.yaml
@@ -69,7 +69,7 @@ atomic_tests:
     name: powershell
 - name: Adfind -Listing password policy
   auto_generated_guid: 736b4f53-f400-4c22-855d-1a6b5a551600
-  description: | 
+  description: |
     Adfind tool can be used for reconnaissance in an Active directory environment. The example chosen illustrates adfind used to query the local password policy.
     reference- http://www.joeware.net/freetools/tools/adfind/, https://social.technet.microsoft.com/wiki/contents/articles/7535.adfind-command-examples.aspx
   supported_platforms:
@@ -93,7 +93,7 @@ atomic_tests:
     name: command_prompt
 - name: Adfind - Enumerate Active Directory Admins
   auto_generated_guid: b95fd967-4e62-4109-b48d-265edfd28c3a
-  description: | 
+  description: |
     Adfind tool can be used for reconnaissance in an Active directory environment. This example has been documented by ransomware actors enumerating Active Directory Admin accounts
     reference- http://www.joeware.net/freetools/tools/adfind/, https://stealthbits.com/blog/fun-with-active-directorys-admincount-attribute/
   supported_platforms:
@@ -117,7 +117,7 @@ atomic_tests:
     name: command_prompt
 - name: Adfind - Enumerate Active Directory User Objects
   auto_generated_guid: e1ec8d20-509a-4b9a-b820-06c9b2da8eb7
-  description: | 
+  description: |
     Adfind tool can be used for reconnaissance in an Active directory environment. This example has been documented by ransomware actors enumerating Active Directory User Objects
     reference- http://www.joeware.net/freetools/tools/adfind/, https://www.fireeye.com/blog/threat-research/2019/04/pick-six-intercepting-a-fin6-intrusion.html
   supported_platforms:
@@ -141,7 +141,7 @@ atomic_tests:
     name: command_prompt
 - name: Adfind - Enumerate Active Directory Exchange AD Objects
   auto_generated_guid: 5e2938fb-f919-47b6-8b29-2f6a1f718e99
-  description: | 
+  description: |
     Adfind tool can be used for reconnaissance in an Active directory environment. This example has been documented by ransomware actors enumerating Active Directory Exchange Objects
     reference- http://www.joeware.net/freetools/tools/adfind/, https://www.fireeye.com/blog/threat-research/2019/04/pick-six-intercepting-a-fin6-intrusion.html
   supported_platforms:
@@ -173,3 +173,43 @@ atomic_tests:
     command: |
       net user administrator /domain
     name: command_prompt
+
+- name: Enumerate Active Directory for Unconstrained Delegation
+  description: |
+    Attackers may attempt to query for computer objects with the UserAccountControl property
+    'TRUSTED_FOR_DELEGATION' (0x80000;524288) set
+    More Information - https://shenaniganslabs.io/2019/01/28/Wagging-the-Dog.html#when-the-stars-align-unconstrained-delegation-leads-to-rce
+    Prerequisite: AD RSAT PowerShell module is needed and it must run under a domain user
+  supported_platforms:
+  - windows
+  input_arguments:
+    domain:
+      description: Domain FQDN
+      type: String
+      default: contoso.com
+    uac_prop:
+      description: UAC Property to search
+      type: String
+      default: 524288
+  dependencies:
+  - description: |
+      PS Module ActiveDirectory
+    prereq_command: |
+      Try {
+          Import-Module ActiveDirectory -ErrorAction Stop | Out-Null
+          exit 0
+      }
+      Catch {
+          exit 1
+      }
+    get_prereq_command: |
+      if((Get-CimInstance -ClassName Win32_OperatingSystem).ProductType -eq 1) {
+        Add-WindowsCapability -Name (Get-WindowsCapability -Name RSAT.ActiveDirectory.DS* -Online).Name -Online
+      } else {
+        Install-WindowsFeature RSAT-AD-PowerShell
+      }
+  executor:
+    name: powershell
+    elevation_required: false
+    command: |
+      Get-ADObject -LDAPFilter '(UserAccountControl:1.2.840.113556.1.4.803:=#{uac_prop})' -Server #{domain}

--- a/atomics/T1087.002/T1087.002.yaml
+++ b/atomics/T1087.002/T1087.002.yaml
@@ -193,7 +193,7 @@ atomic_tests:
       default: 524288
   dependencies:
   - description: |
-      PS Module ActiveDirectory
+      PowerShell ActiveDirectory Module must be installed
     prereq_command: |
       Try {
           Import-Module ActiveDirectory -ErrorAction Stop | Out-Null


### PR DESCRIPTION
**Details:**
Attackers will attempt to enumerate AD objects with unconstrained delegation in order to attempt to ultimately escalate privileges in a domain. AD can be queried for the following UserAccountControl attribute: `TRUSTED_FOR_DELEGATION | 0x80000 | 524288`

**Testing:**
Tested on Win10 attached to a domain w/ DFL 2016

**Associated Issues:**
N/A