### PR TITLE
Adding T1219-8 | NetSupport - RAT Execution

### DIFF
--- a/atomics/T1219/T1219.yaml
+++ b/atomics/T1219/T1219.yaml
@@ -150,3 +150,28 @@ atomic_tests:
       Stop-Process -Name "RPCService" -force -erroraction silentlycontinue
     name: powershell
     elevation_required: True
+- name: NetSupport - RAT Execution
+  description: |
+    A recent trend by threat actors, once a foothold is established, maintain long term persistence using third party remote services such as NetSupport to provide the operator with access to the network using legitimate services. 
+  supported_platforms:
+  - windows
+  input_arguments:
+    NetSupport_Path:
+      description: Path to the NetSupport executable. 
+      type: Path
+      default: $env:temp\T1219Setup.exe
+  dependency_executor_name: powershell
+  dependencies:
+  - description: |
+      NetSupport must be downloaded and exist on the disk at the specified location. (#{NetSupport_Path})
+    prereq_command: |
+      if (Test-Path #{NetSupport_Path}) {exit 0} else {exit 1}
+    get_prereq_command: |
+      Start-BitsTransfer -Source "https://nsproducts.azureedge.net/nsm-1270/en/Setup.exe" -Destination "$env:temp\T1219Setup.exe" -dynamic
+  executor:
+    command: |
+      Start-Process #{NetSupport_Path} -ArgumentList "/S /v/qn"
+    cleanup_command: | 
+      Stop-Process -Name "NetSupport" -force -erroraction silentlycontinue
+    name: powershell
+    elevation_required: True

--- a/atomics/T1219/T1219.yaml
+++ b/atomics/T1219/T1219.yaml
@@ -172,6 +172,6 @@ atomic_tests:
     command: |
       Start-Process #{NetSupport_Path} -ArgumentList "/S /v/qn"
     cleanup_command: | 
-      Stop-Process -Name "NetSupport" -force -erroraction silentlycontinue
+      Stop-Process -Name "client32" -force -erroraction silentlycontinue
     name: powershell
     elevation_required: True


### PR DESCRIPTION
**Details:**
This test is designed to install and execute the NetSupport tool that is capable of RAT execution. A recent trend by threat actors, once a foothold is established, maintain long term persistence using third party remote services such as NetSupport to provide the operator with access to the network using legitimate services.

**Testing:**
Testing for this atomic test was done/verified on a Windows 10 machine over the course of two weeks. 

**Associated Issues:**
NA