### PR TITLE
T1543.004 cleanup file created by launch daemon

### DIFF
--- a/atomics/T1543.004/T1543.004.yaml
+++ b/atomics/T1543.004/T1543.004.yaml
@@ -33,3 +33,4 @@ atomic_tests:
     cleanup_command: |
       sudo launchctl unload /Library/LaunchDaemons/#{plist_filename}
       sudo rm /Library/LaunchDaemons/#{plist_filename}
+      sudo rm /tmp/T1543_004_atomicredteam.txt


### PR DESCRIPTION
**Details:**
The launch daemon does `touch /tmp/T1543_004_atomicredteam.txt`.  This changes adds that file to the cleanup.

**Testing:**
local

**Associated Issues:**
none