### PR TITLE
Update T1082.yaml - Add System Integrity Protection status (MacOS)

### DIFF
--- a/atomics/T1082/T1082.yaml
+++ b/atomics/T1082/T1082.yaml
@@ -146,3 +146,12 @@ atomic_tests:
     command: |
       env
     name: sh
+- name: Show System Integrity Protection status (MacOS)
+  description: |
+    Read and Display System Intergrety Protection status. csrutil is commonly used by malware and post-exploitation tools to determine whether certain files and directories on the system are writable or not.
+  supported_platforms:
+  - macos
+    executor:
+    command: |
+      csrutil status
+    name: sh

--- a/atomics/T1082/T1082.yaml
+++ b/atomics/T1082/T1082.yaml
@@ -152,6 +152,6 @@ atomic_tests:
   supported_platforms:
   - macos
     executor:
-    command: |
-      csrutil status
+      command: |
+        csrutil status
     name: sh

--- a/atomics/T1082/T1082.yaml
+++ b/atomics/T1082/T1082.yaml
@@ -151,7 +151,7 @@ atomic_tests:
     Read and Display System Intergrety Protection status. csrutil is commonly used by malware and post-exploitation tools to determine whether certain files and directories on the system are writable or not.
   supported_platforms:
   - macos
-    executor:
-      command: |
-        csrutil status
+  executor:
+    command: |
+      csrutil status
     name: sh


### PR DESCRIPTION
**Details:**
csrutil is commonly used by malware and post-exploitation tools to determine whether certain files and directories on the system are writable or not. This command checks and displays System Integrity Protection status.

**Testing:**
Copy pasted commands into terminal window to confirm. tested on Monterey 12.3.1

**Associated Issues:**
