### PR TITLE
T1529 Fix windows Logoff

### DIFF
--- a/atomics/T1529/T1529.yaml
+++ b/atomics/T1529/T1529.yaml
@@ -129,13 +129,8 @@ atomic_tests:
     This test performs a Windows system logoff as seen in [dcrat backdoor capabilities](https://www.mandiant.com/resources/analyzing-dark-crystal-rat-backdoor)
   supported_platforms:
   - windows
-  input_arguments:
-    timeout:
-      description: Timeout period before shutdown (seconds)
-      type: Integer
-      default: 1
   executor:
     command: |
-      shutdown /l /t #{timeout}
+      shutdown /l 
     name: command_prompt
     elevation_required: true


### PR DESCRIPTION
**Details:**
Test T1529 windows logoff fail 
`/t` can not be use with `/l`  -> https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/shutdown

<html><body>
<!--StartFragment-->

/l | Logs off the current user immediately, with no time-out period. You cannot use /l with /m or /t.
-- | --


<!--EndFragment-->
</body>
</html>