### PR TITLE
Surround time variable in single quotes

### DIFF
--- a/atomics/T1053.005/T1053.005.yaml
+++ b/atomics/T1053.005/T1053.005.yaml
@@ -159,7 +159,7 @@ atomic_tests:
   executor:
     command: |
       reg add HKCU\SOFTWARE\ATOMIC-T1053.005 /v test /t REG_SZ /d cGluZyAxMjcuMC4wLjE= /f
-      schtasks.exe /Create /F /TN "ATOMIC-T1053.005" /TR "cmd /c start /min \"\" powershell.exe -Command IEX([System.Text.Encoding]::ASCII.GetString([System.Convert]::FromBase64String((Get-ItemProperty -Path HKCU:\\SOFTWARE\\ATOMIC-T1053.005).test)))" /sc daily /st #{time}
+      schtasks.exe /Create /F /TN "ATOMIC-T1053.005" /TR "cmd /c start /min \"\" powershell.exe -Command IEX([System.Text.Encoding]::ASCII.GetString([System.Convert]::FromBase64String((Get-ItemProperty -Path HKCU:\\SOFTWARE\\ATOMIC-T1053.005).test)))" /sc daily /st #{'time'}
     cleanup_command: |
       schtasks /delete /tn "ATOMIC-T1053.005" /F >nul 2>&1
       reg delete HKCU\SOFTWARE\ATOMIC-T1053.005 /F >nul 2>&1

--- a/atomics/T1053.005/T1053.005.yaml
+++ b/atomics/T1053.005/T1053.005.yaml
@@ -155,11 +155,11 @@ atomic_tests:
     time:
       description: Daily scheduled task execution time
       type: string
-      default: 07:45
+      default: '07:45'
   executor:
     command: |
       reg add HKCU\SOFTWARE\ATOMIC-T1053.005 /v test /t REG_SZ /d cGluZyAxMjcuMC4wLjE= /f
-      schtasks.exe /Create /F /TN "ATOMIC-T1053.005" /TR "cmd /c start /min \"\" powershell.exe -Command IEX([System.Text.Encoding]::ASCII.GetString([System.Convert]::FromBase64String((Get-ItemProperty -Path HKCU:\\SOFTWARE\\ATOMIC-T1053.005).test)))" /sc daily /st #{'time'}
+      schtasks.exe /Create /F /TN "ATOMIC-T1053.005" /TR "cmd /c start /min \"\" powershell.exe -Command IEX([System.Text.Encoding]::ASCII.GetString([System.Convert]::FromBase64String((Get-ItemProperty -Path HKCU:\\SOFTWARE\\ATOMIC-T1053.005).test)))" /sc daily /st #{time}
     cleanup_command: |
       schtasks /delete /tn "ATOMIC-T1053.005" /F >nul 2>&1
       reg delete HKCU\SOFTWARE\ATOMIC-T1053.005 /F >nul 2>&1


### PR DESCRIPTION
The time in the YAML file should be wrapped in single quotes due to the colon being interpreted to have special meaning.

**Details:**
The colon in the time value is interpreted to have a special meaning, so it should be wrapped by single quotes to ensure the time value inserted is recognized by schtasks

**Testing:**
<!-- Note any testing done, local or automated here. -->

**Associated Issues:**
The current MD generated by the YAML shows the time as 27900 likely due to the missing quotes in the time variable within the YAML code. 