### PR TITLE
Add T1195 Octopus windows RAT dropper

### DIFF
--- a/atomics/T1195/T1195.yml
+++ b/atomics/T1195/T1195.yml
@@ -1,0 +1,33 @@
+attack_technique: T1195
+display_name: Supply Chain Compromise 
+atomic_tests:
+- name: Octopus Scanner Malware Open Source Supply Chain
+  auto_generated_guid: 3c73d728-75fb-4180-a12f-6712864d7421
+  description: |
+    This test simulates an adversary Octupus drop the RAT dropper ExplorerSync.db
+    [octopus-scanner-malware-open-source-supply-chain](https://securitylab.github.com/research/octopus-scanner-malware-open-source-supply-chain/)
+    [the-supreme-backdoor-factory](https://www.dfir.it/blog/2019/02/26/the-supreme-backdoor-factory/)
+  supported_platforms:
+  - windows
+  input_arguments:
+    rat_payload:
+      description: RAT dropper ExplorerSync.db
+      type: Path
+      default: $env:TEMP\ExplorerSync.db
+  dependency_executor_name: powershell
+  dependencies:
+  - description: |
+      ExplorerSync.db must exist on disk at specified location (#{rat_payload})
+    prereq_command: |
+      if (Test-Path #{rat_payload}) {exit 0} else {exit 1}
+    get_prereq_command: |
+      Out-File -FilePath "#{rat_payload}"
+  executor:
+    command: |
+      copy %temp%\ExplorerSync.db %temp%\..\Microsoft\ExplorerSync.db
+      schtasks /create /tn ExplorerSync /tr "javaw -jar %temp%\..\Microsoft\ExplorerSync.db" /sc MINUTE /f
+    cleanup_command: |
+      schtasks /delete /tn ExplorerSync /F 2>null
+      del %temp%\..\Microsoft\ExplorerSync.db 2>null
+      del %temp%\ExplorerSync.db 2>null
+    name: command_prompt


### PR DESCRIPTION
**Details:**
Add T1195 Octopus windows RAT dropper 
prereg create a empty "ExplorerSync.db" not the real malware payload 
simulate this part 
![image](https://user-images.githubusercontent.com/62423083/162616253-1a72edc9-8cf3-4990-aed3-ed4ebd4d757d.png)


**Testing:**
![image](https://user-images.githubusercontent.com/62423083/162616149-c4bdb918-9ed7-4e39-924f-ae280a74598d.png)

aurora catch [file_event_win_mal_octopus_scanner](https://github.com/frack113/sigma/blob/a3457babca02d32416298301492cbf880436865e/rules/windows/file_event/file_event_win_mal_octopus_scanner.yml)

**Associated Issues:**
None