### PR TITLE
Rundll32 with Control_RunDLL

### DIFF
--- a/atomics/T1218.011/T1218.011.yaml
+++ b/atomics/T1218.011/T1218.011.yaml
@@ -224,3 +224,30 @@ atomic_tests:
     name: command_prompt
     command: | 
       rundll32.exe #{input_file},#2
+- name: Rundll32 with Control_RunDLL
+  auto_generated_guid: e4c04b6f-c492-4782-82c7-3bf75eb8077e
+  description: |
+    Rundll32.exe loading dll with 'control_rundll' within the command-line, loading a .cpl or another file type related to CVE-2021-40444. 
+  supported_platforms:
+      - windows
+  input_arguments:
+    input_url:
+      description: Url to download the DLL
+      type: Url
+      default: https://github.com/redcanaryco/atomic-red-team/raw/master/atomics/T1047/bin/calc.dll
+    input_file:
+      description: DLL File
+      type: String
+      default: PathToAtomicsFolder\T1047\bin\calc.dll
+  dependency_executor_name: powershell 
+  dependencies: 
+  - description: |
+      DLL file must exist on disk at specified location
+    prereq_command: | 
+      if (Test-Path #{input_file}) {exit 0} else {exit 1}
+    get_prereq_command: | 
+      Invoke-WebRequest "#{input_url}" -OutFile "#{input_file}"
+  executor:
+    name: command_prompt
+    command: | 
+      rundll32.exe shell32.dll,Control_RunDLL #{input_file}


### PR DESCRIPTION
**Details:**
Exceute Rundll32.exe loading dll with 'control_rundll' within the command-line

**Testing:**
![image](https://user-images.githubusercontent.com/61369934/153248354-01ade111-6bf3-4be8-8107-13db0e0ee64a.png)

**Associated Issues:**
<!-- Please link any issues that this pull request impacts or fixes. -->