### PR TITLE
T1046 2 fix prerequisites

### DIFF
--- a/atomics/T1046/T1046.yaml
+++ b/atomics/T1046/T1046.yaml
@@ -47,6 +47,12 @@ atomic_tests:
       if [ -x "$(command -v nmap)" ]; then exit 0; else exit 1; fi;
     get_prereq_command: |
       (which yum && yum -y install epel-release nmap)||(which apt-get && DEBIAN_FRONTEND=noninteractive apt-get install -y nmap)
+  - description: |
+      Check if nc command exists on the machine
+    prereq_command: |
+      if [ -x "$(command -v nc)" ]; then exit 0; else exit 1; fi;
+    get_prereq_command: |
+      (which yum && yum -y install epel-release nc)||(which apt-get && DEBIAN_FRONTEND=noninteractive apt-get install -y netcat)
   executor:
     command: |
       nmap -sS #{network_range} -p #{port}

--- a/atomics/T1046/T1046.yaml
+++ b/atomics/T1046/T1046.yaml
@@ -53,6 +53,12 @@ atomic_tests:
       if [ -x "$(command -v nc)" ]; then exit 0; else exit 1; fi;
     get_prereq_command: |
       (which yum && yum -y install epel-release nc)||(which apt-get && DEBIAN_FRONTEND=noninteractive apt-get install -y netcat)
+  - description: |
+      Check if telnet command exists on the machine
+    prereq_command: |
+      if [ -x "$(command -v telnet)" ]; then exit 0; else exit 1; fi;
+    get_prereq_command: |
+      (which yum && yum -y install epel-release telnet)||(which apt-get && DEBIAN_FRONTEND=noninteractive apt-get install -y telnet)
   executor:
     command: |
       nmap -sS #{network_range} -p #{port}

--- a/atomics/T1046/T1046.yaml
+++ b/atomics/T1046/T1046.yaml
@@ -53,6 +53,7 @@ atomic_tests:
       telnet #{host} #{port}
       nc -nv #{host} #{port}
     name: sh
+    elevation_required: true
 - name: Port Scan NMap for Windows
   auto_generated_guid: d696a3cb-d7a8-4976-8eb5-5af4abf2e3df
   description: Scan ports to check for listening ports for the local host 127.0.0.1


### PR DESCRIPTION
**Details:**

Testing the T1046-2 I appreciate that the prerequisites were incomplete, since after installed all of them, the test still fails because some depencies that were not installed:
- nc
- telnet
Moreover, nmap displays an error message requiring administrator privileges.

Here are the commands:
```
PS /home/admin> Invoke-AtomicTest T1046 -TestNumbers 2 -CheckPrereqs                                    
PathToAtomicsFolder = /home/admin/AtomicRedTeam/atomics

CheckPrereq's for: T1046-2 Port Scan Nmap                                                               
Prerequisites met: T1046-2 Port Scan Nmap                                                               
PS /home/admin> Invoke-AtomicTest T1046 -TestNumbers 2 -GetPrereqs                                      
PathToAtomicsFolder = /home/admin/AtomicRedTeam/atomics

GetPrereq's for: T1046-2 Port Scan Nmap                                                                 
Attempting to satisfy prereq: Check if nmap command exists on the machine                               
Prereq already met: Check if nmap command exists on the machine    
PS /home/admin> Invoke-AtomicTest T1046 -TestNumbers 2
PathToAtomicsFolder = /home/admin/AtomicRedTeam/atomics

Executing test: T1046-2 Port Scan Nmap                                                                  
Done executing test: T1046-2 Port Scan Nmap                                                             
You requested a scan type which requires root privileges.                                               
QUITTING!                                                                                               
/usr/bin/sh: 1: telnet: not found                                                                       
/usr/bin/sh: 1: nc: not found 
```

Therefore I added 3 prerequisites:
- elevation_required: true -> required for nmap
- netcat check and installation
- telnet check and installation

**Testing:**
For testing I reinvoke the test with the new yaml file on a Debian machine, and check the correct packages on Centos machine.

**Other:**

I would like to suggest, after fixing the issue, to separate this test in several ones, one per tool used, or rename the test, since "nmap scan" is confusing since telnet and netcat are also used.