### PR TITLE
T1572 Protocol Tunneling (DNS over HTTPS)

### DIFF
--- a/atomics/T1572/T1572.yaml
+++ b/atomics/T1572/T1572.yaml
@@ -31,7 +31,7 @@ atomic_tests:
       default: 127.0.0.1.xip.io
   executor:
     command: |
-      for($i=0; $i -le #{query_volume}; $i++) { Invoke-WebRequest "#{doh_server}?name=#{subdomain}.$(Get-Random -Minimum 1 -Maximum 999999).#{domain}&type=#{query_type}" -UseBasicParsing }
+      for($i=0; $i -le #{query_volume}; $i++) { (Invoke-WebRequest "#{doh_server}?name=#{subdomain}.$(Get-Random -Minimum 1 -Maximum 999999).#{domain}&type=#{query_type}" -UseBasicParsing).Content }
     name: powershell
 - name: DNS over HTTPS Regular Beaconing
   description: |

--- a/atomics/T1572/T1572.yaml
+++ b/atomics/T1572/T1572.yaml
@@ -1,0 +1,105 @@
+attack_technique: T1572
+display_name: 'Protocol Tunneling'
+atomic_tests:
+- name: DNS over HTTPS Large Query Volume
+  description: |
+    This test simulates an infected host sending a large volume of DoH queries to a command and control server.
+    The intent of this test is to trigger threshold based detection on the number of DoH queries either from a single source system or to a single targe domain.
+    A custom domain and sub-domain will need to be passed as input parameters for this test to work. Upon execution, DNS information about the domain will be displayed for each callout in a JSON format.
+  supported_platforms:
+  - windows
+  input_arguments:
+    doh_server:
+      description: Default DoH resolver
+      type: string
+      default: https://8.8.8.8/resolve
+    query_type:
+      description: DNS query type
+      type: string
+      default: TXT
+    subdomain:
+      description: Subdomain prepended to the domain name
+      type: string
+      default: atomicredteam
+    query_volume:
+      description: Number of DNS queries to send
+      type: integer
+      default: "1000"
+    domain:
+      description: Default domain to simulate against
+      type: string
+      default: 127.0.0.1.xip.io
+  executor:
+    command: |
+      for($i=0; $i -le #{query_volume}; $i++) { Invoke-WebRequest "#{doh_server}?name=#{subdomain}.$(Get-Random -Minimum 1 -Maximum 999999).#{domain}&type=#{query_type}" -UseBasicParsing }
+    name: powershell
+- name: DNS over HTTPS Regular Beaconing
+  description: |
+    This test simulates an infected host beaconing via DoH queries to a command and control server at regular intervals over time.
+    This behaviour is typical of implants either in an idle state waiting for instructions or configured to use a low query volume over time to evade threshold based detection.
+    A custom domain and sub-domain will need to be passed as input parameters for this test to work. Upon execution, DNS information about the domain will be displayed for each callout in a JSON format.
+  supported_platforms:
+  - windows
+  input_arguments:
+    doh_server:
+      description: Default DoH resolver
+      type: string
+      default: https://8.8.8.8/resolve
+    runtime:
+      description: Time in minutes to run the simulation
+      type: integer
+      default: "30"
+    domain:
+      description: Default domain to simulate against
+      type: string
+      default: 127.0.0.1.xip.io
+    subdomain:
+      description: Subdomain prepended to the domain name
+      type: string
+      default: atomicredteam
+    query_type:
+      description: DNS query type
+      type: string
+      default: TXT
+    c2_interval:
+      description: Seconds between C2 requests to the command and control server
+      type: integer
+      default: "30"
+    c2_jitter:
+      description: Percentage of jitter to add to the C2 interval to create variance in the times between C2 requests
+      type: integer
+      default: "20"
+  executor:
+    command: |
+      Set-Location PathToAtomicsFolder
+      .\T1572\src\T1572-doh-beacon.ps1 -DohServer #{doh_server} -Domain #{domain} -Subdomain #{subdomain} -QueryType #{query_type} -C2Interval #{c2_interval} -C2Jitter #{c2_jitter} -RunTime #{runtime}
+    name: powershell
+- name: DNS over HTTPS Long Domain Query
+  description: |
+    This test simulates an infected host returning data to a command and control server using long domain names.
+    The simulation involves sending DoH queries that gradually increase in length until reaching the maximum length. The intent is to test the effectiveness of detection of DoH queries for long domain names over a set threshold.
+     Upon execution, DNS information about the domain will be displayed for each callout in a JSON format.
+  supported_platforms:
+  - windows
+  input_arguments:
+    doh_server:
+      description: Default DoH resolver
+      type: string
+      default: https://8.8.8.8/resolve
+    query_type:
+      description: DNS query type
+      type: string
+      default: TXT
+    subdomain:
+      description: Subdomain prepended to the domain name (should be 63 characters to test maximum length)
+      type: string
+      default: atomicredteamatomicredteamatomicredteamatomicredteamatomicredte
+    domain:
+      description: Default domain to simulate against
+      type: string
+      default: 127.0.0.1.xip.io
+  executor:
+    command: |
+      Set-Location PathToAtomicsFolder
+      .\T1572\src\T1572-doh-domain-length.ps1 -DohServer #{doh_server} -Domain #{domain} -Subdomain #{subdomain} -QueryType #{query_type}
+    name: powershell

--- a/atomics/T1572/src/T1572-doh-beacon.ps1
+++ b/atomics/T1572/src/T1572-doh-beacon.ps1
@@ -12,7 +12,7 @@ $RunStart = Get-Date
 $RunEnd = $RunStart.addminutes($RunTime)
 Do { 
     $TimeNow = Get-Date
-    Invoke-WebRequest "$($DohServer)?name=$Subdomain.$(Get-Random -Minimum 1 -Maximum 999999).$Domain&type=$QueryType" -UseBasicParsing
+    (Invoke-WebRequest "$($DohServer)?name=$Subdomain.$(Get-Random -Minimum 1 -Maximum 999999).$Domain&type=$QueryType" -UseBasicParsing).Content
     $Jitter = (Get-Random -Minimum -$C2Jitter -Maximum $C2Jitter) / 100 + 1
     Start-Sleep -Seconds $C2Interval
 }

--- a/atomics/T1572/src/T1572-doh-beacon.ps1
+++ b/atomics/T1572/src/T1572-doh-beacon.ps1
@@ -1,0 +1,19 @@
+﻿param(
+    [string]$DohServer = "https://8.8.8.8/resolve",
+    [string]$Domain = "example.com",
+    [string]$Subdomain = "atomicredteam",
+    [string]$QueryType = "TXT",
+	[int]$C2Interval = 30,
+	[int]$C2Jitter = 20,
+	[int]$RunTime = 30
+)
+
+$RunStart = Get-Date
+$RunEnd = $RunStart.addminutes($RunTime)
+Do { 
+    $TimeNow = Get-Date
+    Invoke-WebRequest "$($DohServer)?name=$Subdomain.$(Get-Random -Minimum 1 -Maximum 999999).$Domain&type=$QueryType" -UseBasicParsing
+    $Jitter = (Get-Random -Minimum -$C2Jitter -Maximum $C2Jitter) / 100 + 1
+    Start-Sleep -Seconds $C2Interval
+}
+Until ($TimeNow -ge $RunEnd)

--- a/atomics/T1572/src/T1572-doh-domain-length.ps1
+++ b/atomics/T1572/src/T1572-doh-domain-length.ps1
@@ -1,0 +1,26 @@
+﻿param(
+    [string]$DohServer = "https://8.8.8.8/resolve",
+    [string]$Domain = "example.com",
+    [string]$Subdomain = "atomicredteamatomicredteamatomicredteamatomicredteamatomicredte",
+    [string]$QueryType = "TXT"
+)
+
+$Subdomain1Length = 1;
+$Subdomain2Length = 1;
+$Subdomain3Length = 1;
+$Subdomain4Length = 1;
+for($i=$Domain.Length+12; $i -le 253; $i++) {
+
+    $DomainLength = ([string]$i).PadLeft(3, "0")      
+    $DomainToQuery = $DomainLength + "." + 
+                         $Subdomain.substring(0, $Subdomain1Length) + "." + 
+                         $Subdomain.substring(0, $Subdomain2Length) + "." + 
+                         $Subdomain.substring(0, $Subdomain3Length) + "." + 
+                         $Subdomain.substring(0, $Subdomain4Length) + "." + 
+                         $Domain
+    Invoke-WebRequest "$($DohServer)?name=$DomainToQuery&type=$QueryType" -UseBasicParsing
+    if ($Subdomain1Length -lt 63) { $Subdomain1Length++ }
+    elseif ($Subdomain2Length -lt 63) { $Subdomain2Length++ }
+    elseif ($Subdomain3Length -lt 63) { $Subdomain3Length++ }
+    elseif ($Subdomain4Length -lt 63) { $Subdomain4Length++ }
+}

--- a/atomics/T1572/src/T1572-doh-domain-length.ps1
+++ b/atomics/T1572/src/T1572-doh-domain-length.ps1
@@ -18,7 +18,7 @@ for($i=$Domain.Length+12; $i -le 253; $i++) {
                          $Subdomain.substring(0, $Subdomain3Length) + "." + 
                          $Subdomain.substring(0, $Subdomain4Length) + "." + 
                          $Domain
-    Invoke-WebRequest "$($DohServer)?name=$DomainToQuery&type=$QueryType" -UseBasicParsing
+    (Invoke-WebRequest "$($DohServer)?name=$DomainToQuery&type=$QueryType" -UseBasicParsing).Content
     if ($Subdomain1Length -lt 63) { $Subdomain1Length++ }
     elseif ($Subdomain2Length -lt 63) { $Subdomain2Length++ }
     elseif ($Subdomain3Length -lt 63) { $Subdomain3Length++ }


### PR DESCRIPTION
**Details:**
Adds three tests for DNS over HTTPS utilizing the DNS tests from T1071.004, but tunneled over DoH.
This does not include the dnscat C2 in test 4.

**Testing:**
Tested on Windows 10
```
PS D:\Projects\atomic-red-team> Invoke-AtomicTest T1572
PathToAtomicsFolder = D:\Projects\atomic-red-team\atomics

Executing test: T1572-1 DNS over HTTPS Large Query Volume
Done executing test: T1572-1 DNS over HTTPS Large Query Volume

{"Status":2,"TC":false,"RD":true,"RA":true,"AD":false,"CD":false,"Question":[{"name":"atomicredteam.673087.127.0.0.1.xip.io.","type":16}],"Comment":"Name servers did not respond [166.78.161.251, 192.237.180.202]."}
{"Status":2,"TC":false,"RD":true,"RA":true,"AD":false,"CD":false,"Question":[{"name":"atomicredteam.543150.127.0.0.1.xip.io.","type":16}],"Comment":"All name servers for zone unresponsive (no query sent)."}
{"Status":2,"TC":false,"RD":true,"RA":true,"AD":false,"CD":false,"Question":[{"name":"atomicredteam.237852.127.0.0.1.xip.io.","type":16}],"Comment":"All name servers for zone unresponsive (no query sent)."}
{"Status":2,"TC":false,"RD":true,"RA":true,"AD":false,"CD":false,"Question":[{"name":"atomicredteam.182342.127.0.0.1.xip.io.","type":16}],"Comment":"All name servers for zone unresponsive (no query sent)."}
{"Status":2,"TC":false,"RD":true,"RA":true,"AD":false,"CD":false,"Question":[{"name":"atomicredteam.951461.127.0.0.1.xip.io.","type":16}],"Comment":"Name servers did not respond [166.78.161.251, 192.237.180.202]."}
{"Status":2,"TC":false,"RD":true,"RA":true,"AD":false,"CD":false,"Question":[{"name":"atomicredteam.401706.127.0.0.1.xip.io.","type":16}],"Comment":"All name servers for zone unresponsive (no query sent)."}
{"Status":2,"TC":false,"RD":true,"RA":true,"AD":false,"CD":false,"Question":[{"name":"atomicredteam.838788.127.0.0.1.xip.io.","type":16}],"Comment":"All name servers for zone unresponsive (no query sent)."}
{"Status":2,"TC":false,"RD":true,"RA":true,"AD":false,"CD":false,"Question":[{"name":"atomicredteam.32318.127.0.0.1.xip.io.","type":16}],"Comment":"All name servers for zone unresponsive (no query sent)."}
{"Status":2,"TC":false,"RD":true,"RA":true,"AD":false,"CD":false,"Question":[{"name":"atomicredteam.127726.127.0.0.1.xip.io.","type":16}],"Comment":"All name servers for zone unresponsive (no query sent)."}
...

Executing test: T1572-2 DNS over HTTPS Regular Beaconing
Done executing test: T1572-2 DNS over HTTPS Regular Beaconing

{"Status":2,"TC":false,"RD":true,"RA":true,"AD":false,"CD":false,"Question":[{"name":"atomicredteam.28041.127.0.0.1.xip.io.","type":16}],"Comment":"All name servers for zone unresponsive (no query sent)."}
{"Status":2,"TC":false,"RD":true,"RA":true,"AD":false,"CD":false,"Question":[{"name":"atomicredteam.689484.127.0.0.1.xip.io.","type":16}],"Comment":"All name servers for zone unresponsive (no query sent)."}
{"Status":2,"TC":false,"RD":true,"RA":true,"AD":false,"CD":false,"Question":[{"name":"atomicredteam.352.127.0.0.1.xip.io.","type":16}],"Comment":"All name servers for zone unresponsive (no query sent)."}
{"Status":2,"TC":false,"RD":true,"RA":true,"AD":false,"CD":false,"Question":[{"name":"atomicredteam.56842.127.0.0.1.xip.io.","type":16}],"Comment":"All name servers for zone unresponsive (no query sent)."}
...

Executing test: T1572-3 DNS over HTTPS Long Domain Query
Done executing test: T1572-3 DNS over HTTPS Long Domain Query

{"Status":2,"TC":false,"RD":true,"RA":true,"AD":false,"CD":false,"Question":[{"name":"028.a.a.a.a.127.0.0.1.xip.io.","type":16}],"Comment":"Name servers did not respond [192.237.180.202, 166.78.161.251]."}
{"Status":2,"TC":false,"RD":true,"RA":true,"AD":false,"CD":false,"Question":[{"name":"029.at.a.a.a.127.0.0.1.xip.io.","type":16}],"Comment":"Name servers did not respond [166.78.161.251, 192.237.180.202]."}
{"Status":2,"TC":false,"RD":true,"RA":true,"AD":false,"CD":false,"Question":[{"name":"030.ato.a.a.a.127.0.0.1.xip.io.","type":16}],"Comment":"Name servers did not respond [166.78.161.251, 192.237.180.202]."}
{"Status":2,"TC":false,"RD":true,"RA":true,"AD":false,"CD":false,"Question":[{"name":"031.atom.a.a.a.127.0.0.1.xip.io.","type":16}],"Comment":"Name servers did not respond [192.237.180.202, 166.78.161.251]."}
{"Status":2,"TC":false,"RD":true,"RA":true,"AD":false,"CD":false,"Question":[{"name":"032.atomi.a.a.a.127.0.0.1.xip.io.","type":16}],"Comment":"Name servers did not respond [192.237.180.202, 166.78.161.251]."}
{"Status":2,"TC":false,"RD":true,"RA":true,"AD":false,"CD":false,"Question":[{"name":"033.atomic.a.a.a.127.0.0.1.xip.io.","type":16}],"Comment":"Name servers did not respond [192.237.180.202, 166.78.161.251]."}
{"Status":2,"TC":false,"RD":true,"RA":true,"AD":false,"CD":false,"Question":[{"name":"034.atomicr.a.a.a.127.0.0.1.xip.io.","type":16}],"Comment":"Name servers did not respond [192.237.180.202, 166.78.161.251]."}
{"Status":2,"TC":false,"RD":true,"RA":true,"AD":false,"CD":false,"Question":[{"name":"035.atomicre.a.a.a.127.0.0.1.xip.io.","type":16}],"Comment":"Name servers did not respond [192.237.180.202, 166.78.161.251]."}
{"Status":2,"TC":false,"RD":true,"RA":true,"AD":false,"CD":false,"Question":[{"name":"036.atomicred.a.a.a.127.0.0.1.xip.io.","type":16}],"Comment":"Name servers did not respond [192.237.180.202, 166.78.161.251]."}
{"Status":2,"TC":false,"RD":true,"RA":true,"AD":false,"CD":false,"Question":[{"name":"037.atomicredt.a.a.a.127.0.0.1.xip.io.","type":16}],"Comment":"Name servers did not respond [166.78.161.251, 192.237.180.202]."}
...
```

**Associated Issues:**
n/a