### PR TITLE
github perm url

### DIFF
--- a/atomics/T1059.004/T1059.004.yaml
+++ b/atomics/T1059.004/T1059.004.yaml
@@ -81,7 +81,7 @@ atomic_tests:
     linenum_url:
       description: Path to download LinEnum shell script
       type: Url
-      default: https://raw.githubusercontent.com/rebootuser/LinEnum/master/LinEnum.sh
+      default: https://raw.githubusercontent.com/rebootuser/LinEnum/c47f9b226d3ce2848629f25fe142c1b2986bc427/LinEnum.sh
   dependency_executor_name: bash
   dependencies:
   - description: |

--- a/atomics/T1110.004/T1110.004.yaml
+++ b/atomics/T1110.004/T1110.004.yaml
@@ -54,7 +54,7 @@ atomic_tests:
       prereq_command: |
         if [ -x "$(command -v sshpass)" ]; then exit 0; else exit 1; fi;
       get_prereq_command: |
-        /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
+        /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/e8114640740938c20cc41ffdbf07816b428afc49/install.sh)"
         brew install hudochenkov/sshpass/sshpass
 
   executor:


### PR DESCRIPTION
Using github permanent urls instead of pointing to Master so that tests don't change out-of-band