### PR TITLE
Fix prereq_command Get-Module AzureAD

### DIFF
--- a/atomics/T1098.001/T1098.001.yaml
+++ b/atomics/T1098.001/T1098.001.yaml
@@ -35,7 +35,7 @@ atomic_tests:
   - description: |
       AzureAD module must be installed.
     prereq_command: |
-      if (Get-Module AzureAD) {exit 0} else {exit 1}
+      try {if (Get-InstalledModule -Name AzureAD -ErrorAction SilentlyContinue) {exit 0} else {exit 1}} catch {exit 1}
     get_prereq_command: |
       Install-Module -Name AzureAD -Force
   executor:
@@ -119,7 +119,7 @@ atomic_tests:
   - description: |
       AzureAD module must be installed.
     prereq_command: |
-      if (Get-Module AzureAD) {exit 0} else {exit 1}
+      try {if (Get-InstalledModule -Name AzureAD -ErrorAction SilentlyContinue) {exit 0} else {exit 1}} catch {exit 1}
     get_prereq_command: |
       Install-Module -Name AzureAD -Force
   executor:

--- a/atomics/T1110.001/T1110.001.yaml
+++ b/atomics/T1110.001/T1110.001.yaml
@@ -92,7 +92,7 @@ atomic_tests:
   - description: |
       AzureAD module must be installed.
     prereq_command: |
-      if (Get-Module AzureAD) {exit 0} else {exit 1}
+      try {if (Get-InstalledModule -Name AzureAD -ErrorAction SilentlyContinue) {exit 0} else {exit 1}} catch {exit 1}
     get_prereq_command: |
       Install-Module -Name AzureAD -Force
   executor:

--- a/atomics/T1110.003/T1110.003.yaml
+++ b/atomics/T1110.003/T1110.003.yaml
@@ -127,7 +127,7 @@ atomic_tests:
   - description: |
       AzureAD module must be installed.
     prereq_command: |
-      if (Get-Module AzureAD) {exit 0} else {exit 1}
+      try {if (Get-InstalledModule -Name AzureAD -ErrorAction SilentlyContinue) {exit 0} else {exit 1}} catch {exit 1}
     get_prereq_command: |
       Install-Module -Name AzureAD -Force
   executor:


### PR DESCRIPTION
**Details:**
AzureAD allways install when check prereq

![image](https://user-images.githubusercontent.com/62423083/149564338-d6ec1502-7a4b-4848-b6b7-9bfb257617bc.png)

I use `-ErrorAction SilentlyContinue` to not display error on screen when missing.
Now install only 1 time
![image](https://user-images.githubusercontent.com/62423083/149564875-33b6663a-4d79-497d-a1bb-d5da0d94a8c0.png)

