### PR TITLE
Update T1047.yaml

### DIFF
--- a/atomics/T1047/T1047.yaml
+++ b/atomics/T1047/T1047.yaml
@@ -149,3 +149,16 @@ atomic_tests:
     cleanup_command: |
       $CleanupClass = New-Object Management.ManagementClass(New-Object Management.ManagementPath("#{new_class}"))
       $CleanupClass.Delete()
+- name: Executing local javascript via WMI to call mshta
+  description: |
+    This Action demonstrates using executing local javascript via WMI to call mshta. FIN7 has been observed using WMI to call mshta and execute arbitrary javascript
+  supported_platforms:
+  - windows
+    executor:
+    name: command_prompt
+    elevation_required: true
+    command: |
+      wmic process call create "mshta javascript:eval(\"var a = new ActiveXObject('WScript.shell'); a.run('notepad')\");"
+    cleanup_command: |
+      taskkill /IM notepad.exe /F
+      taskkill /IM mshta.exe /F

--- a/atomics/T1047/T1047.yaml
+++ b/atomics/T1047/T1047.yaml
@@ -154,7 +154,7 @@ atomic_tests:
     This Action demonstrates using executing local javascript via WMI to call mshta. FIN7 has been observed using WMI to call mshta and execute arbitrary javascript
   supported_platforms:
   - windows
-    executor:
+  executor:
     name: command_prompt
     elevation_required: true
     command: |


### PR DESCRIPTION
This Action demonstrates Threat Actor executing local javascript via WMI to call mshta. FIN7 has been observed using WMI to call mshta and execute arbitrary javascript.

**Details:**
This particular Technique has been used by FIN7 APT.

**Testing:**
Successful Command execution in Windows 10 using command prompt:
![image](https://user-images.githubusercontent.com/31036535/128349521-3d4cc4fb-99a0-4fdb-8923-40523c1d44a9.png)

See the presense of notepad.exe and mshta.exe after running the command:
![image](https://user-images.githubusercontent.com/31036535/128349419-fd521741-f300-4d8a-9539-bf6ab8a1c741.png)
![image](https://user-images.githubusercontent.com/31036535/128349593-a369d0b7-9461-4b05-b7e3-02a36c012b98.png)

See the successful cleanup commands:
![image](https://user-images.githubusercontent.com/31036535/128349653-9f4271e8-82ad-43ca-a557-3639d6e6a5e8.png)
![image](https://user-images.githubusercontent.com/31036535/128349672-e6d1f02b-232e-4615-9fcc-eac31928f240.png)


**Associated Issues:**
<!-- Please link any issues that this pull request impacts or fixes. -->