### PR TITLE
ServicePrincipleName Gathering T1558.003

### DIFF
--- a/atomics/T1558.003/T1558.003.yaml
+++ b/atomics/T1558.003/T1558.003.yaml
@@ -131,7 +131,7 @@ atomic_tests:
     domain_name:
       description: The Domain Name to lookup against
       type: String
-      default: %USERDNSDOMAIN%
+      default: "%USERDNSDOMAIN%"
   dependency_executor_name: powershell
   dependencies:
   - description: |


### PR DESCRIPTION
Added 3 new atomics for gathering ServicePrincipleNames using setspn.exe or “KerberosRequestorSecurityToken”. 


Some references:
  - https://docs.microsoft.com/en-us/windows/win32/ad/service-principal-names
  - https://docs.microsoft.com/en-us/dotnet/api/system.identitymodel.tokens.kerberosrequestorsecuritytoken?view=netframework-4.8
  - https://www.ired.team/offensive-security-experiments/active-directory-kerberos-abuse/t1208-kerberoasting
  - https://strontic.github.io/xcyclopedia/library/setspn.exe-5C184D581524245DAD7A0A02B51FD2C2.html
  - https://attack.mitre.org/techniques/T1558/003/
  - https://social.technet.microsoft.com/wiki/contents/articles/717.service-principal-names-spn-setspn-syntax.aspx
  - https://www.harmj0y.net/blog/powershell/kerberoasting-without-mimikatz/
  - https://blog.zsec.uk/paving-2-da-wholeset/
  - https://msitpros.com/?p=3113
  - https://adsecurity.org/?p=3466