### PR TITLE
Rewriting T1036 Test 1 in Powershell

### DIFF
--- a/atomics/T1036/T1036.yaml
+++ b/atomics/T1036/T1036.yaml
@@ -8,10 +8,12 @@ atomic_tests:
   - windows
   executor:
     command: |-
-      copy %WINDIR%\System32\cmd.exe /Y %ALLUSERSPROFILE%\cmd.exe
-      start %ALLUSERSPROFILE%\cmd.exe
-    cleanup_command: del %ALLUSERSPROFILE%\cmd.exe >nul 2>&1
-    name: command_prompt
+      copy-item "$env:windir\System32\cmd.exe" -destination "$env:allusersprofile\cmd.exe"
+      start-process "$env:allusersprofile\cmd.exe"
+      sleep -s 5 
+      stop-process -name "cmd" | out-null
+    cleanup_command: remove-item "$env:allusersprofile\cmd.exe" -force -erroraction silentlycontinue
+    name: powershell
 - name: Malware Masquerading and Execution from Zip File
   auto_generated_guid: 4449c89b-ec82-43a4-89c1-91e2f1abeecc
   description: When the file is unzipped and the README.cmd file opened, it executes and changes the .pdf to .dll and executes the dll. This is a BazaLoader technique [as reported here](https://twitter.com/ffforward/status/1481672378639912960)


### PR DESCRIPTION
**Details:**
Rewriting T1036 test 1 in Powershell. With the way the test was written in command prompt previously, it would cause automatic execution to halt due to the fact that copying cmd.exe to another location using command prompt creates a lock on the process, preventing it from being successfully copied. Additionally, added commands to kill the new command prompt window after 5 seconds so that there is not a spare command prompt window left open. 

**Testing:**
Tested on 2 Windows 10 machines. 

**Associated Issues:**
See details. I don't believe there are any open issues for this in Github. 