### PR TITLE
Fix spelling mistake 'diectory' to 'directory'

### DIFF
--- a/atomics/T1083/T1083.md
+++ b/atomics/T1083/T1083.md
@@ -10,7 +10,7 @@ Many command shell utilities can be used to obtain this information. Examples in
 
 - [Atomic Test #2 - File and Directory Discovery (PowerShell)](#atomic-test-2---file-and-directory-discovery-powershell)
 
-- [Atomic Test #3 - Nix File and Diectory Discovery](#atomic-test-3---nix-file-and-diectory-discovery)
+- [Atomic Test #3 - Nix File and Directory Discovery](#atomic-test-3---nix-file-and-directory-discovery)
 
 - [Atomic Test #4 - Nix File and Directory Discovery 2](#atomic-test-4---nix-file-and-directory-discovery-2)
 
@@ -82,7 +82,7 @@ gci -recurse
 <br/>
 <br/>
 
-## Atomic Test #3 - Nix File and Diectory Discovery
+## Atomic Test #3 - Nix File and Directory Discovery
 Find or discover files on the file system
 
 References:

--- a/atomics/T1083/T1083.yaml
+++ b/atomics/T1083/T1083.yaml
@@ -30,7 +30,7 @@ atomic_tests:
       get-childitem -recurse
       gci -recurse
     name: powershell
-- name: Nix File and Diectory Discovery
+- name: Nix File and Directory Discovery
   auto_generated_guid: ffc8b249-372a-4b74-adcd-e4c0430842de
   description: |
     Find or discover files on the file system


### PR DESCRIPTION
**Details:**
This pull request changes the `Atomic Test #3 - Nix File and Diectory Discovery` to `Atomic Test #3 - Nix File and Directory Discovery`, fixing the spelling mistake in the title and also in the hyperlink.