### PR TITLE
Remove trailing \ from web_shells default path

### DIFF
--- a/atomics/T1505.003/T1505.003.yaml
+++ b/atomics/T1505.003/T1505.003.yaml
@@ -17,7 +17,7 @@ atomic_tests:
     web_shells:
       description: Path of Web Shell
       type: Path
-      default: PathToAtomicsFolder\T1505.003\src\
+      default: PathToAtomicsFolder\T1505.003\src
   dependency_executor_name: powershell
   dependencies:
   - description: |


### PR DESCRIPTION
**Details:**
xcopy doesn't work when there is a trailing \ in a path.  default: PathToAtomicsFolder\T1505.003\src\ caused the "Invalid path" error Removing the trailing \ fixes the issue

**Testing:**
Tested locally via remote execution of the test