### PR TITLE
Updating T1547.003 to stop w32time first

### DIFF
--- a/atomics/T1547.003/T1547.003.yaml
+++ b/atomics/T1547.003/T1547.003.yaml
@@ -14,6 +14,7 @@ atomic_tests:
   - windows
   executor:
     command: |
+      net stop w32time
       Copy-Item $PathToAtomicsFolder\T1547.003\bin\AtomicTest.dll C:\Users\Public\AtomicTest.dll
       reg add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\W32Time\TimeProviders\AtomicTest" /t REG_SZ /v "DllName" /d "C:\Users\Public\AtomicTest.dll" /f
       reg add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\W32Time\TimeProviders\AtomicTest" /t REG_DWORD /v "Enabled" /d "1" /f
@@ -23,6 +24,7 @@ atomic_tests:
       net stop w32time
       reg delete "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\W32Time\TimeProviders\AtomicTest" /f
       rm -force C:\Users\Public\AtomicTest.dll
+      net start w32time
     name: powershell
     elevation_required: true
 
@@ -39,6 +41,7 @@ atomic_tests:
   - windows
   executor:
     command: |
+      net stop w32time
       Copy-Item $PathToAtomicsFolder\T1547.003\bin\AtomicTest.dll C:\Users\Public\AtomicTest.dll
       reg add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\W32Time\TimeProviders\NtpServer" /t REG_SZ /v "DllName" /d "C:\Users\Public\AtomicTest.dll" /f
       reg add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\W32Time\TimeProviders\NtpServer" /t REG_DWORD /v "Enabled" /d "1" /f
@@ -50,5 +53,6 @@ atomic_tests:
       reg add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\W32Time\TimeProviders\NtpServer" /t REG_DWORD /v "Enabled" /d "0" /f
       reg add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\W32Time\TimeProviders\NtpServer" /t REG_DWORD /v "InputProvider" /d "0" /f
       rm -force C:\Users\Public\AtomicTest.dll
+      net start w32time
     name: powershell
     elevation_required: true


### PR DESCRIPTION
**Details:**
I just tested on a domain joined machine and the w32time service was starting by default, so I'm adding the `net stop w32time` to first stop the service. If it's not running, it won't be an issue, the rest of the commands will execute successfully. Also it seems that in most cases, this service is enabled by default (it wasn't on my test VMs for some reason), so I'm re-enabling it at the end of the clean up commands.

**Testing:**
On domain-join host

**Associated Issues:**
N/A