### PR TITLE
Adding T1555.003 Test 5 - Simulating Access to Opera Login Data

### DIFF
--- a/atomics/T1555.003/T1555.003.yaml
+++ b/atomics/T1555.003/T1555.003.yaml
@@ -102,3 +102,30 @@ atomic_tests:
     cleanup_command: |
       Remove-Item -Path "$env:temp\Login Data" -Force -ErrorAction Ignore
       Remove-Item -Path "$env:temp\Login Data For Account" -Force -ErrorAction Ignore
+- name: Simulating access to Opera Login Data
+  description: |
+    Simulates an adversary accessing encrypted credentials from Opera web browser's login database. 
+  supported_platforms:
+    - windows
+  dependency_executor_name: powershell
+  dependencies:
+  - description: |
+      Opera must be installed
+    prereq_command: 'if (((Test-Path "$env:LOCALAPPDATA\Programs\Opera\launcher.exe") -Or (Test-Path "C:\Program Files\Opera\launcher.exe") -Or (Test-Path "C:\Program Files (x86)\Opera\launcher.exe"))) {exit 0} else {exit 1}'      
+    get_prereq_command: | 
+      $installer = "$env:temp\OperaStandaloneInstaller.exe"
+      Invoke-WebRequest -OutFile $env:temp\OperaStandaloneInstaller.exe https://get.geo.opera.com/pub/opera/desktop/82.0.4227.43/win/Opera_82.0.4227.43_Setup.exe
+      Start-Process $installer -ArgumentList '/install /silent /launchopera=1 /setdefaultbrowser=0'
+      Start-Sleep -s 180
+      Stop-Process -Name "opera"
+  - description: |
+      Opera login data file must exist
+    prereq_command: 'if (Test-Path "$env:APPDATA\Opera Software\Opera Stable\Login Data") {exit 0} else {exit 1}'    
+    get_prereq_command: | 
+      New-Item -Path "$env:APPDATA\Opera Software\Opera Stable\Login Data" -ItemType File
+  executor:
+    name: powershell
+    command: |
+      Copy-Item "$env:APPDATA\Opera Software\Opera Stable\Login Data" -Destination $env:temp
+    cleanup_command: |
+      Remove-Item -Path "$env:temp\Login Data" -Force -ErrorAction Ignore

--- a/atomics/T1555.003/T1555.003.yaml
+++ b/atomics/T1555.003/T1555.003.yaml
@@ -31,7 +31,8 @@ atomic_tests:
     command: |
       Set-Location -path "#{file_path}\Sysinternals";
       ./accesschk.exe -accepteula .;
-    cleanup_command: 'Remove-Item #{file_path}\Sysinternals -Force -Recurse -ErrorAction Ignore'
+    cleanup_command: |
+      Remove-Item #{file_path}\Sysinternals -Force -Recurse -ErrorAction Ignore
     name: powershell
 - name: Search macOS Safari Cookies
   auto_generated_guid: c1402f7b-67ca-43a8-b5f3-3143abedc01b


### PR DESCRIPTION
Adding a 5th test that simulates access to Opera Login Data within Windows.

**Testing:**
Tested on Windows 10. If using the Get-PreReqs parameter to install Opera automatically, I would recommend changing the timeout seconds to 900 (append -TimeoutSeconds 900 after -GetPreReqs) to ensure that there is enough time to download Opera before the GetPreReqs command times out, as it is a fairly large download. 
