### PR TITLE
Fix test 10

### DIFF
--- a/atomics/T1112/T1112.yaml
+++ b/atomics/T1112/T1112.yaml
@@ -179,10 +179,10 @@ atomic_tests:
   - windows
   executor:
     command: |
-      reg add "HKEY_CURRENT_USER\Software\Policies\Microsoft\Windows\System" /v "DisableCMD" /t REG_DWORD /d "1" /f
+      New-ItemProperty -Path "HKCU:\Software\Policies\Microsoft\Windows\System" -Name DisableCMD -Value 1
     cleanup_command: |
-      reg delete "HKEY_CURRENT_USER\Software\Policies\Microsoft\Windows\System" /v "DisableCMD" /f >nul 2>&1
-    name: command_prompt
+      Remove-ItemProperty -Path "HKCU:\Software\Policies\Microsoft\Windows\System" -Name DisableCMD -ErrorAction Ignore
+    name: powershell
     elevation_required: true
 - name: Disable Windows Task Manager application
   auto_generated_guid: af254e70-dd0e-4de6-9afe-a994d9ea8b62


### PR DESCRIPTION
**Details:**
As cmd is disable `cleanup_command` failed
So change to powershell executor

**Testing:**
![image](https://user-images.githubusercontent.com/62423083/159117052-b65290db-0b80-429c-9c25-a68aefc1b18d.png)

Cmd is disable and open with a message like  "your administrator have..." (My is in French :wink:) 
after Cleanup cmd is back

**Associated Issues:**
close #1817