### PR TITLE
Update T1543.003.yaml

### DIFF
--- a/atomics/T1543.003/T1543.003.yaml
+++ b/atomics/T1543.003/T1543.003.yaml
@@ -121,3 +121,31 @@ atomic_tests:
       reg delete "HKLM\SYSTEM\CurrentControlSet\Services\W64Time\Parameters" /v ServiceDll /f
     name: command_prompt
     elevation_required: true
+- name: Launch NSudo Executable
+  description: |-
+    Launches the NSudo executable for a short period of time and then exits.
+    NSudo download observed after maldoc execution. NSudo is a system management tool for advanced users to launch programs with full privileges.
+  supported_platforms:
+  - windows
+  input_arguments:
+    nsudo_path:
+      description: 'Path to the NSudo bat file'
+      type: Path
+      default: $env:TEMP\NSudo_8.2_All_Components\NSudo_Launcher\x64\NSudoLG.exe
+  dependency_executor_name: powershell
+  dependencies:
+  - description: |
+      NSudo.bat must exist in the specified path #{nsudo_path}
+    prereq_command: |
+      if (Test-Path #{nsudo_path}) {exit 0} else {exit 1}
+    get_prereq_command: |
+      Invoke-WebRequest -OutFile $env:TEMP\NSudo_8.2_All_Components.zip "https://github.com/M2Team/NSudo/releases/download/8.2/NSudo_8.2_All_Components.zip"
+      Expand-Archive -Path $env:TEMP\NSudo_8.2_All_Components.zip -DestinationPath $env:TEMP\NSudo_8.2_All_Components -Force
+      Rename-Item "$env:TEMP\NSudo_8.2_All_Components\NSudo Launcher" $env:TEMP\NSudo_8.2_All_Components\NSudo_Launcher
+      Remove-Item $env:TEMP\NSudo_8.2_All_Components.zip -Recurse -ErrorAction Ignore
+  executor:
+    command: |
+     Start-Process #{nsudo_path} -Argument "-U:T -P:E cmd"
+     Start-Sleep -Second 5
+     Stop-Process -Name "cmd" -force -erroraction silentlycontinue
+    name: powershell


### PR DESCRIPTION
Test05
description: |-
    Launches the NSudo executable for a short period of time and then exits.
    NSudo download observed after maldoc execution. NSudo is a system management tool for advanced users to launch programs with full privileges.

**Details:**
<!-- Insert details about this change here. Please include as much detail as possible -->

**Testing:**
<!-- Note any testing done, local or automated here. -->

**Associated Issues:**
<!-- Please link any issues that this pull request impacts or fixes. -->