### PR TITLE
New Atomic test 29 - iwr download

### DIFF
--- a/atomics/T1105/T1105.yaml
+++ b/atomics/T1105/T1105.yaml
@@ -769,8 +769,7 @@ atomic_tests:
         Copy-Item $env:temp\nim\nim-1.6.6\bin\nimgrab.exe #{local_nimgrab}
         Remove-Item $env:temp\nim
         Remove-Item $env:temp\nim.zip
-- name: iwr or Invoke Web-Request download 
-  auto_generated_guid: 
+- name: iwr or Invoke Web-Request download  
   description: |  
     Use 'iwr' or "Invoke-WebRequest" -URI argument to download a file from the web. Note: without -URI also works in some versions.
   supported_platforms:

--- a/atomics/T1105/T1105.yaml
+++ b/atomics/T1105/T1105.yaml
@@ -790,3 +790,4 @@ atomic_tests:
     cleanup_command: |
       del %temp%\Atomic-license.txt >nul 2>&1
     name: command_prompt
+    elevation_required: true

--- a/atomics/T1105/T1105.yaml
+++ b/atomics/T1105/T1105.yaml
@@ -769,4 +769,24 @@ atomic_tests:
         Copy-Item $env:temp\nim\nim-1.6.6\bin\nimgrab.exe #{local_nimgrab}
         Remove-Item $env:temp\nim
         Remove-Item $env:temp\nim.zip
-
+- name: iwr or Invoke Web-Request download 
+  auto_generated_guid: 
+  description: |  
+    Use 'iwr' or "Invoke-WebRequest" -URI argument to download a file from the web. Note: without -URI also works in some versions.
+  supported_platforms:
+  - windows
+  input_arguments:
+    remote_file:
+      description: URL of file to copy
+      type: Url
+      default: https://raw.githubusercontent.com/redcanaryco/atomic-red-team/master/LICENSE.txt
+    local_path:
+      description: Local path to place file
+      type: Path
+      default: '%temp%\Atomic-license.txt'
+  executor:
+    command: |
+      powershell.exe iwr -URI #{remote_file} -Outfile #{local_path}
+    cleanup_command: |
+      del %temp%\Atomic-license.txt >nul 2>&1
+    name: command_prompt


### PR DESCRIPTION
iwr or Invoke Web-Request download. Use 'iwr' or "Invoke-WebRequest" -URI argument to download a file from the web. Note: without -URI also works in some versions.

Details:
The iwr inbuilt powershell cmdlet utility can be used to to download any http/https file and can be leveraged further to invoke many further such web requests. There was no dedicated atomic in place for the same functionality hence raised new.

Testing:
Testing done successfully under ART environment and lab.
