### PR TITLE
Added a new atomic test

### DIFF
--- a/atomics/T1491.001/T1491.001.yaml
+++ b/atomics/T1491.001/T1491.001.yaml
@@ -77,3 +77,40 @@ atomic_tests:
         Remove-Item "#{pointer_to_orginal_wallpaper}" -ErrorAction Ignore
         Remove-Item "#{wallpaper_location}" -ErrorAction Ignore
     name: powershell
+- name: Configure LegalNoticeCaption and LegalNoticeText registry keys to display ransom message
+  auto_generated_guid: ffcbfaab-c9ff-470b-928c-f086b326089b
+  description: |
+    Display ransom message to users at system start-up by configuring registry keys HKLM\SOFTWARE\Micosoft\Windows\CurrentVersion\Policies\System\LegalNoticeCaption and HKLM\SOFTWARE\Micosoft\Windows\CurrentVersion\Policies\System\LegalNoticeText.
+   
+    [SynAck Ransomware](https://www.trendmicro.com/vinfo/es/security/news/cybercrime-and-digital-threats/synack-ransomware-leverages-process-doppelg-nging-for-evasion-and-infection), 
+    [Grief Ransomware](https://redcanary.com/blog/grief-ransomware/), 
+    [Maze Ransomware](https://cyware.com/research-and-analysis/maze-ransomware-a-deadly-combination-of-data-theft-and-encryption-to-target-us-organizations-8f27)
+    [Pysa Ransomware](https://www.cybereason.com/blog/research/threat-analysis-report-inside-the-destructive-pysa-ransomware)
+    [Spook Ransomware](https://community.fortinet.com/t5/FortiEDR/Threat-Coverage-How-FortiEDR-protects-against-Spook-Ransomware/ta-p/204226)
+    [DopplePaymer Ransomware](https://www.microsoft.com/en-us/wdsi/threats/malware-encyclopedia-description?Name=Ransom:Win32/Dopplepaymer&threatId=-2147221958)
+    [Reedemer Ransomware](https://blog.cyble.com/2022/07/20/redeemer-ransomware-back-action/)
+    [Kangaroo Ransomware](https://www.bleepingcomputer.com/news/security/the-kangaroo-ransomware-not-only-encrypts-your-data-but-tries-to-lock-you-out-of-windows/)
+  supported_platforms:
+  - windows
+  input_arguments:
+    legal_notice_caption:
+      description: Title of ransom message
+      type: String
+      default: PYSA
+    legal_notice_text:
+      description: Body of ransom message
+      type: String
+      default: "Hi Company, every byte on any types of your devices was encrypted. Don't try to use backups because it were encrypted too. To get all your data contact us:xxxx@onionmail.org" 
+  executor:
+    command: |-
+      $orgLegalNoticeCaption = (Get-ItemProperty HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System -Name LegalNoticeCaption).LegalNoticeCaption
+      $orgLegalNoticeText = (Get-ItemProperty HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System -Name LegalNoticeText).LegalNoticeText
+      $newLegalNoticeCaption = "#{legal_notice_caption}"
+      $newLegalNoticeText = "#{legal_notice_text}"
+      Set-ItemProperty HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System -Name LegalNoticeCaption -Value $newLegalNoticeCaption -Type String -Force
+      Set-ItemProperty HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System -Name LegalNoticeText -Value $newLegalNoticeText -Type String -Force      
+    cleanup_command: |
+      Set-ItemProperty HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System -Name LegalNoticeCaption -Value $orgLegalNoticeCaption -Type String -Force
+      Set-ItemProperty HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System -Name LegalNoticeText -Value $orgLegalNoticeText -Type String -Force
+    name: powershell
+    elevation_required: true


### PR DESCRIPTION
**Details:**
After encrypting files, ransomwares modify the Windows LegalNoticeCaption and LegalNoticeText registry keys to display a ransom message to victim at logon. We have added a new atomic test with guid ffcbfaab-c9ff-470b-928c-f086b326089b that sets two registry keys HKLM\SOFTWARE\Micosoft\Windows\CurrentVersion\Policies\System\LegalNoticeCaption and HKLM\SOFTWARE\Micosoft\Windows\CurrentVersion\Policies\System\LegalNoticeText to display a ransom message. While executing this atomic test, the value for these registries can be configured using the switch -PromptForInputArgs. This technique has been used by many ransomwares in the past including SynAck, Grief, Maze, Pysa, Spook, DopplePaymer, Reedemer and Kangaroo.  

**Testing:**
For testing, we added the proposed atomic test to our local version of T1491.001.yaml and executed it on Windows 10 OS using Invoke-AtomicTest cmdlet. The test command and clean up command worked correctly. We also tried to set custom values for LegalNoticeCaption and LegalNoticeText using the switch -PromptForInputArgs, it also worked correctly.
