### PR TITLE
Added Disabling Firewall via Registry

### DIFF
--- a/atomics/T1562.004/T1562.004.yaml
+++ b/atomics/T1562.004/T1562.004.yaml
@@ -36,6 +36,19 @@ atomic_tests:
     cleanup_command: |
       netsh advfirewall set currentprofile state on >nul 2>&1
     name: command_prompt
+- name: Disable Microsoft Defender Firewall via Registry
+  auto_generated_guid: afedc8c4-038c-4d82-b3e5-623a95f8a612
+  description: |
+    Disables the Microsoft Defender Firewall for the public profile via registry
+    Caution if you access remotely the host where the test runs! Especially with the cleanup command which will re-enable firewall for the current profile...
+  supported_platforms:
+  - windows
+  executor:
+    command: |
+      reg add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\SharedAccess\Parameters\FirewallPolicy\PublicProfile" /v "EnableFirewall" /t REG_DWORD /d 0 /f
+    cleanup_command: |
+      reg add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\SharedAccess\Parameters\FirewallPolicy\PublicProfile" /v "EnableFirewall" /t REG_DWORD /d 1 /f
+    name: command_prompt
 - name: Allow SMB and RDP on Microsoft Defender Firewall
   auto_generated_guid: d9841bf8-f161-4c73-81e9-fd773a5ff8c1
   description: |


### PR DESCRIPTION
**Details:**
Added Disable Microsoft Defender Firewall via Registry as Windows firewall can be disabled via a registry key. This demonstrates disabling the public profile.

**Testing:**
Local Atomic testing 

**Associated Issues:**
N/A