### PR TITLE
bump layer version

### DIFF
--- a/bin/generate-atomic-docs.rb
+++ b/bin/generate-atomic-docs.rb
@@ -190,7 +190,7 @@ class AtomicRedTeamDocs
 
   def get_layer(techniques, layer_name)
     layer = {
-      "version" => "4.1",
+      "version" => "4.2",
       "name" => layer_name,
       "description" => layer_name + " MITRE ATT&CK Navigator Layer",
       "domain" => "mitre-enterprise",


### PR DESCRIPTION
To avoid a version number mismatch warning when using the Mitre Att&ck Navigator layer, I've bumped the json layer version.