### PR TITLE
UltraVNC Execution -New atomictest

### DIFF
--- a/atomics/T1219/T1219.yaml
+++ b/atomics/T1219/T1219.yaml
@@ -202,4 +202,31 @@ atomic_tests:
     cleanup_command: | 
       Stop-Process -Name "UltraViewer_Desktop" -Force -ErrorAction SilentlyContinue
     name: powershell
+    elevation_required: True 
+ - name: UltraVNC Execution
+  description: |
+    An adversary may attempt to trick the user into downloading UltraVNC for use as a C2 channel.
+    Upon successful execution, UltraVNC will be executed.
+  supported_platforms:
+  - windows
+  input_arguments:
+    UltraVNC_Viewer_Path:
+      description: Path of UltraVNC Viewer executable
+      type: Path
+      default: $env:ProgramFiles\'uvnc bvba\UltraVnc\vncviewer.exe'
+  dependency_executor_name: powershell
+  dependencies:
+  - description: |
+      UltraVNC must exist at (#{UltraVNC_Viewer_Path})
+    prereq_command: |
+      if (Test-Path #{UltraVNC_Viewer_Path}) {exit 0} else {exit 1}
+    get_prereq_command: |
+       Start-BitsTransfer -Source "https://www.uvnc.eu/download/1381/UltraVNC_1_3_81_X64_Setup.exe" -Destination $env:temp\vncsetup.exe -dynamic
+       start-process $env:temp\vncsetup.exe /silent
+  executor:
+    command: |
+      Start-Process #{UltraVNC_Viewer_Path}
+    cleanup_command: |
+      Stop-Process -Name "vncviewer" -force -erroraction silentlycontinue
+    name: powershell
     elevation_required: True


### PR DESCRIPTION
 An adversary may attempt to trick the user into downloading UltraVNC for use as a C2 channel.
 Upon successful execution, UltraVNC will be executed

**Details:**
     Tested successfully in atomic Labs 