### PR TITLE
Update T1059.006-4

### DIFF
--- a/atomics/T1059.006/T1059.006.yaml
+++ b/atomics/T1059.006/T1059.006.yaml
@@ -164,8 +164,9 @@ atomic_tests:
           pip install requests
     executor:
       command: |-
-        python -c "import pty;pty.spawn('/bin/sh')"
+        which_python=$(which python || which python3 || which python2)
+        $which_python -c "import pty;pty.spawn('/bin/sh')"
         exit
-        python -c "import pty;pty.spawn('/bin/bash')"
+        $which_python -c "import pty;pty.spawn('/bin/bash')"
         exit
       name: bash


### PR DESCRIPTION
Get correct python version

**Details:**
The existing logic causes an error if `python` command is not found.  Use similar logic from other tests to pick the correct python interpreter to use for the test.  

**Testing:**
Locally on Linux host
