### PR TITLE
Update T1070.003.yaml

### DIFF
--- a/atomics/T1070.003/T1070.003.yaml
+++ b/atomics/T1070.003/T1070.003.yaml
@@ -128,7 +128,7 @@ atomic_tests:
   - windows
   executor:
     command: |
-       Set-PSReadlineOption –HistorySaveStyle SaveNothing
+       Set-PSReadlineOption -HistorySaveStyle SaveNothing
     name: powershell
     cleanup_command: 'Set-PSReadLineOption -HistorySaveStyle SaveIncrementally'
     


### PR DESCRIPTION
In this command "Set-PSReadLineOption -HistorySaveStyle SaveIncrementally"，The "–" correct is "-"

**Details:**
<!-- Insert details about this change here. Please include as much detail as possible -->
original command line : Set-PSReadlineOption –HistorySaveStyle SaveNothing
and when i copy this command line to test,powershell report error
i find the command line has a weird character “–”,and replace this character  to "-",anything will be work

**Testing:**
<!-- Note any testing done, local or automated here. -->

**Associated Issues:**
<!-- Please link any issues that this pull request impacts or fixes. -->