### PR TITLE
Adding T1217 Test 8 - List Safari Bookmarks

### DIFF
--- a/atomics/T1217/T1217.yaml
+++ b/atomics/T1217/T1217.yaml
@@ -97,3 +97,20 @@ atomic_tests:
     command: |
       dir /s /b %USERPROFILE%\Favorites
     name: command_prompt
+- name: List Safari Bookmarks on MacOS
+  description: |
+    This test searches for Safari's Bookmarks file (on macOS) and lists any found instances to a text file.
+  supported_platforms:
+  - macos
+  input_arguments:
+    output_file:
+      description: Path where captured results will be placed.
+      type: Path
+      default: /tmp/T1217-Safari.txt
+  executor:
+    command: |
+      find / -path "*/Safari/Bookmarks.plist" 2>/dev/null >> #{output_file} 
+      cat #{output_file} 
+    cleanup_command: |
+      rm -f #{output_file} 2>/dev/null
+    name: sh


### PR DESCRIPTION
Adding T1217 Test 8 - List Safari Bookmarks for MacOS. This test locates any Safari bookmarks files and outputs the file paths to a text document.

**Testing:**
Tested on MacOS Mojave and Catalina. Please note that depending on the size of the drive it is being ran on, this test might take longer than the default 120 seconds. When testing on a 30 GB Mojave VM, the test only took about 20 seconds, but on a 1 TB Catalina physical machine, it took closer to 3.5 minutes. 