### PR TITLE
T1027: Add generic Command-Line Obfuscation

### DIFF
--- a/atomics/T1027/T1027.yaml
+++ b/atomics/T1027/T1027.yaml
@@ -159,7 +159,6 @@ atomic_tests:
       $cmDwhy =[TyPe]("{0}{1}" -f 'S','TrING')  ;   $pz2Sb0  =[TYpE]("{1}{0}{2}"-f'nv','cO','ert')  ;  &("{0}{2}{3}{1}{4}" -f'In','SiO','vOKe-EXp','ReS','n') (  (&("{1}{2}{0}"-f'blE','gET-','vaRIA')  ('CMdw'+'h'+'y'))."v`ALUe"::("{1}{0}" -f'iN','jO').Invoke('',( (127, 162,151, 164,145 ,55 , 110 ,157 ,163 , 164 ,40,47, 110 , 145 ,154, 154 ,157 , 54 ,40, 146, 162 , 157,155 ,40, 120, 157 ,167,145 , 162 ,123,150 ,145 , 154 , 154 , 41,47)| .('%') { ( [CHAR] (  $Pz2sB0::"t`OinT`16"(( [sTring]${_}) ,8)))})) )
     name: powershell
 - name: Obfuscated Command Line using special Unicode characters
-  auto_generated_guid: 787a4632-d4dc-4fcc-afe9-520a49234a47
   description: |
     This is an obfuscated certutil command that when executed downloads a file from the web. Adapted from T1105. Obfuscation includes special options chars (unicode hyphens), character substitution (e.g. ᶠ) and character insertion (including the usage of the right-to-left 0x202E and left-to-right 0x202D override characters).
     Reference:


### PR DESCRIPTION
**Details:**
Adding an extra test for 'generic' command-line obfuscation,  The test uses `certutil.exe` as an example. 
Note that I have used the command from T1105-7 (`dd3b61dd-7bbc-48cd-ab51-49ad1a776df0`) as a base.
More details about this type of obfuscation on https://wietze.github.io/blog/windows-command-line-obfuscation . 

**Testing:**
Local testing:
![image](https://user-images.githubusercontent.com/2811785/136989272-2a9731cc-1719-4fb6-a276-656d57b76a3a.png)

*NOTE*: As shown in the screenshot above, this test bypasses default Defender config, whereas the unobfuscated equivalent, T1105-7, would be stopped:
![image](https://user-images.githubusercontent.com/2811785/136989545-28a4cde8-b07e-4c24-bd9e-ff54e1106706.png)

This highlights the value of this new test.

**Associated Issues:**
Not an 'issue' as such, but as explained in the description of the new test, Right-to-Left and Left-to-Right override chars are used, and therefore looking at the command on GitHub or a text editor may give you the impression that it is formatted the wrong way - but it isn't, certutil ignores these characters and downloads the requested file as expected.