### PR TITLE
Modify description of "Disable UAC admin consent prompt"

### DIFF
--- a/atomics/T1548.002/T1548.002.yaml
+++ b/atomics/T1548.002/T1548.002.yaml
@@ -601,7 +601,7 @@ atomic_tests:
 - name: Disable UAC admin consent prompt via ConsentPromptBehaviorAdmin registry key
   auto_generated_guid: 251c5936-569f-42f4-9ac2-87a173b9e9b8
   description: |
-    Disable User Account Conrol (UAC) for admin by modifying the registry key 
+    Disable User Account Conrol (UAC) for admin by setting the registry key 
     HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System\ConsentPromptBehaviorAdmin to 0.
     
     [MedusaLocker Ransomware](https://cloudsek.com/technical-analysis-of-medusalocker-ransomware/), 


### PR DESCRIPTION
Changing the description of atomic test 251c5936-569f-42f4-9ac2-87a173b9e9b8 from "modifying the registry key" to "setting the registry key".  In this context, the word "setting" sounds more appropriate than "modifying".