### PR TITLE
Adding T1090.003 Test 4 - Tor Proxy Usage on MacOS

### DIFF
--- a/atomics/T1090.003/T1090.003.yaml
+++ b/atomics/T1090.003/T1090.003.yaml
@@ -85,4 +85,25 @@ atomic_tests:
      sudo systemctl start tor 
     cleanup_command: |
      sudo systemctl stop tor
-    name: sh    
+    name: sh
+- name: Tor Proxy Usage - MacOS
+  description: |
+    This test is designed to launch the tor proxy service, which is what is utilized in the background by the Tor Browser and other applications with add-ons in order to provide onion routing functionality.
+    Upon successful execution, the tor proxy service will be launched. 
+  supported_platforms:
+  - macos
+  dependency_executor_name: sh
+  dependencies:
+  - description: |
+     Tor must be installed on the machine 
+    prereq_command: |
+     if [ -x "$(command -v tor --version)" ]; then exit 0; else exit 1; fi
+    get_prereq_command: |
+      if [ ! -x "$(command -v brew --version)" ]; then /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh keystroke return)"; fi
+      brew install tor
+  executor:
+    command: |
+     osascript -e 'tell application "Terminal" to do script "tor"'
+    cleanup_command: |
+     killall tor > /dev/null 2>&1
+    name: sh        


### PR DESCRIPTION
This test is designed to launch the Tor proxy service on MacOS.

**Testing:**
Tested on MacOS Mojave and Catalina. When getting prereqs, my testing found that in Mojave, it can take longer than the 120 second default to finish the prereq install, so it might be best to append "-timeoutseconds 300" or greater to the end of the getprereq command if it fails the first time. 
