### PR TITLE
Fix T1574.006-1 CleanUp

### DIFF
--- a/atomics/T1574.006/T1574.006.yaml
+++ b/atomics/T1574.006/T1574.006.yaml
@@ -30,7 +30,7 @@ atomic_tests:
     command: |
       sudo sh -c 'echo #{path_to_shared_library} > /etc/ld.so.preload'
     cleanup_command: |
-      sudo sed -i '\~#{path_to_shared_library}~d' /etc/ld.so.preload
+      sudo sed -i 's##{path_to_shared_library}##' /etc/ld.so.preload
     name: bash
     elevation_required: true
 - name: Shared Library Injection via LD_PRELOAD


### PR DESCRIPTION
Fix sed syntax to properly remove the test library from ld.so.preload.

**Details:**
The CleanUp function was throwing a sed expression error and thus failing to clean up ld.so.preload.

**Testing:**
Tested manually and works as expected.

**Associated Issues:**
T1674.006-1