### PR TITLE
update script link

### DIFF
--- a/atomics/T1059.006/T1059.006.yaml
+++ b/atomics/T1059.006/T1059.006.yaml
@@ -10,7 +10,7 @@ atomic_tests:
       script_url: 
         description: Shell script public URL
         type: String
-        default: https://raw.githubusercontent.com/carlospolop/privilege-escalation-awesome-scripts-suite/master/linPEAS/linpeas.sh
+        default: https://github.com/carlospolop/PEASS-ng/releases/download/20220214/linpeas.sh
       payload_file_name: 
         description: Name of shell script downloaded from the script_url
         type: String
@@ -51,7 +51,7 @@ atomic_tests:
       script_url: 
         description: Shell script public URL
         type: String
-        default: https://raw.githubusercontent.com/carlospolop/privilege-escalation-awesome-scripts-suite/master/linPEAS/linpeas.sh
+        default: https://github.com/carlospolop/PEASS-ng/releases/download/20220214/linpeas.sh
       payload_file_name: 
         description: Shell script file name downloaded from the script_url
         type: String
@@ -104,7 +104,7 @@ atomic_tests:
       script_url: 
         description: URL hosting external malicious payload
         type: String
-        default: https://raw.githubusercontent.com/carlospolop/privilege-escalation-awesome-scripts-suite/master/linPEAS/linpeas.sh
+        default: https://github.com/carlospolop/PEASS-ng/releases/download/20220214/linpeas.sh
       payload_file_name: 
         description: Shell script file name downloaded from the script_url
         type: String


### PR DESCRIPTION
Old link gave 404. Also new link uses permalink instead of pointing to "master" which can change over time.