### PR TITLE
Adding T1059.003 Test 4 - BlackByte Print Bombing

### DIFF
--- a/atomics/T1059.003/T1059.003.yaml
+++ b/atomics/T1059.003/T1059.003.yaml
@@ -71,3 +71,33 @@ atomic_tests:
     command: |
       %LOCALAPPDATA:~-3,1%md /c echo #{input_message} > #{output_file} & type #{output_file}
     name: command_prompt
+- name: Simulate BlackByte Ransomware Print Bombing
+  description: |
+    This test attempts to open a file a specified number of times in Wordpad, then prints the contents. 
+    It is designed to mimic BlackByte ransomware's print bombing technique, where tree.dll, which contains the ransom note, is opened in Wordpad 75 times and then printed. 
+    See https://redcanary.com/blog/blackbyte-ransomware/. 
+  supported_platforms:
+  - windows
+  input_arguments:
+    file_to_print:
+      description: File to be opened/printed by Wordpad.
+      type: String
+      default: $env:temp\T1059_003note.txt
+    max_to_print:
+      description: The maximum number of Wordpad windows the test will open/print.
+      type: String
+      default: 75
+  dependency_executor_name: powershell
+  dependencies:
+  - description: |
+      File to print must exist on disk at specified location (#{file_to_print})
+    prereq_command: |
+      if (test-path "#{file_to_print}"){exit 0} else {exit 1}
+    get_prereq_command: |
+      new-item #{file_to_print} -value "This file has been created by T1059.003 Test 4" -Force | Out-Null
+  executor:
+    command: |
+      cmd /c "for /l %x in (1,1,#{max_to_print}) do start wordpad.exe /p #{file_to_print}" | out-null
+    cleanup_command: |
+      stop-process -name wordpad -force -erroraction silentlycontinue
+    name: powershell


### PR DESCRIPTION
**Details:**
Adding T1059.003 Test 4, which is designed to emulate the print bombing behavior observed in recent BlackByte ransomware attacks. In the actual BlackByte ransomware attacks, a Wordpad window is opened 75 times, however, an input argument was created for the number of windows to open on this test so as not to potentially overwhelm/crash a VM. 

**Testing:**
Tested on 3 Windows 10 VMs. 