### PR TITLE
Update T1489 - Add Kill for macOS and Linux

### DIFF
--- a/atomics/T1489/T1489.yaml
+++ b/atomics/T1489/T1489.yaml
@@ -66,9 +66,8 @@ atomic_tests:
   - macos
   - linux
   input_arguments:
-    process_pid: |
-      Process ID of a running service, to list running processes run ps aux
-      description: 
+    process_name:
+      description: Process ID of a running service, to list running processes run ps aux
       type: String
       default: kill
   executor:

--- a/atomics/T1489/T1489.yaml
+++ b/atomics/T1489/T1489.yaml
@@ -67,12 +67,12 @@ atomic_tests:
   - linux
   input_arguments:
     process_name:
-      description: Process ID of a running service, to list running processes run ps aux
+      description: PID of a running service, to list running processes run ps aux
       type: String
       default: kill
   executor:
     command: |
-      kill -9 #{process_pid}
+      kill -9 #{process_name}
     name: sh
 
 

--- a/atomics/T1489/T1489.yaml
+++ b/atomics/T1489/T1489.yaml
@@ -59,4 +59,33 @@ atomic_tests:
     command: |
       taskkill.exe /f /im #{process_name}
     name: command_prompt
+- name: MacOS - Stop service by killing process
+  description: |
+    Stops a specified service killng the service's process.
+  supported_platforms:
+  - MacOS
+  - Linux
+  input_arguments:
+    process_pid: |
+      Process ID of a running service, to list running processes run 
+      ps aux
+      description: 
+      type: String
+      default: kill
+  executor:
+    command: |
+      kill -9 #{process_pid}
+    name: sh
+
+
+
+
+
+
+
+
+
+
+
+
 

--- a/atomics/T1489/T1489.yaml
+++ b/atomics/T1489/T1489.yaml
@@ -63,7 +63,7 @@ atomic_tests:
   description: |
     Stops a specified service killng the service's process.
   supported_platforms:
-  - MacOS
+  - macos
   - Linux
   input_arguments:
     process_pid: |

--- a/atomics/T1489/T1489.yaml
+++ b/atomics/T1489/T1489.yaml
@@ -67,8 +67,7 @@ atomic_tests:
   - linux
   input_arguments:
     process_pid: |
-      Process ID of a running service, to list running processes run 
-      ps aux
+      Process ID of a running service, to list running processes run ps aux
       description: 
       type: String
       default: kill

--- a/atomics/T1489/T1489.yaml
+++ b/atomics/T1489/T1489.yaml
@@ -67,16 +67,18 @@ atomic_tests:
   - linux
   input_arguments:
     process_name:
-      description: PID of a running service, to list running processes run ps aux
+      description: PID of a running service, to list running processes run ps aux or use for macos run |
+      launchctl list |
+      or linux run |
+      systemctl list-units --type=service
       type: String
-      default: kill
+      default: kill -9 $(pgrep cron)
   executor:
     command: |
-      kill -9 #{process_name}
+      kill -9 $(pgrep #{service_name})
     name: sh
-
-
-
+    elevation_required: true
+elevation_required: true
 
 
 

--- a/atomics/T1489/T1489.yaml
+++ b/atomics/T1489/T1489.yaml
@@ -64,7 +64,7 @@ atomic_tests:
     Stops a specified service killng the service's process.
   supported_platforms:
   - macos
-  - Linux
+  - linux
   input_arguments:
     process_pid: |
       Process ID of a running service, to list running processes run 


### PR DESCRIPTION
Add Kill command for macOS and Linux

**Details:**
Add Kill command for macOS and Linux

**Testing:**
Tested on MacOS and Ubuntu 

