### PR TITLE
T1219 fix errors

### DIFF
--- a/atomics/T1219/T1219.yaml
+++ b/atomics/T1219/T1219.yaml
@@ -11,7 +11,7 @@ atomic_tests:
     command: |
       Invoke-WebRequest -OutFile C:\Users\$env:username\Desktop\TeamViewer_Setup.exe https://download.teamviewer.com/download/TeamViewer_Setup.exe
       $file1 = "C:\Users\" + $env:username + "\Desktop\TeamViewer_Setup.exe"
-      Start-Process $file1 /S;
+      Start-Process -Wait $file1 /S; 
       Start-Process 'C:\Program Files (x86)\TeamViewer\TeamViewer.exe'
     cleanup_command: |-
       $file = 'C:\Program Files (x86)\TeamViewer\uninstall.exe'
@@ -46,8 +46,8 @@ atomic_tests:
     command: |
       Invoke-WebRequest -OutFile C:\Users\$env:username\Desktop\LogMeInIgnition.msi https://secure.logmein.com/LogMeInIgnition.msi
       $file1 = "C:\Users\" + $env:username + "\Desktop\LogMeInIgnition.msi"
-      Start-Process $file1 /S;
-      Start-Process 'C:\Program Files (x86)\LogMeInIgnition\LMIIgnition.exe' "/S"
+      Start-Process -Wait $file1 /quiet;
+      Start-Process 'C:\Program Files (x86)\LogMeIn Ignition\LMIIgnition.exe' "/S"
     cleanup_command: |-
       get-package *'LogMeIn Client'* -ErrorAction Ignore | uninstall-package 
       $file1 = "C:\Users\" + $env:username + "\Desktop\LogMeInIgnition.msi"


### PR DESCRIPTION
Fix errors when try t1219
- add `-Wait` otherwise try to launch exe before installation is finish
- msi use `/quiet` not "/S"
- Fix the path of LMIIgnition.exe

For ScreenConnect did not find the way to start it like the other