### PR TITLE
Fix T1098.004

### DIFF
--- a/atomics/T1098.004/T1098.004.yaml
+++ b/atomics/T1098.004/T1098.004.yaml
@@ -15,6 +15,6 @@ atomic_tests:
     name: bash
     elevation_required: false 
     command: | 
-      if [ -f ~/.ssh/authorized_keys ]; then ssh_authorized_keys=$(cat ~/.ssh/authorized_keys); echo $ssh_authorized_keys > ~/.ssh/authorized_keys; fi;
+      if [ -f ~/.ssh/authorized_keys ]; then ssh_authorized_keys=$(cat ~/.ssh/authorized_keys); echo "$ssh_authorized_keys" > ~/.ssh/authorized_keys; fi;
     cleanup_command: | 
       unset ssh_authorized_keys


### PR DESCRIPTION

**Details:**
Fix for systems with multiple authorized keys. Without quotes, the echo command separates new lines with space instead of new line character which breaks authorized_keys file in case there are multiple keys in the file.

**Testing:**
Tried for authorized_keys file with single line (one key) and multiple lines (multiple keys).

**Associated Issues:**
n/a