### PR TITLE
Fix T1110.003 quote usage in PowerShell

### DIFF
--- a/atomics/T1110.003/T1110.003.yaml
+++ b/atomics/T1110.003/T1110.003.yaml
@@ -88,7 +88,7 @@ atomic_tests:
 
       $DomainUsers | Foreach-Object {
         $user = $_
-        $password = "#{password}"
+        $password = '#{password}'
 
         $credz = new-object System.Net.NetworkCredential($user, $password, "#{domain}")
         $conn = new-object System.DirectoryServices.Protocols.LdapConnection($di, $credz, [System.DirectoryServices.Protocols.AuthType]::#{auth})


### PR DESCRIPTION
**Details:**
In PowerShell, special characters are interpreted in double quotes. By using a single quote, the password won't change.
So this commit/PR just replaces double quotes with single quotes for

- Test: `T1110.003`
- Name: `Password spray all Active Directory domain users with a single password via LDAP against domain controller (NTLM or Kerberos)`
- Guid: `f14d956a-5b6e-4a93-847f-0c415142f07d`

**Testing:**
The password used is `Pa$$w0rd1`.

Before:
```
 [-] Attempting Paw0rd1 on account Administrator.
Exception calling "Bind" with "0" argument(s): "The supplied credential is invalid."
 [-] Attempting Paw0rd1 on account user1.
Exception calling "Bind" with "0" argument(s): "The supplied credential is invalid."
```
After:
```
 [-] Attempting Pa$$w0rd1 on account Administrator.
Exception calling "Bind" with "0" argument(s): "The supplied credential is invalid."
 [-] Attempting Pa$$w0rd1 on account user1.
 [!] user1:Pa$$w0rd1 are valid credentials!
```

**Associated Issues:**
N/A