### PR TITLE
T1485 - constrains dd to write the original file size when overwriting

### DIFF
--- a/atomics/T1485/T1485.yaml
+++ b/atomics/T1485/T1485.yaml
@@ -51,5 +51,5 @@ atomic_tests:
       default: /var/log/syslog
   executor:
     command: |
-      dd of=#{file_to_overwrite} if=#{overwrite_source}
+      dd of=#{file_to_overwrite} if=#{overwrite_source} count=$(ls -l #{file_to_overwrite} | awk '{print $5}') iflag=count_bytes
     name: bash


### PR DESCRIPTION
**Details:**
`dd of=#{file_to_overwrite} if=#{overwrite_source}` has neither timeout nor size limit, and will fill the disk (T1499) vs just wiping the file, preventing automation or further testing.

**Testing:**
Local on ubuntu

**Associated Issues:**
N/A