### PR TITLE
remove duplicate test

### DIFF
--- a/atomics/T1218/T1218.yaml
+++ b/atomics/T1218/T1218.yaml
@@ -30,21 +30,6 @@ atomic_tests:
       mavinject.exe #{process_id} /INJECTRUNNING #{dll_payload}
     name: command_prompt
     elevation_required: true
-- name: SyncAppvPublishingServer - Execute arbitrary PowerShell code
-  auto_generated_guid: d590097e-d402-44e2-ad72-2c6aa1ce78b1
-  description: |
-    Executes arbitrary PowerShell code using SyncAppvPublishingServer.exe. Requires Windows 10.
-  supported_platforms:
-  - windows
-  input_arguments:
-    powershell_code:
-      description: PowerShell code to execute
-      type: String
-      default: Start-Process calc.exe
-  executor:
-    command: |
-      SyncAppvPublishingServer.exe "n; #{powershell_code}"
-    name: command_prompt
 - name: Register-CimProvider - Execute evil dll
   auto_generated_guid: ad2c17ed-f626-4061-b21e-b9804a6f3655
   description: |


### PR DESCRIPTION
The same test was also found [here](https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1216/T1216.md#atomic-test-1---syncappvpublishingserver-signed-script-powershell-command-execution) and it is a better fit in T1216, so removing from T1218