### PR TITLE
bump navigator layer version

### DIFF
--- a/bin/generate-atomic-docs.rb
+++ b/bin/generate-atomic-docs.rb
@@ -190,7 +190,7 @@ class AtomicRedTeamDocs
 
   def get_layer(techniques, layer_name)
     layer = {
-      "version" => "4.2",
+      "version" => "4.3",
       "name" => layer_name,
       "description" => layer_name + " MITRE ATT&CK Navigator Layer",
       "domain" => "mitre-enterprise",


### PR DESCRIPTION
Bumping the navigator json version avoids a warning when importing the layer to the MITRE ATT&CK Navigator