### PR TITLE
Fixed bug in script path

### DIFF
--- a/atomics/T1082/T1082.yaml
+++ b/atomics/T1082/T1082.yaml
@@ -121,7 +121,7 @@ atomic_tests:
     vbscript:
       description: Path to sample script
       type: String
-      default: PathToAtomicsFolder\T1595.002\src\griffon_recon.vbs
+      default: PathToAtomicsFolder\T1082\src\griffon_recon.vbs
   executor:
     command: 'cscript #{vbscript}'
     name: powershell


### PR DESCRIPTION
**Details:**
The path was referring to T1595.002 instead of T1082, where the script resides. Due to the moved requested in #1320 and missed.

**Testing:**
Working with the new path.

**Associated Issues:**
#1320 