### PR TITLE
Updates to T1046-1,2

### DIFF
--- a/atomics/T1046/T1046.yaml
+++ b/atomics/T1046/T1046.yaml
@@ -10,13 +10,15 @@ atomic_tests:
   supported_platforms:
   - linux
   - macos
+  input_arguments:
+    host:
+      description: Host to scan.
+      type: String
+      default: 192.168.1.1
   executor:
     command: |
-      for port in {1..65535};
-      do
-        echo >/dev/tcp/192.168.1.1/$port && echo "port $port is open" || echo "port $port is closed" : ;
-      done
-    name: sh
+      for port in {1..65535}; do (2>/dev/null echo >/dev/tcp/#{host}/$port) && echo port $port is open ; done
+    name: bash
 - name: Port Scan Nmap
   auto_generated_guid: 515942b0-a09f-4163-a7bb-22fefb6f185f
   description: |
@@ -61,7 +63,7 @@ atomic_tests:
       (which yum && yum -y install epel-release telnet)||(which apt-get && DEBIAN_FRONTEND=noninteractive apt-get install -y telnet)
   executor:
     command: |
-      nmap -sS #{network_range} -p #{port}
+      sudo nmap -sS #{network_range} -p #{port}
       telnet #{host} #{port}
       nc -nv #{host} #{port}
     name: sh


### PR DESCRIPTION
Updates to T1046 Test 1 and 2

**Details:**
For Test 1:
- Added ability to pass in `host` as an argument instead of having hard coded IP address
- Changed the shell executor from `sh` to `bash`.  Using `sh`, an error was occurring in the execution causing all ports to report as closed.  
- Made the script one line.  The new line replacement that occurs in the `Invoke-ExecuteCommand` causes a semicolon to be added after the `do`.  This caused a syntax error during execution.  
- Redirect any errors to `/dev/null` to cleanup the output

For Test 2:
- Add `sudo` to nmap command

**Testing:**
Tested locally on Linux host

