### PR TITLE
Update T1567.002.yaml

### DIFF
--- a/atomics/T1567.002/T1567.002.yaml
+++ b/atomics/T1567.002/T1567.002.yaml
@@ -32,7 +32,7 @@ atomic_tests:
     remote_share:
       description: Remote Mega share
       type: String
-      default: T1567002	 
+      default: T1567002
   dependency_executor_name: powershell
   dependencies:
   - description: |


### PR DESCRIPTION
Removed tab from file which was causing parsing to break

**Details:**
Line 35 contained a hanging tab which was causing pyaml to break. Since tabs are illegal characters in yaml, it is assumed this will break other yaml parsers.

![image](https://user-images.githubusercontent.com/81784737/206320021-989739e7-000d-4929-8aac-8d323d89eb76.png)

**Testing:**
Tested using the following validation snippet 

`python3 -c 'import yaml, sys; print(yaml.safe_load(sys.stdin))'< ~/Desktop/T1567.002.yaml`

**Associated Issues:**
None