### PR TITLE
T1550.002 fix test 2

### DIFF
--- a/atomics/T1550.002/T1550.002.yaml
+++ b/atomics/T1550.002/T1550.002.yaml
@@ -75,10 +75,10 @@ atomic_tests:
   - description: |
       CrackMapExec executor must exist on disk at specified location (#{crackmapexec_exe})
     prereq_command: |
-      if(Test-Path #{crackmapexec_exe}) { 0 } else { -1 }
+      if(Test-Path #{crackmapexec_exe}) {exit 0} else {exit 1}
     get_prereq_command: |
       Write-Host Automated installer not implemented yet, please install crackmapexec manually at this location: #{crackmapexec_exe}
   executor:
     command: |
-      crackmapexec #{domain} -u #{user_name} -H #{ntlm} -x #{command}
+      #crackmapexec #{domain} -u #{user_name} -H #{ntlm} -x #{command}
     name: command_prompt

--- a/atomics/T1550.002/T1550.002.yaml
+++ b/atomics/T1550.002/T1550.002.yaml
@@ -80,5 +80,5 @@ atomic_tests:
       Write-Host Automated installer not implemented yet, please install crackmapexec manually at this location: #{crackmapexec_exe}
   executor:
     command: |
-      #crackmapexec #{domain} -u #{user_name} -H #{ntlm} -x #{command}
+      #{crackmapexec_exe} #{domain} -u #{user_name} -H #{ntlm} -x #{command}
     name: command_prompt


### PR DESCRIPTION
**Details:**
![image](https://user-images.githubusercontent.com/62423083/151696601-964056a8-fc12-45b1-be5f-32738f4d2000.png)

Fix : 

- prereq_command (correct ouptut exit)
- executor

**Testing:**
![image](https://user-images.githubusercontent.com/62423083/151696636-25fb46ee-411c-486e-ac07-98ebff1cfb11.png)
test run even if I have #crackmapexec internal error 😄 

**Associated Issues:**
None