### PR TITLE
Sigma sysmon_susp_mic_cam_access

### DIFF
--- a/atomics/T1123/T1123.yaml
+++ b/atomics/T1123/T1123.yaml
@@ -11,4 +11,15 @@ atomic_tests:
     command: |
       powershell.exe -Command WindowsAudioDevice-Powershell-Cmdlet
     name: powershell
-
+- name: Registry artefact when application use microphone
+  description: |
+    [can-you-track-processes-accessing-the-camera-and-microphone](https://svch0st.medium.com/can-you-track-processes-accessing-the-camera-and-microphone-7e6885b37072)
+  supported_platforms:
+  - windows
+  executor:
+    command: |
+      reg add HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\CapabilityAccessManager\ConsentStore\microphone\NonPackaged\C:#Windows#Temp#atomic.exe /v LastUsedTimeStart /t REG_BINARY /d a273b6f07104d601 /f
+      reg add HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\CapabilityAccessManager\ConsentStore\microphone\NonPackaged\C:#Windows#Temp#atomic.exe /v LastUsedTimeStop /t REG_BINARY /d 96ef514b7204d601 /f
+    cleanup_command: |
+      reg DELETE HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\CapabilityAccessManager\ConsentStore\microphone\NonPackaged\C:#Windows#Temp#atomic.exe /f
+    name: command_prompt

--- a/atomics/T1125/T1125.yaml
+++ b/atomics/T1125/T1125.yaml
@@ -1,0 +1,15 @@
+attack_technique: T1125
+display_name: Video Capture
+atomic_tests:
+- name: Registry artefact when application use webcam
+  description: |
+    [can-you-track-processes-accessing-the-camera-and-microphone](https://svch0st.medium.com/can-you-track-processes-accessing-the-camera-and-microphone-7e6885b37072)
+  supported_platforms:
+  - windows
+  executor:
+    command: |
+      reg add HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\CapabilityAccessManager\ConsentStore\webcam\NonPackaged\C:#Windows#Temp#atomic.exe /v LastUsedTimeStart /t REG_BINARY /d a273b6f07104d601 /f
+      reg add HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\CapabilityAccessManager\ConsentStore\webcam\NonPackaged\C:#Windows#Temp#atomic.exe /v LastUsedTimeStop /t REG_BINARY /d 96ef514b7204d601 /f
+    cleanup_command: |
+      reg DELETE HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\CapabilityAccessManager\ConsentStore\webcam\NonPackaged\C:#Windows#Temp#atomic.exe /f
+    name: command_prompt


### PR DESCRIPTION
**Details:**
Add test from SigmaHQ sysmon_susp_mic_cam_access.yml
leaves the normal traces of an application in the registry...

**Testing:**
![image](https://user-images.githubusercontent.com/62423083/154851407-adccb63a-922b-4cc3-a4e8-228f42ec8486.png)

**Associated Issues:**
None