### PR TITLE
Update on Permission Groups Discovery: Domain Groups

### DIFF
--- a/atomics/T1069.002/T1069.002.yaml
+++ b/atomics/T1069.002/T1069.002.yaml
@@ -14,7 +14,7 @@ atomic_tests:
       net group /domain
       net group "domain admins" /domain
       net group "enterprise admins" /domain
-      net1 group "Domain Computers" /domain
+      net group "Domain Computers" /domain
     name: command_prompt
 - name: Permission Groups Discovery PowerShell (Domain)
   auto_generated_guid: 6d5d8c96-3d2a-4da9-9d6d-9a9d341899a7

--- a/atomics/T1069.002/T1069.002.yaml
+++ b/atomics/T1069.002/T1069.002.yaml
@@ -14,6 +14,7 @@ atomic_tests:
       net group /domain
       net group "domain admins" /domain
       net group "enterprise admins" /domain
+      net1 group "Domain Computers" /domain
     name: command_prompt
 - name: Permission Groups Discovery PowerShell (Domain)
   auto_generated_guid: 6d5d8c96-3d2a-4da9-9d6d-9a9d341899a7


### PR DESCRIPTION
T1069.002 Permission Groups Discovery: Domain Group was missing with "domain computer" enumeration using the "net group" command. Updating the command.

**Details:**
<!-- Insert details about this change here. Please include as much detail as possible -->

**Testing:**
<!-- Note any testing done, local or automated here. -->

**Associated Issues:**
<!-- Please link any issues that this pull request impacts or fixes. -->