### PR TITLE
Clean up T1546.005 linux TRAP

### DIFF
--- a/atomics/T1546.005/T1546.005.yaml
+++ b/atomics/T1546.005/T1546.005.yaml
@@ -1,17 +1,30 @@
 attack_technique: T1546.005
 display_name: 'Event Triggered Execution: Trap'
 atomic_tests:
-- name: Trap
+- name: Trap EXIT
   auto_generated_guid: a74b2e07-5952-4c03-8b56-56274b076b61
   description: |
-    After exiting the shell, the script will download and execute.
-    After sending a keyboard interrupt (CTRL+C) the script will download and execute.
+    Launch bash shell with command arg to create TRAP on EXIT.
+    The trap executes script that writes to /tmp/art-fish.txt
   supported_platforms:
   - macos
   - linux
   executor:
     command: |
-      trap "nohup sh $PathToAtomicsFolder/T1546.005/src/echo-art-fish.sh | bash" EXIT
-      exit
-      trap "nohup sh $PathToAtomicsFolder/T1546.005/src/echo-art-fish.sh | bash" SIGINt
+      bash -c 'trap "nohup sh $PathToAtomicsFolder/T1546.005/src/echo-art-fish.sh" EXIT'
+    cleanup_command: |
+      rm -f /tmp/art-fish.txt
+    name: sh
+- name: Trap SIGINT
+  description: |
+    Launch bash shell with command arg to create TRAP on SIGINT (CTRL+C), then send SIGINT signal.
+    The trap executes script that writes to /tmp/art-fish.txt
+  supported_platforms:
+  - macos
+  - linux
+  executor:
+    command: |
+      bash -c 'trap "nohup sh $PathToAtomicsFolder/T1546.005/src/echo-art-fish.sh" SIGINT && kill -SIGINT $$'
+    cleanup_command: |
+      rm -f /tmp/art-fish.txt
     name: sh


### PR DESCRIPTION
**Details:**
Cleans up a few things:
 - rather than modifying current shell, launches new one with -c argument.  This makes it easy to test EXIT trap.
 - previous was doing `nohup sh echo-art-fish.sh | bash` in trap. no need for the pipe to bash now.
 - I separated the EXIT and SIGINT traps. otherwise, it's not possible to tell which trap(s) executed.
 - The previous SIGINT case required user to hit CTRL+C.  now it's automated using signal
 - added cleanup step

**Testing:**
Tested on macOS BigSur and Ubuntu 20.04

**Associated Issues:**
I changed the name of first test from `Trap` to `Trap EXIT`