### PR TITLE
T1197-3: Update timeout command to ping

### DIFF
--- a/atomics/T1197/T1197.yaml
+++ b/atomics/T1197/T1197.yaml
@@ -79,7 +79,7 @@ atomic_tests:
       bitsadmin.exe /addfile #{bits_job_name} #{remote_file} #{local_file}
       bitsadmin.exe /setnotifycmdline #{bits_job_name} #{command_path} NULL
       bitsadmin.exe /resume #{bits_job_name}
-      timeout 5
+      ping -n 5 127.0.0.1 >nul 2>&1
       bitsadmin.exe /complete #{bits_job_name}
     cleanup_command: |
       del #{local_file} >nul 2>&1


### PR DESCRIPTION
**Details:**
The "timeout" command doesn't work in batch scripts or otherwise background-ed command prompts. If you run the T1197-3 command using "Invoke-Atomic" then you will see the following error and the technique will fail.

```
ERROR: Input redirection is not supported, exiting the process immediately.
```

As an alternative we can use the `ping` utility and just specify that it should only send 5 packets (1 second / packet = 5 seconds).

**Testing:**
Works on my machine 😄 In all seriousness though this is a minor change that just uses the `ping` utility.

**Associated Issues:**
See details