### PR TITLE
Add T1113 test for CopyFromScreen API

### DIFF
--- a/atomics/T1113/T1113.yaml
+++ b/atomics/T1113/T1113.yaml
@@ -118,3 +118,26 @@ atomic_tests:
       cmd /c "timeout #{recording_time} > NULL && psr.exe /stop"
     cleanup_command: |
       rm #{output_file} -ErrorAction Ignore
+- name: Windows Screen Capture (CopyFromScreen)
+  description: |
+    Take a screen capture of the desktop through a call to the [Graphics.CopyFromScreen] .NET API.
+
+    [Graphics.CopyFromScreen]: https://docs.microsoft.com/en-us/dotnet/api/system.drawing.graphics.copyfromscreen
+  supported_platforms:
+  - windows
+  input_arguments:
+    output_file:
+      description: Path where captured results will be placed
+      type: Path
+      default: $env:TEMP\T1113.png
+  executor:
+    command: |
+      Add-Type -AssemblyName System.Windows.Forms
+      $screen = [Windows.Forms.SystemInformation]::VirtualScreen
+      $bitmap = New-Object Drawing.Bitmap $screen.Width, $screen.Height
+      $graphic = [Drawing.Graphics]::FromImage($bitmap)
+      $graphic.CopyFromScreen($screen.Left, $screen.Top, 0, 0, $bitmap.Size)
+      $bitmap.Save("#{output_file}")
+    cleanup_command: |
+      Remove-Item #{output_file} -ErrorAction Ignore
+    name: powershell


### PR DESCRIPTION
**Details:**
Add a test for [T1113: Screen Capture](https://attack.mitre.org/techniques/T1113/) that uses the `CopyFromScreen` .NET API ([docs.microsoft.com](https://docs.microsoft.com/en-us/dotnet/api/system.drawing.graphics.copyfromscreen)).
Similar implementations have been used both in the APT29 (2019) and Carbanak+FIN7 (2020) ATT&CK Evaluations ([center-for-threat-informed-defense/adversary_emulation_library](https://github.com/center-for-threat-informed-defense/adversary_emulation_library/search?q=CopyFromScreen)).

**Testing:**
Tested locally via `Invoke-AtomicTest`.

**Associated Issues:**
N/A