### PR TITLE
T1135 - Fixed key name in executor test

### DIFF
--- a/atomics/T1135/T1135.yaml
+++ b/atomics/T1135/T1135.yaml
@@ -45,7 +45,7 @@ atomic_tests:
     command: |
       smbstatus --shares
     name: bash
-    elevation_require: true
+    elevation_required: true
 - name: Network Share Discovery command prompt
   auto_generated_guid: 20f1097d-81c1-405c-8380-32174d493bbb
   description: |


### PR DESCRIPTION
**Details:**

Fixed key name of `elevation_require` to `elevation_required`

**Testing:**
<!-- Note any testing done, local or automated here. -->

**Associated Issues:**
<!-- Please link any issues that this pull request impacts or fixes. -->