### PR TITLE
Fix T1112 test 33-34

### DIFF
--- a/atomics/T1112/T1112.yaml
+++ b/atomics/T1112/T1112.yaml
@@ -527,7 +527,7 @@ atomic_tests:
   - windows
   executor:
     command: |
-      REG ADD "HKLM\SYSTEM\CurrentControlSet\Control\SafeBoot\Minimal\AtomicSafeMode" /VE /T REG_SZ /F /D “Service”
+      REG ADD "HKLM\SYSTEM\CurrentControlSet\Control\SafeBoot\Minimal\AtomicSafeMode" /VE /T REG_SZ /F /D "Service"
     cleanup_command: |
       reg delete "HKLM\SYSTEM\CurrentControlSet\Control\SafeBoot\Minimal\AtomicSafeMode" /f
     name: command_prompt
@@ -542,7 +542,7 @@ atomic_tests:
   - windows
   executor:
     command: |
-      REG ADD "HKLM\SYSTEM\CurrentControlSet\Control\SafeBoot\Network\AtomicSafeMode" /VE /T REG_SZ /F /D “Service”
+      REG ADD "HKLM\SYSTEM\CurrentControlSet\Control\SafeBoot\Network\AtomicSafeMode" /VE /T REG_SZ /F /D "Service"
     cleanup_command: |
       reg delete "HKLM\SYSTEM\CurrentControlSet\Control\SafeBoot\Network\AtomicSafeMode" /f
     name: command_prompt


### PR DESCRIPTION
**Details:**
fix bad `“Service”` to `"Service"`

PS the `"` can be remove as the string to put in Default have no space .

**Testing:**
Windows 10x64 + Sysnon + Aurora (Sigma rule)

**Associated Issues:**
None