### PR TITLE
Create T1091.yaml

### DIFF
--- a/atomics/T1091/T1091.yaml
+++ b/atomics/T1091/T1091.yaml
@@ -1,0 +1,24 @@
+attack_technique: T1091
+display_name: "Replication Through Removable Media"
+atomic_tests:
+- name: USB Malware Spread Simulation
+  description: |
+    Simulates an adversary copying malware to all connected removable drives. 
+  supported_platforms:
+    - windows
+  executor:
+    name: powershell
+    command: |
+      $RemovableDrives=@()
+      $RemovableDrives = Get-WmiObject -Class Win32_LogicalDisk -filter "drivetype=2" | select-object -expandproperty DeviceID
+      ForEach ($Drive in $RemovableDrives)
+      {
+      write-host "Removable Drive Found:" $Drive
+      New-Item -Path $Drive/T1091Test1.txt -ItemType "file" -Force -Value "T1091 Test 1 has created this file to simulate malware spread to removable drives."
+      }
+    cleanup_command: |
+      $RemovableDrives = Get-WmiObject -Class Win32_LogicalDisk -filter "drivetype=2" | select-object -expandproperty DeviceID
+      ForEach ($Drive in $RemovableDrives)
+      {
+      Remove-Item -Path $Drive\T1091Test1.txt -Force -ErrorAction Ignore
+      }


### PR DESCRIPTION
Creating a directory for T1091 and corresponding YAML file so that a new test can be submitted for this technique. The proposed test is designed to detect removable drives connected to a Windows system and then create a file named "T1091Test1.txt" on them to simulate USB spread.


**Testing:**
This test was tested on 1 physical Windows 10 host and 2 Windows 10 VMs. 