### PR TITLE
Fix prereq_command test 2

### DIFF
--- a/atomics/T1564.006/T1564.006.yaml
+++ b/atomics/T1564.006/T1564.006.yaml
@@ -90,15 +90,17 @@ atomic_tests:
     prereq_command: |
       if (Test-Path "#{virtualbox_exe}") {exit 0} else {exit 1}
     get_prereq_command: |
-      Invoke-WebRequest "#{virtualbox_download}" -OutFile $env:TEMP\#{virtualbox_installer}
-      $env:TEMP\#{virtualbox_installer}
+      $wc = New-Object System.Net.WebClient
+      $wc.DownloadFile("#{virtualbox_download}","$env:TEMP\#{virtualbox_installer}")
+      start-process -FilePath "$env:TEMP\#{virtualbox_installer}" -ArgumentList "--silent" -Wait
   - description: |
       VBoxManage must exist on disk at specified locations (#{vboxmanage_exe})
     prereq_command: |
       if (Test-Path "#{vboxmanage_exe}") {exit 0} else {exit 1}
     get_prereq_command: |
-      Invoke-WebRequest "#{virtualbox_download}" -OutFile $env:TEMP\#{virtualbox_installer}
-      $env:TEMP\#{virtualbox_installer}
+      $wc = New-Object System.Net.WebClient
+      $wc.DownloadFile("#{virtualbox_download}","$env:TEMP\#{virtualbox_installer}")
+      start-process -FilePath "$env:TEMP\#{virtualbox_installer}" -ArgumentList "--silent" -Wait
   executor:
     name: command_prompt
     elevation_required: false


### PR DESCRIPTION
**Details:**
`prereq_command` did not work.

**Testing:**
Windows 10 x64 without virtualbox
![image](https://user-images.githubusercontent.com/62423083/162566846-d518a497-e260-4e7a-b8f6-4e0f25727e01.png)

**Associated Issues:**
Can not find a way to fix cleanup (need to be run twice)