### PR TITLE
Update T1078.003-1

### DIFF
--- a/atomics/T1078.003/T1078.003.yaml
+++ b/atomics/T1078.003/T1078.003.yaml
@@ -11,7 +11,7 @@ atomic_tests:
     password:
       description: Password for art-test user
       type: String
-      default: Password123!
+      default: -4RTisCool!-321
   executor:
     command: |-
       net user art-test /add

--- a/atomics/T1078.003/T1078.003.yaml
+++ b/atomics/T1078.003/T1078.003.yaml
@@ -7,10 +7,15 @@ atomic_tests:
   description: After execution the new account will be active and added to the Administrators group
   supported_platforms:
   - windows
+  input_arguments:
+    password:
+      description: Password for art-test user
+      type: String
+      default: Password123!
   executor:
     command: |-
       net user art-test /add
-      net user art-test Password123!
+      net user art-test #{password}
       net localgroup administrators art-test /add
     cleanup_command: |-
       net localgroup administrators art-test /delete >nul 2>&1


### PR DESCRIPTION
Make password an input argument for Test 1

**Details:**
Make the password an input argument.  The existing default password was not passing password complexity requirements in the test environment causing the test to fail.    

**Testing:**
Local testing was done on a Windows 10 system.

**Associated Issues:**
N/A 