### PR TITLE
T1546.012: change target_binary path

### DIFF
--- a/atomics/T1546.012/T1546.012.yaml
+++ b/atomics/T1546.012/T1546.012.yaml
@@ -11,7 +11,7 @@ atomic_tests:
     target_binary:
       description: Binary To Attach To
       type: Path
-      default: C:\Windows\System32\calc.exe
+      default: calc.exe
     payload_binary:
       description: Binary To Execute
       type: Path
@@ -33,7 +33,7 @@ atomic_tests:
     target_binary:
       description: Binary To Attach To
       type: Path
-      default: C:\Windows\System32\notepad.exe
+      default: notepad.exe
     payload_binary:
       description: Binary To Execute
       type: Path


### PR DESCRIPTION
**Details:**
In current version of code target_binary: default: creating following registry keys: "C:", "Windows", "System32" and then "notepad.exe" or "calc.exe" which is incorrect and we should create key with filename only how its done in other registry keys

**Testing:**
Tested on Windows 10 x64

**Associated Issues:**
None