### PR TITLE
Add simple T1039 tests

### DIFF
--- a/atomics/T1039/T1039.yaml
+++ b/atomics/T1039/T1039.yaml
@@ -1,0 +1,85 @@
+attack_technique: T1039
+display_name: Data from Network Shared Drive 
+atomic_tests:
+- name: Copy a sensitive File over Administive share with copy
+  description: |-
+    Copy from sensitive File from the c$ of another LAN computer with copy cmd
+    https://twitter.com/SBousseaden/status/1211636381086339073
+  supported_platforms:
+  - windows
+  input_arguments:
+    remote:
+      description: Remote server name 
+      type: string
+      default: '127.0.0.1'
+    share_file:
+      description: Remote Path to the file
+      type: Path
+      default: Windows\temp\Easter_Bunny.password
+    local_file:
+      description: Local name
+      type: string
+      default: 'Easter_egg.password'  
+  dependency_executor_name: powershell
+  dependencies:
+    - description: |
+        Administrative share must exist on #{remote}
+      prereq_command: |
+        if (Test-Path "\\#{remote}\C$") {exit 0} else {exit 1}
+      get_prereq_command: |
+        Write-Host 'Please Enable "C$" share on #{remote}'
+    - description: |
+        "\\#{remote}\C$\#{share_file}" must exist on #{remote}
+      prereq_command: |
+        if (Test-Path "\\#{remote}\C$\#{share_file}") {exit 0} else {exit 1}
+      get_prereq_command: |
+        Out-File -FilePath "\\#{remote}\C$\#{share_file}"
+  executor:
+    command: |-
+      copy \\#{remote}\C$\#{share_file} %TEMP%\#{local_file}
+    cleanup_command: |-
+      del \\#{remote}\C$\#{share_file}
+      del %TEMP%\#{local_file}
+    name: command_prompt
+    elevation_required: true
+- name: Copy a sensitive File over Administive share with Powershell
+  description: |-
+    Copy from sensitive File from the c$ of another LAN computer with powershell
+    https://twitter.com/SBousseaden/status/1211636381086339073
+  supported_platforms:
+  - windows
+  input_arguments:
+    remote:
+      description: Remote server name 
+      type: string
+      default: '127.0.0.1'
+    share_file:
+      description: Remote Path to the file
+      type: Path
+      default: Windows\temp\Easter_Bunny.password
+    local_file:
+      description: Local name
+      type: string
+      default: 'Easter_egg.password'  
+  dependency_executor_name: powershell
+  dependencies:
+    - description: |
+        Administrative share must exist on #{remote}
+      prereq_command: |
+        if (Test-Path "\\#{remote}\C$") {exit 0} else {exit 1}
+      get_prereq_command: |
+        Write-Host 'Please Enable "C$" share on #{remote}'
+    - description: |
+        "\\#{remote}\C$\#{share_file}" must exist on #{remote}
+      prereq_command: |
+        if (Test-Path "\\#{remote}\C$\#{share_file}") {exit 0} else {exit 1}
+      get_prereq_command: |
+        Out-File -FilePath "\\#{remote}\C$\#{share_file}"
+  executor:
+    command: |-
+      copy-item -Path "\\#{remote}\C$\#{share_file}" -Destination "$Env:TEMP\#{local_file}"
+    cleanup_command: |-
+      Remove-Item -Path "\\#{remote}\C$\#{share_file}"
+      Remove-Item -Path "$Env:TEMP\#{local_file}"
+    name: powershell
+    elevation_required: true 


### PR DESCRIPTION
**Details:**
Very simple tests to copy over admin share
match sigma [proc_creation_win_susp_copy_lateral_movement.yml](https://github.com/SigmaHQ/sigma/blob/f4a696471f2d8868a1a730213354736cd2d59933/rules/windows/process_creation/proc_creation_win_susp_copy_lateral_movement.yml)

**Testing:**
windows 10

![image](https://user-images.githubusercontent.com/62423083/163708329-9fbe5ff8-4295-4849-85b9-e225e43e5042.png)

![image](https://user-images.githubusercontent.com/62423083/163708360-1fbbd21b-8695-42a8-a6dd-7951ddab15f5.png)


**Associated Issues:**
English spelling mistakes