### PR TITLE
 T1560.002 :: Fix typo for gzip

### DIFF
--- a/atomics/T1560.002/T1560.002.yaml
+++ b/atomics/T1560.002/T1560.002.yaml
@@ -28,7 +28,7 @@ atomic_tests:
     name: bash
     elevation_required: false
     command: |
-      $which_python -c "import gzip;input_file=open('#{path_to_input_file}', 'rb');content=input_file.read();input_file.close();output_file=gzip.GzipFile('#{path_to_output_file}','wb','compresslevel=6');output_file.write(content);output_file.close();"
+      $which_python -c "import gzip;input_file=open('#{path_to_input_file}', 'rb');content=input_file.read();input_file.close();output_file=gzip.GzipFile('#{path_to_output_file}','wb',compresslevel=6);output_file.write(content);output_file.close();"
     cleanup_command: |
       rm #{path_to_output_file}
 - name: Compressing data using bz2 in Python (Linux)


### PR DESCRIPTION
**Details:**
Removed single quotes to avoid type error. (TypeError: 'str' object cannot be interpreted as an integer)

**Testing:**
Local testing was done.

**Associated Issues:**
N/A