### PR TITLE
Update T1552.001-3

### DIFF
--- a/atomics/T1552.001/T1552.001.yaml
+++ b/atomics/T1552.001/T1552.001.yaml
@@ -37,7 +37,7 @@ atomic_tests:
   executor:
     command: |
       findstr /si pass *.xml *.doc *.txt *.xls
-      ls -R | select-string -Pattern password
+      ls -R | select-string -ErrorAction SilentlyContinue -Pattern password
     name: powershell
 - name: Access unattend.xml
   auto_generated_guid: 367d4004-5fc0-446d-823f-960c74ae52c3


### PR DESCRIPTION
Update T1552.001 Test 3 to silently continue when errors occur

**Details:**
Test failed and exited when reading a file that it did not have permission to access.  
```
select-string : The file <file> cannot be read: The process cannot access the file '<file>' because it is being used by another process.
```
Added `-ErrorAction SilentlyContinue` to the command so that the test will continue to execute.

**Testing:**
Locally against Windows 10 host
