### PR TITLE
T1105: Update timeout to ping

### DIFF
--- a/atomics/T1105/src/T1105.bat
+++ b/atomics/T1105/src/T1105.bat
@@ -11,6 +11,6 @@ cmdl32 /vpn /lan %temp%\T1105\setting.txt
 icacls %temp%\T1105 /remove:d %username%
 move %temp%\T1105\*.tmp %temp%\T1105\file.exe
 %temp%\T1105\file.exe
-timeout /T 10
+ping -n 10 127.0.0.1 >nul 2>&1
 Taskkill /IM notepad.exe /F
 Taskkill /IM Calculator.exe /F


### PR DESCRIPTION
**Details:**
Hey folks, I submitted a PR request yesterday for the same thing I found again today in a different technique (https://github.com/redcanaryco/atomic-red-team/pull/1865). 

The "timeout" command doesn't work in batch scripts or otherwise background-ed command prompts. If you run the T1105-20 command using "Invoke-Atomic" then you will see the following error and the technique will fail.

```
ERROR: Input redirection is not supported, exiting the process immediately.
```

As an alternative we can use the ping utility and just specify that it should only send 10 packets (1 second / packet = 10 seconds).

**Testing:**
Minor change that uses `ping`.

**Associated Issues:**
See details
