### PR TITLE
T1036.003-2 let sh exit vs forcing hard-timeout

### DIFF
--- a/atomics/T1036.003/T1036.003.yaml
+++ b/atomics/T1036.003/T1036.003.yaml
@@ -27,7 +27,7 @@ atomic_tests:
   executor:
     command: |
       cp /bin/sh /tmp/crond;
-      /tmp/crond
+      echo 'sleep 5' | /tmp/crond
     cleanup_command: |
       rm /tmp/crond
     name: sh


### PR DESCRIPTION
**Details:**
sh with no args doesn't exit until the timeout, feeding it a command to prompt it to exit achieves the MITRE behavior without relying on the external ART timeout. Also on some of my VMs the ART enforced default timeout didn't exit properly, hanging the test.

**Testing:**
local `Invoke-AtomicTest -AtomicTechnique T1036.003 -TestNumbers 2`

**Associated Issues:**
N/A