### PR TITLE
pnputil lolbin

### DIFF
--- a/atomics/T1547/T1547.yaml
+++ b/atomics/T1547/T1547.yaml
@@ -1,0 +1,17 @@
+attack_technique: T1547
+display_name: 'Boot or Logon Autostart Execution'
+atomic_tests:
+- name: Add a driver
+  description: |
+    Install a driver via pnputil.exe lolbin
+  supported_platforms:
+  - windows
+  input_arguments:
+    driver_inf:
+      description: A build-in allready installed windows driver inf
+      type: Path    
+      default: 'C:\Windows\INF\usbstor.inf'
+  executor:
+    command: |
+      pnputil.exe /add-driver "#{driver_inf}"
+    name: command_prompt


### PR DESCRIPTION
**Details:**
Install a driver via pnputil.exe lolbin.
As is not a LSASS driver not use the `T1547.008` 

**Testing:**
Windows 10 21H2

**Associated Issues:**
No cleanup as I use `usbstor.inf` part of windows