### PR TITLE
Update T1056.001.yaml

### DIFF
--- a/atomics/T1056.001/T1056.001.yaml
+++ b/atomics/T1056.001/T1056.001.yaml
@@ -104,7 +104,7 @@ atomic_tests:
       type: String
       default: /tmp/.keyboard.log
   executor:
-    name: command_prompt
+    name: sh
     elevation_required: false 
     command: | 
       trap 'echo "$(date +"%d/%m/%y %H:%M:%S.%s") $USER $BASH_COMMAND" >> #{output_file}' DEBUG
@@ -133,7 +133,7 @@ atomic_tests:
       type: String
       default: ubuntu
   executor:
-    name: command_prompt
+    name: sh
     elevation_required: true 
     command: | 
       cp -v /etc/pam.d/sshd /tmp/
@@ -163,7 +163,7 @@ atomic_tests:
       get_prereq_command: | 
         echo ""
   executor:
-    name: command_prompt
+    name: sh
     elevation_required: true 
     command: | 
       auditctl -a always,exit -F arch=b64 -S execve -k CMDS 


### PR DESCRIPTION
Details:
Why executor name is command prompt ? It should be 'sh' for linux platforms right ? I changed executor name 'command prompt' to 'sh'.

Testing:
T1056.001-Bash session based keylogger
T1056.001-SSHD PAM keylogger
T1056.001-Auditd keylogger

Associated Issues:
None