### PR TITLE
moving invoke-maldoc into art repo

### DIFF
--- a/atomics/T1053.005/T1053.005.yaml
+++ b/atomics/T1053.005/T1053.005.yaml
@@ -128,7 +128,7 @@ atomic_tests:
   executor:
     command: |
       [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-      IEX (iwr "https://raw.githubusercontent.com/redcanaryco/invoke-atomicredteam/master/Public/Invoke-MalDoc.ps1" -UseBasicParsing) 
+      IEX (iwr "https://raw.githubusercontent.com/redcanaryco/atomic-red-team/master/atomics/T1204.002/src/Invoke-MalDoc.ps1" -UseBasicParsing) 
       Invoke-MalDoc -macroFile "PathToAtomicsFolder\T1053.005\src\T1053.005-macrocode.txt" -officeProduct "#{ms_product}" -sub "Scheduler"
     name: powershell
 - name: WMI Invoke-CimMethod Scheduled Task

--- a/atomics/T1055.012/T1055.012.yaml
+++ b/atomics/T1055.012/T1055.012.yaml
@@ -60,6 +60,6 @@ atomic_tests:
   executor:
     command: |
       [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-      IEX (iwr "https://raw.githubusercontent.com/redcanaryco/invoke-atomicredteam/master/Public/Invoke-MalDoc.ps1" -UseBasicParsing) 
+      IEX (iwr "https://raw.githubusercontent.com/redcanaryco/atomic-red-team/master/atomics/T1204.002/src/Invoke-MalDoc.ps1" -UseBasicParsing) 
       Invoke-MalDoc -macroFile "PathToAtomicsFolder\T1055.012\src\T1055.012-macrocode.txt" -officeProduct "#{ms_product}" -sub "Exploit"
     name: powershell

--- a/atomics/T1055/T1055.yaml
+++ b/atomics/T1055/T1055.yaml
@@ -27,7 +27,7 @@ atomic_tests:
   executor:
     command: |
       [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-      IEX (iwr "https://raw.githubusercontent.com/redcanaryco/invoke-atomicredteam/master/Public/Invoke-MalDoc.ps1" -UseBasicParsing)
+      IEX (iwr "https://raw.githubusercontent.com/redcanaryco/atomic-red-team/master/atomics/T1204.002/src/Invoke-MalDoc.ps1" -UseBasicParsing)
       Invoke-Maldoc -macroFile "PathToAtomicsFolder\T1055\src\x64\T1055-macrocode.txt" -officeProduct "Word" -sub "Execute"
     name: powershell
 - name: Remote Process Injection in LSASS via mimikatz

--- a/atomics/T1059.005/T1059.005.yaml
+++ b/atomics/T1059.005/T1059.005.yaml
@@ -55,7 +55,7 @@ atomic_tests:
   executor:
     command: |
       [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-      IEX (iwr "https://raw.githubusercontent.com/redcanaryco/invoke-atomicredteam/master/Public/Invoke-MalDoc.ps1" -UseBasicParsing)
+      IEX (iwr "https://raw.githubusercontent.com/redcanaryco/atomic-red-team/master/atomics/T1204.002/src/Invoke-MalDoc.ps1" -UseBasicParsing)
       Invoke-Maldoc -macroFile "PathToAtomicsFolder\T1059.005\src\T1059.005-macrocode.txt" -officeProduct "Word" -sub "Exec"
     cleanup_command: |
       Get-WmiObject win32_process | Where-Object {$_.CommandLine -like "*mshta*"}  | % { "$(Stop-Process $_.ProcessID)" } | Out-Null
@@ -90,7 +90,7 @@ atomic_tests:
   executor:
     command: |
       [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-      IEX (iwr "https://raw.githubusercontent.com/redcanaryco/invoke-atomicredteam/master/Public/Invoke-MalDoc.ps1" -UseBasicParsing) 
+      IEX (iwr "https://raw.githubusercontent.com/redcanaryco/atomic-red-team/master/atomics/T1204.002/src/Invoke-MalDoc.ps1" -UseBasicParsing) 
       Invoke-Maldoc -macroFile "PathToAtomicsFolder\T1059.005\src\T1059_005-macrocode.txt" -officeProduct "Word" -sub "Extract"
     cleanup_command: |
       Remove-Item "$env:TEMP\atomic_t1059_005_test_output.bin" -ErrorAction Ignore

--- a/atomics/T1070.001/T1070.001.yaml
+++ b/atomics/T1070.001/T1070.001.yaml
@@ -55,7 +55,7 @@ atomic_tests:
   executor:
     command: |
       [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-      IEX (iwr "https://raw.githubusercontent.com/redcanaryco/invoke-atomicredteam/master/Public/Invoke-MalDoc.ps1" -UseBasicParsing)
+      IEX (iwr "https://raw.githubusercontent.com/redcanaryco/atomic-red-team/master/atomics/T1204.002/src/Invoke-MalDoc.ps1" -UseBasicParsing)
       Invoke-Maldoc -macroFile "PathToAtomicsFolder\T1070.001\src\T1070.001-macrocode.txt" -officeProduct "Word" -sub "ClearLogs"
     name: powershell
     elevation_required: true

--- a/atomics/T1115/T1115.yaml
+++ b/atomics/T1115/T1115.yaml
@@ -64,7 +64,7 @@ atomic_tests:
     command: |
       [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
       Set-Clipboard -value "Atomic T1115 Test, grab data from clipboard via VBA"
-      IEX (iwr "https://raw.githubusercontent.com/redcanaryco/invoke-atomicredteam/master/Public/Invoke-MalDoc.ps1" -UseBasicParsing)
+      IEX (iwr "https://raw.githubusercontent.com/redcanaryco/atomic-red-team/master/atomics/T1204.002/src/Invoke-MalDoc.ps1" -UseBasicParsing)
       Invoke-Maldoc -macroFile "PathToAtomicsFolder\T1115\src\T1115-macrocode.txt" -officeProduct "Word" -sub "GetClipboard"
     cleanup_command: |
       Remove-Item "$env:TEMP\atomic_T1115_clipboard_data.txt" -ErrorAction Ignore

--- a/atomics/T1204.002/T1204.002.yaml
+++ b/atomics/T1204.002/T1204.002.yaml
@@ -37,7 +37,7 @@ atomic_tests:
   executor:
     command: |
       [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-      IEX (iwr "https://raw.githubusercontent.com/redcanaryco/invoke-atomicredteam/master/Public/Invoke-MalDoc.ps1" -UseBasicParsing)
+      IEX (iwr "https://raw.githubusercontent.com/redcanaryco/atomic-red-team/master/atomics/T1204.002/src/Invoke-MalDoc.ps1" -UseBasicParsing)
       $macrocode = "   Open `"#{jse_path}`" For Output As #1`n   Write #1, `"WScript.Quit`"`n   Close #1`n   Shell`$ `"cscript.exe #{jse_path}`"`n"
       Invoke-MalDoc -macroCode $macrocode -officeProduct "#{ms_product}"
     cleanup_command: |
@@ -93,7 +93,7 @@ atomic_tests:
   executor:
     command: |
       [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-      IEX (iwr "https://raw.githubusercontent.com/redcanaryco/invoke-atomicredteam/master/Public/Invoke-MalDoc.ps1" -UseBasicParsing)
+      IEX (iwr "https://raw.githubusercontent.com/redcanaryco/atomic-red-team/master/atomics/T1204.002/src/Invoke-MalDoc.ps1" -UseBasicParsing)
       $macrocode = "  a = Shell(`"cmd.exe /c choice /C Y /N /D Y /T 3`", vbNormalFocus)"
       Invoke-MalDoc -macroCode $macrocode -officeProduct "#{ms_product}"
     name: powershell
@@ -129,7 +129,7 @@ atomic_tests:
   executor:
     command: |
       [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-      IEX (iwr "https://raw.githubusercontent.com/redcanaryco/invoke-atomicredteam/master/Public/Invoke-MalDoc.ps1" -UseBasicParsing)
+      IEX (iwr "https://raw.githubusercontent.com/redcanaryco/atomic-red-team/master/atomics/T1204.002/src/Invoke-MalDoc.ps1" -UseBasicParsing)
       $macrocode = "   Open `"#{jse_path}`" For Output As #1`n   Write #1, `"WScript.Quit`"`n   Close #1`n   a = Shell(`"cmd.exe /c wscript.exe //E:jscript #{jse_path}`", vbNormalFocus)`n"
       Invoke-MalDoc -macroCode $macrocode -officeProduct "#{ms_product}"
     name: powershell
@@ -164,7 +164,7 @@ atomic_tests:
   executor:
     command: |
       [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-      IEX (iwr "https://raw.githubusercontent.com/redcanaryco/invoke-atomicredteam/master/Public/Invoke-MalDoc.ps1" -UseBasicParsing)
+      IEX (iwr "https://raw.githubusercontent.com/redcanaryco/atomic-red-team/master/atomics/T1204.002/src/Invoke-MalDoc.ps1" -UseBasicParsing)
       $macrocode = "   Open `"#{bat_path}`" For Output As #1`n   Write #1, `"calc.exe`"`n   Close #1`n   a = Shell(`"cmd.exe /c $bat_path `", vbNormalFocus)`n"
       Invoke-MalDoc -macroCode $macrocode -officeProduct #{ms_product}
     name: powershell
@@ -290,7 +290,7 @@ atomic_tests:
   executor:
     command: |
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-        IEX (iwr "https://raw.githubusercontent.com/redcanaryco/invoke-atomicredteam/master/Public/Invoke-MalDoc.ps1" -UseBasicParsing)
+        IEX (iwr "https://raw.githubusercontent.com/redcanaryco/atomic-red-team/master/atomics/T1204.002/src/Invoke-MalDoc.ps1" -UseBasicParsing)
         Invoke-Maldoc -macroFile "PathToAtomicsFolder\T1204.002\src\chromeexec-macrocode.txt" -officeProduct "Word" -sub "ExecChrome"
     name: powershell
 

--- a/atomics/T1204.002/src/Invoke-MalDoc.ps1
+++ b/atomics/T1204.002/src/Invoke-MalDoc.ps1
@@ -1,0 +1,100 @@
+function Invoke-MalDoc {
+    <#
+    .SYNOPSIS
+    A module to programatically execute Microsoft Word and Exel Documents containing macros.
+
+    .DESCRIPTION
+    A module to programatically execute Microsoft Word and Exel Documents containing macros. The module will temporarily add a registry key to allow PowerShell to interact with VBA.
+    .PARAMETER macroCode
+    [Required] The VBA code to be executed. By default, this macro code will be wrapped in a sub routine, called "Test" by default. If you don't want your macro code to be wrapped in a subroutine use the `-noWrap` flag. To specify the subroutine name use the `-sub` parameter.
+    .PARAMETER macroFile
+    [Required] A file containing the VBA code to be executed. To specify the subroutine name to be called use the `-sub` parameter.
+    .PARAMETER officeVersion
+    [Optional] The Microsoft Office version to use for executing the document. e.g. "16.0". The version will be determined Programmatically if not specified.
+    .PARAMETER officeProduct
+    [Required] The Microsoft Office application in which to create and execute the macro, either "Word" or "Excel".
+    .PARAMETER sub
+    [Optional] The name of the subroutine in the macro code to call for execution. Also the name of the subroutine to wrap the supplied `macroCode` in if `noWrap` is not specified.
+    .PARAMETER noWrap
+    [Optional] A switch that specifies that the supplied `macroCode` should be used as-is and not wrapped in a subroutine.
+    
+    .EXAMPLE
+    C:\PS> Invoke-Maldoc -macroCode "MsgBox `"Hello`"" -officeProduct "Word"
+    -----------
+    Create a macro enabled Microsoft Word Document. The macro code `MsgBox "Hello"` will be wrapped inside of a subroutine call "Test" and then executed.
+    
+    .EXAMPLE
+    C:\PS> $macroCode = Get-Content path/to/macro.txt -Raw
+    C:\PS> Invoke-Maldoc -macroCode $macroCode -officeProduct "Word"
+    -----------
+    Create a macro enabled Microsoft Word Document. The macro code read from `path/to/macro.txt` will be wrapped inside of a subroutine call "Test" and then executed.
+    
+    .EXAMPLE
+    C:\PS> Invoke-Maldoc -macroCode "MsgBox `"Hello`"" -officeProduct "Excel" -sub "DoIt"
+    -----------
+    Create a macro enabled Microsoft Excel Document. The macro code `MsgBox "Hello"` will be wrapped inside of a subroutine call "DoIt" and then executed.
+
+    .EXAMPLE
+    C:\PS> Invoke-Maldoc -macroCode "Sub Exec()`nMsgBox `"Hello`"`nEnd Sub" -officeProduct "Word" -noWrap -sub "Exec"
+    -----------
+    Create a macro enabled Microsoft Word Document. The macroCode will be unmodified (i.e. not wrapped insided a subroutine) and the "Exec" subroutine will be executed.
+
+    .EXAMPLE
+    C:\PS> Invoke-Maldoc -macroFile "C:\AtomicRedTeam\atomics\T1003\src\macro.txt" -officeProduct "Word" -sub "DoIt"
+    -----------
+    Create a macro enabled Microsoft Word Document. The macroCode will be read from the specified file and the "DoIt" subroutine will be executed.
+
+#>
+
+    Param(
+        [Parameter(Position = 0, Mandatory = $True, ParameterSetName = "code")]
+        [String]$macroCode,
+
+        [Parameter(Position = 0, Mandatory = $True, ParameterSetName = "file")]
+        [String]$macroFile,
+
+        [Parameter(Position = 1, Mandatory = $False)]
+        [String]$officeVersion,
+
+        [Parameter(Position = 2, Mandatory = $True)]
+        [ValidateSet("Word", "Excel")]
+        [String]$officeProduct,
+
+        [Parameter(Position = 3, Mandatory = $false)]
+        [String]$sub = "Test",
+
+        [Parameter(Position = 4, Mandatory = $false, ParameterSetName = "code")]
+        [switch]$noWrap
+    )
+
+    $app = New-Object -ComObject "$officeProduct.Application"
+    if (-not $officeVersion) { $officeVersion = $app.Version } 
+    $Key = "HKCU:\Software\Microsoft\Office\$officeVersion\$officeProduct\Security\"
+    if (-not (Test-Path $key)) { New-Item $Key }
+    Set-ItemProperty -Path $Key -Name 'AccessVBOM' -Value 1
+
+    if ($macroFile) {
+        $macroCode = Get-Content $macroFile -Raw
+    }
+    elseif (-not $noWrap) {
+        $macroCode = "Sub $sub()`n" + $macroCode + "`nEnd Sub"
+    }
+
+    if ($officeProduct -eq "Word") {
+        $doc = $app.Documents.Add()
+    }
+    else {
+        $doc = $app.Workbooks.Add()
+    }
+    $comp = $doc.VBProject.VBComponents.Add(1)
+    $comp.CodeModule.AddFromString($macroCode)
+    $app.Run($sub)
+    $doc.Close(0)
+    $app.Quit()
+    [System.Runtime.InteropServices.Marshal]::ReleaseComObject($comp) | Out-Null
+    [System.Runtime.InteropServices.Marshal]::ReleaseComObject($doc) | Out-Null
+    [System.Runtime.InteropServices.Marshal]::ReleaseComObject($app) | Out-Null
+    [System.GC]::Collect()
+    [System.GC]::WaitForPendingFinalizers()
+    Remove-ItemProperty -Path "HKCU:\Software\Microsoft\Office\$officeVersion\$officeProduct\Security\" -Name 'AccessVBOM' -ErrorAction Ignore
+}

--- a/atomics/T1555/T1555.yaml
+++ b/atomics/T1555/T1555.yaml
@@ -24,7 +24,7 @@ atomic_tests:
   executor:
     command: |
       [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-      IEX (iwr "https://raw.githubusercontent.com/redcanaryco/invoke-atomicredteam/master/Public/Invoke-MalDoc.ps1" -UseBasicParsing)
+      IEX (iwr "https://raw.githubusercontent.com/redcanaryco/atomic-red-team/master/atomics/T1204.002/src/Invoke-MalDoc.ps1" -UseBasicParsing)
       Invoke-Maldoc -macroFile "PathToAtomicsFolder\T1555\src\T1555-macrocode.txt" -officeProduct "Word" -sub "Extract"
     cleanup_command: |
       Remove-Item "$env:TEMP\windows-credentials.txt" -ErrorAction Ignore

--- a/atomics/T1564/T1564.yaml
+++ b/atomics/T1564/T1564.yaml
@@ -34,7 +34,7 @@ atomic_tests:
       $macro = [System.IO.File]::ReadAllText("PathToAtomicsFolder\T1564\src\T1564-macrocode.txt")
       $macro = $macro -replace "aREPLACEMEa", "PathToAtomicsFolder\T1564\bin\extractme.bin"
       [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-      IEX (iwr "https://raw.githubusercontent.com/redcanaryco/invoke-atomicredteam/master/Public/Invoke-MalDoc.ps1" -UseBasicParsing)
+      IEX (iwr "https://raw.githubusercontent.com/redcanaryco/atomic-red-team/master/atomics/T1204.002/src/Invoke-MalDoc.ps1" -UseBasicParsing)
       Invoke-Maldoc -macroCode "$macro" -officeProduct "Word" -sub "Extract" -NoWrap
     cleanup_command: |
       Remove-Item "$env:TEMP\extracted.exe" -ErrorAction Ignore

--- a/atomics/T1566.001/T1566.001.yaml
+++ b/atomics/T1566.001/T1566.001.yaml
@@ -57,7 +57,7 @@ atomic_tests:
   executor:
     command: |
       [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-      IEX (iwr "https://raw.githubusercontent.com/redcanaryco/invoke-atomicredteam/master/Public/Invoke-MalDoc.ps1" -UseBasicParsing)
+      IEX (iwr "https://raw.githubusercontent.com/redcanaryco/atomic-red-team/master/atomics/T1204.002/src/Invoke-MalDoc.ps1" -UseBasicParsing)
       $macrocode = "   Open `"#{jse_path}`" For Output As #1`n   Write #1, `"WScript.Quit`"`n   Close #1`n   Shell`$ `"ping 8.8.8.8`"`n"
       Invoke-MalDoc -macroCode $macrocode -officeProduct "#{ms_product}"
     cleanup_command: |


### PR DESCRIPTION
The Invoke-Maldoc.ps1 script used by many atomics is being moved into this repo from the Invoke-AtomicRedTeam repo (the PowerShell Execution Framework) because it is a more fitting home for it.

This was also done in preparation for the Invoke-AtomicRedTeam tool being added to the PowerShell Gallery for easy install.

For now, there is still a copy of Invoke-Madoc in the Invoke-AtomicRedTeam repo but when that is removed, users whose atomic definition files still point to the old location will need to update their files in order for the Maldoc atomics to continue to work.