### PR TITLE
T1059.005 Fix Cleanup and Prereq

### DIFF
--- a/atomics/T1059.005/T1059.005.yaml
+++ b/atomics/T1059.005/T1059.005.yaml
@@ -19,13 +19,11 @@ atomic_tests:
   - description: Sample script must exist on disk at specified location (#{vbscript})
     prereq_command: 'if (Test-Path #{vbscript}) {exit 0} else {exit 1} '
     get_prereq_command: |-
-      Invoke-WebRequest "https://raw.githubusercontent.com/redcanaryco/atomic-red-team/master/atomics/T1059.005/src/sys_info.vbs" -OutFile "$env:TEMP\sys_info.vbs"
       New-Item -ItemType Directory (Split-Path #{vbscript}) -Force | Out-Null
-      Copy-Item $env:TEMP\sys_info.vbs #{vbscript} -Force
+      Invoke-WebRequest "https://raw.githubusercontent.com/redcanaryco/atomic-red-team/master/atomics/T1059.005/src/sys_info.vbs" -OutFile "#{vbscript}"
   executor:
     command: 'cscript #{vbscript} > $env:TEMP\T1059.005.out.txt'
     cleanup_command: |-
-      Remove-Item $env:TEMP\sys_info.vbs -ErrorAction Ignore
       Remove-Item $env:TEMP\T1059.005.out.txt -ErrorAction Ignore
     name: powershell
 


### PR DESCRIPTION
**Details:**
Fixed the prereq command so that the New-Item came before Invoke-WebRequest and got rid of the Copy. The Invoke -OutFile changed to the vbscript path. On the cleanup command, I got rid of it deleting the vbscript so that the prereq only needs to be run once.

**Testing:**
Tested on Windows10 to make sure that it functioned as expected.

**Associated Issues:**
<!-- Please link any issues that this pull request impacts or fixes. -->