### PR TITLE
Incomplete Process Termination Process

### DIFF
--- a/atomics/T1546.007/T1546.007.yaml
+++ b/atomics/T1546.007/T1546.007.yaml
@@ -27,6 +27,7 @@ atomic_tests:
   executor:
     command: |
       netsh.exe add helper #{helper_file}
+      taskkill /im notepad.exe /t /f > NUL 2>&1
     cleanup_command: |
       netsh.exe delete helper #{helper_file}
     name: command_prompt


### PR DESCRIPTION
**Detail:**
The Notepad process was not terminating after the command execution Line Added: 
taskkill /im notepad.exe /t /f > NUL 2>&1
 
The /t option makes sure any child processes are closed as well, and the /f option forcefully terminates the process. The > NUL redirects the stdout to the NUL device (the equivalent of /dev/null) and the 2 >&1 also redirects the stderr to stdout so that nothing is output to the console

**Testing:**
Tested Successfully
