### PR TITLE
Update T1082-3,4

### DIFF
--- a/atomics/T1082/T1082.yaml
+++ b/atomics/T1082/T1082.yaml
@@ -38,9 +38,9 @@ atomic_tests:
   executor:
     command: |
       uname -a >> #{output_file}
-      if [ -f /etc/lsb-release ]; then cat /etc/lsb-release >> #{output_file}; fi;
-      if [ -f /etc/redhat-release ]; then cat /etc/redhat-release >> #{output_file}; fi;      
-      if [ -f /etc/issue ]; then cat /etc/issue >> #{output_file}; fi;
+      if [ -f /etc/lsb-release ]; then cat /etc/lsb-release >> #{output_file}; fi
+      if [ -f /etc/redhat-release ]; then cat /etc/redhat-release >> #{output_file}; fi   
+      if [ -f /etc/issue ]; then cat /etc/issue >> #{output_file}; fi
       uptime >> #{output_file}
       cat #{output_file} 2>/dev/null
     cleanup_command: |
@@ -54,14 +54,14 @@ atomic_tests:
   - linux
   executor:
     command: |
-      if [ -f /sys/class/dmi/id/bios_version ]; then cat /sys/class/dmi/id/bios_version | grep -i amazon; fi;
-      if [ -f /sys/class/dmi/id/product_name ]; then cat /sys/class/dmi/id/product_name | grep -i "Droplet\|HVM\|VirtualBox\|VMware"; fi;
-      if [ -f /sys/class/dmi/id/product_name ]; then cat /sys/class/dmi/id/chassis_vendor | grep -i "Xen\|Bochs\|QEMU"; fi;
-      if [ -x "$(command -v dmidecode)" ]; then sudo dmidecode | grep -i "microsoft\|vmware\|virtualbox\|quemu\|domu"; fi;
-      if [ -f /proc/scsi/scsi ]; then cat /proc/scsi/scsi | grep -i "vmware\|vbox"; fi;
-      if [ -f /proc/ide/hd0/model ]; then cat /proc/ide/hd0/model | grep -i "vmware\|vbox\|qemu\|virtual"; fi;
-      if [ -x "$(command -v lspci)" ]; then sudo lspci | grep -i "vmware\|virtualbox"; fi;
-      if [ -x "$(command -v lscpu)" ]; then sudo lscpu | grep -i "Xen\|KVM\|Microsoft"; fi;
+      if [ -f /sys/class/dmi/id/bios_version ]; then cat /sys/class/dmi/id/bios_version | grep -i amazon; fi
+      if [ -f /sys/class/dmi/id/product_name ]; then cat /sys/class/dmi/id/product_name | grep -i "Droplet\|HVM\|VirtualBox\|VMware"; fi
+      if [ -f /sys/class/dmi/id/product_name ]; then cat /sys/class/dmi/id/chassis_vendor | grep -i "Xen\|Bochs\|QEMU"; fi
+      if [ -x "$(command -v dmidecode)" ]; then sudo dmidecode | grep -i "microsoft\|vmware\|virtualbox\|quemu\|domu"; fi
+      if [ -f /proc/scsi/scsi ]; then cat /proc/scsi/scsi | grep -i "vmware\|vbox"; fi
+      if [ -f /proc/ide/hd0/model ]; then cat /proc/ide/hd0/model | grep -i "vmware\|vbox\|qemu\|virtual"; fi
+      if [ -x "$(command -v lspci)" ]; then sudo lspci | grep -i "vmware\|virtualbox"; fi
+      if [ -x "$(command -v lscpu)" ]; then sudo lscpu | grep -i "Xen\|KVM\|Microsoft"; fi
     name: bash
 - name: Linux VM Check via Kernel Modules
   auto_generated_guid: 8057d484-0fae-49a4-8302-4812c4f1e64e


### PR DESCRIPTION
Remove semicolons from end of if statements

**Details:**
Remove the semicolons from the end of the if statements in Tests 3 and 4.  The extra semicolons were causing errors when the Invoke-ExecuteCommand new line formatting occurred.  

**Testing:**
Locally on Linux hosts.  
