### PR TITLE
Fix reg cleanup T1112 Test 9

### DIFF
--- a/atomics/T1112/T1112.yaml
+++ b/atomics/T1112/T1112.yaml
@@ -167,7 +167,7 @@ atomic_tests:
     command: |
       reg add HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\policies\system /v DisableRegistryTools /t REG_DWORD /d 1 /f
     cleanup_command: |
-      powershell powershell Remove-ItemProperty -Path "HKCU:\Software\Microsoft\Windows\CurrentVersion\policies\system" -Name DisableRegistryTools
+      powershell Remove-ItemProperty -Path "HKCU:\Software\Microsoft\Windows\CurrentVersion\policies\system" -Name DisableRegistryTools -ErrorAction Ignore
     name: command_prompt
     elevation_required: true
 - name: Disable Windows CMD application

--- a/atomics/T1112/T1112.yaml
+++ b/atomics/T1112/T1112.yaml
@@ -167,7 +167,7 @@ atomic_tests:
     command: |
       reg add HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\policies\system /v DisableRegistryTools /t REG_DWORD /d 1 /f
     cleanup_command: |
-      reg delete HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\policies\system /v DisableRegistryTools /f >nul 2>&1
+      powershell powershell Remove-ItemProperty -Path "HKCU:\Software\Microsoft\Windows\CurrentVersion\policies\system" -Name DisableRegistryTools
     name: command_prompt
     elevation_required: true
 - name: Disable Windows CMD application


### PR DESCRIPTION
**Details:**
Fix the cleanup option.
As the test deactivates the reg tools, it goes through a powershell command

**Testing:**

![image](https://user-images.githubusercontent.com/62423083/158780736-45714200-f456-4e77-bd33-a7a1e0ddc3a5.png)


**Associated Issues:**
None