### PR TITLE
Update T1027.yaml

### DIFF
--- a/atomics/T1027/T1027.yaml
+++ b/atomics/T1027/T1027.yaml
@@ -176,7 +176,6 @@ atomic_tests:
       type: Path
       default: Atomic-license.txt
   executor:
-    executor:
     steps: |
       1. Copy the following command into the command prompt after replacing #{remote_file} and #{local_path} with your desired URL and filename.
 


### PR DESCRIPTION
Remove nested `executor` found by community member!

**Details:**
Nested executor caused atomic-operator to fail. Was reported in Slack.

**Testing:**
No testing was performed.

**Associated Issues:**
N/A