### PR TITLE
Initial creation of BlackByte Ransomware Registry Changes atomic

### DIFF
--- a/atomics/T1112/T1112.yaml
+++ b/atomics/T1112/T1112.yaml
@@ -108,3 +108,27 @@ atomic_tests:
     cleanup_command: |
       try { Set-ExecutionPolicy -ExecutionPolicy #{default_execution_policy} -Scope LocalMachine -Force } catch {}
     name: powershell
+- name: BlackByte Ransomware Registry Changes
+  auto_generated_guid: 
+  description: |
+    This task recreates the steps taken by BlackByte ransomware before it worms to other machines.  See "Preparing to Worm" section: https://redcanary.com/blog/blackbyte-ransomware/
+    The steps are as follows:
+    <ol>
+        <li>1. Elevate Local Privilege by disabling UAC Remote Restrictions</li>
+        <li>2. Enable OS to share network connections between different privilege levels</li>
+        <li>3. Enable long path values for file paths, names, and namespaces to ensure encryption of all file names and paths</li>
+    </ol>
+    The registry keys and their respective values will be created upon successful execution.
+  supported_platforms:
+  - windows
+  executor:
+    command: |
+      cmd.exe /c reg add HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System /v LocalAccountTokenFilterPolicy /t REG_DWORD /d 1 /f
+      cmd.exe /c reg add HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System /v EnableLinkedConnections /t REG_DWORD /d 1 /f
+      cmd.exe /c reg add HKLM\SYSTEM\CurrentControlSet\Control\FileSystem /v LongPathsEnabled /t REG_DWORD /d 1 /f
+    cleanup_command: |
+      reg delete HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System\ /v LocalAccountTokenFilterPolicy /f 2>&1
+      reg delete HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System\ /v EnableLinkedConnections /f 2>&1
+      reg delete HKLM\SYSTEM\CurrentControlSet\Control\FileSystem\ /v LongPathsEnabled /f 2>&1
+    name: command_prompt
+    elevation_required: true

--- a/atomics/T1112/T1112.yaml
+++ b/atomics/T1112/T1112.yaml
@@ -108,8 +108,7 @@ atomic_tests:
     cleanup_command: |
       try { Set-ExecutionPolicy -ExecutionPolicy #{default_execution_policy} -Scope LocalMachine -Force } catch {}
     name: powershell
-- name: BlackByte Ransomware Registry Changes
-  auto_generated_guid: 
+- name: BlackByte Ransomware Registry Changes - CMD
   description: |
     This task recreates the steps taken by BlackByte ransomware before it worms to other machines.  See "Preparing to Worm" section: https://redcanary.com/blog/blackbyte-ransomware/
     The steps are as follows:
@@ -132,3 +131,4 @@ atomic_tests:
       reg delete HKLM\SYSTEM\CurrentControlSet\Control\FileSystem\ /v LongPathsEnabled /f 2>&1
     name: command_prompt
     elevation_required: true
+    


### PR DESCRIPTION
**Details:**
This atomic tests for registry changes made by BlackByte ransomware that allows for elevated remote access privileges and long file names which are required before encrypting.

**Testing:**
Windows 10.

**Associated Issues:**
<!-- Please link any issues that this pull request impacts or fixes. -->