### PR TITLE
Automating getprereqs and fixing prereq errors for T1087.001 Test 5

### DIFF
--- a/atomics/T1087.001/T1087.001.yaml
+++ b/atomics/T1087.001/T1087.001.yaml
@@ -70,6 +70,7 @@ atomic_tests:
       username=$(id -u -n) && lsof -u $username
     name: sh
 - name: Show if a user account has ever logged in remotely
+  auto_generated_guid: 0f0b6a29-08c3-44ad-a30b-47fd996b2110
   description: |
     Show if a user account has ever logged in remotely
   supported_platforms:

--- a/atomics/T1087.001/T1087.001.yaml
+++ b/atomics/T1087.001/T1087.001.yaml
@@ -70,7 +70,6 @@ atomic_tests:
       username=$(id -u -n) && lsof -u $username
     name: sh
 - name: Show if a user account has ever logged in remotely
-  auto_generated_guid: 0f0b6a29-08c3-44ad-a30b-47fd996b2110
   description: |
     Show if a user account has ever logged in remotely
   supported_platforms:
@@ -85,9 +84,9 @@ atomic_tests:
   - description: |
       Check if lastlog command exists on the machine
     prereq_command: |
-      if [ -x "$(command -v lastlog)" ]; then exit 0; else exit 1;
+      if [ -x "$(command -v lastlog)" ]; then exit 0; else exit 1; fi
     get_prereq_command: |
-      echo "Install lastlog on the machine to run the test."; exit 1;
+      sudo apt-get install login; exit 1;
   executor:
     command: |
       lastlog > #{output_file}


### PR DESCRIPTION
Updating T1087.001 Test 5 to automatically install the login package that contains lastlog, as well as resolving an issue with its prereqs that results in an unexpected eof error.

**Testing:**
Tested with Ubuntu and Kali