### PR TITLE
typo in AtomicTest no 3 brief description

### DIFF
--- a/atomics/T1014/T1014.md
+++ b/atomics/T1014/T1014.md
@@ -137,7 +137,7 @@ sudo depmod -a
 <br/>
 
 ## Atomic Test #3 - dynamic-linker based rootkit (libprocesshider)
-Uses libprocesshider to simulate rootkit behavior by hiding a specific process name via ls.so.preload (see also T1574.006).
+Uses libprocesshider to simulate rootkit behavior by hiding a specific process name via ld.so.preload (see also T1574.006).
 
 **Supported Platforms:** Linux
 


### PR DESCRIPTION


**Details:**
In description of AtomicTest 3, it seems it should be "ld.so.preload" instead of "ls.so.preload"