### PR TITLE
fix systemd-run tests

### DIFF
--- a/atomics/T1053.006/T1053.006.yaml
+++ b/atomics/T1053.006/T1053.006.yaml
@@ -70,7 +70,7 @@ atomic_tests:
   executor:
     elevation_required: false 
     command: |
-      systemd-run --user --unit=Atomic-Red-Team --on-calender '*:0/1' /bin/sh -c 'echo "$(date) $(whoami)" >>/tmp/log'
+      systemd-run --user --unit=Atomic-Red-Team --on-calendar '*:0/1' /bin/sh -c 'echo "$(date) $(whoami)" >>/tmp/log'
     cleanup_command: |
       systemctl --user stop Atomic-Red-Team.service
       systemctl --user stop Atomic-Red-Team.timer
@@ -94,7 +94,7 @@ atomic_tests:
   executor:
     elevation_required: true 
     command: |
-      systemd-run --unit=Atomic-Red-Team --on-calender '*:0/1' /bin/sh -c 'echo "$(date) $(whoami)" >>/tmp/log'
+      systemd-run --unit=Atomic-Red-Team --on-calendar '*:0/1' /bin/sh -c 'echo "$(date) $(whoami)" >>/tmp/log'
     cleanup_command: |
       systemctl stop Atomic-Red-Team.service
       systemctl stop Atomic-Red-Team.timer


### PR DESCRIPTION
**Details:**
Fixes a typo preventing `systemd-run` with `--on-calendar` from working.

ref: https://man7.org/linux/man-pages/man1/systemd-run.1.html

**Testing:**
local/manual `Invoke-AtomicTest -AtomicTechnique T1053.006`

**Associated Issues:**
N/A