### PR TITLE
making test manual to avoid execution errors

### DIFF
--- a/atomics/T1027/T1027.yaml
+++ b/atomics/T1027/T1027.yaml
@@ -184,6 +184,6 @@ atomic_tests:
         certutil —ૹu૰rlࢰca࣢c෯he  –‮spli؅t‮‭ −"൏ᶠ൸" #{remote_file} #{local_path}
 
 
-      2. Press enter to execute the command. You will the file or webpage you specified saved to the file you specified in the command.
+      2. Press enter to execute the command. You will find the file or webpage you specified saved to the file you specified in the command.
 
     name: manual

--- a/atomics/T1027/T1027.yaml
+++ b/atomics/T1027/T1027.yaml
@@ -172,7 +172,7 @@ atomic_tests:
       type: Url
       default: https://raw.githubusercontent.com/redcanaryco/atomic-red-team/master/LICENSE.txt
     local_path:
-      description: Local path to save the file
+      description: Local path/filename to save the dowloaded file to
       type: Path
       default: Atomic-license.txt
   executor:

--- a/atomics/T1027/T1027.yaml
+++ b/atomics/T1027/T1027.yaml
@@ -168,16 +168,22 @@ atomic_tests:
   - windows
   input_arguments:
     remote_file:
-      description: URL of file to copy
+      description: URL of file to download
       type: Url
       default: https://raw.githubusercontent.com/redcanaryco/atomic-red-team/master/LICENSE.txt
     local_path:
-      description: Local path to place file
+      description: Local path to save the file
       type: Path
       default: Atomic-license.txt
   executor:
-    command: |
-      cmd /c certutil —ૹu૰rlࢰca࣢c෯he  –‮spli؅t‮‭ −"൏ᶠ൸" #{remote_file} #{local_path}
-    cleanup_command: |
-      del #{local_path} >nul 2>&1
-    name: command_prompt
+    executor:
+    steps: |
+      1. Copy the following command into the command prompt after replacing #{remote_file} and #{local_path} with your desired URL and filename.
+
+
+        certutil —ૹu૰rlࢰca࣢c෯he  –‮spli؅t‮‭ −"൏ᶠ൸" #{remote_file} #{local_path}
+
+
+      2. Press enter to execute the command. You will the file or webpage you specified saved to the file you specified in the command.
+
+    name: manual


### PR DESCRIPTION
As noted in issue #1696 this atomic was not running correctly using the execution framework. I tried to move the command to a batch file but found the same issue. I moved this test to a "manual" test since for the time being, this is the only way I know to make it work.