### PR TITLE
T1003.003 Add remote Shadow Copy creation over wmi

### DIFF
--- a/atomics/T1003.003/T1003.003.yaml
+++ b/atomics/T1003.003/T1003.003.yaml
@@ -138,6 +138,35 @@ atomic_tests:
     name: command_prompt
     elevation_required: true
 
+- name: Create Volume Shadow Copy remotely with WMI
+  auto_generated_guid: d893459f-71f0-484d-9808-ec83b2b64226
+  description: |
+    This test is intended to be run from a remote workstation with domain admin context.
+    The Active Directory database NTDS.dit may be dumped by copying it from a Volume Shadow Copy.
+  supported_platforms:
+  - windows
+  input_arguments:
+    drive_letter:
+      description: Drive letter to source VSC (including colon and backslash)
+      type: String
+      default: 'C:\'
+    target_host:
+      description: IP Address / Hostname you want to target
+      type: String
+      default: dc.example.net
+  dependencies:
+  - description: |
+      Target must be a reachable Domain Controller, and current context must be domain admin
+    prereq_command: |
+      wmic /node:#{target_host} shadowcopy list brief
+    get_prereq_command: |
+      echo Sorry, can't connect to target host, check: network, firewall or permissions (must be admin on target)
+  executor:
+    command: |
+      wmic /node:#{target_host} shadowcopy call create Volume=#{drive_letter}
+    name: command_prompt
+    elevation_required: false
+
 - name: Create Volume Shadow Copy with Powershell
   auto_generated_guid: 542bb97e-da53-436b-8e43-e0a7d31a6c24
   description: |


### PR DESCRIPTION
Hi!

This PR extends the existing NTDS credential dumping atomics by adding remote shadow copy creation over wmi.

**Details:**
For T1003.003:
* Add a new Atomic to allow remote Shadow Copy creation over wmi

**Testing:**
Local testing

![Screenshot 2021-10-01 111450](https://user-images.githubusercontent.com/6689144/135600442-9fba2af4-a5b5-4d97-8511-680901694764.png)

**Associated Issues:**
N/A