### PR TITLE
Fixed Automated Collection Command Prompt variable call

### DIFF
--- a/atomics/T1119/T1119.yaml
+++ b/atomics/T1119/T1119.yaml
@@ -12,7 +12,7 @@ atomic_tests:
     command: |
       mkdir %temp%\T1119_command_prompt_collection >nul 2>&1
       dir c: /b /s .docx | findstr /e .docx
-      for /R c: %%f in (*.docx) do copy %%f %temp%\T1119_command_prompt_collection
+      for /R c: %%f in (*.docx) do copy /Y %%f %temp%\T1119_command_prompt_collection
     cleanup_command: |
       del %temp%\T1119_command_prompt_collection /F /Q >nul 2>&1
     name: command_prompt

--- a/atomics/T1119/T1119.yaml
+++ b/atomics/T1119/T1119.yaml
@@ -12,7 +12,7 @@ atomic_tests:
     command: |
       mkdir %temp%\T1119_command_prompt_collection >nul 2>&1
       dir c: /b /s .docx | findstr /e .docx
-      for /R c: %f in (*.docx) do copy %f %temp%\T1119_command_prompt_collection
+      for /R c: %%f in (*.docx) do copy %%f %temp%\T1119_command_prompt_collection
     cleanup_command: |
       del %temp%\T1119_command_prompt_collection /F /Q >nul 2>&1
     name: command_prompt

--- a/atomics/T1119/T1119.yaml
+++ b/atomics/T1119/T1119.yaml
@@ -12,7 +12,7 @@ atomic_tests:
     command: |
       mkdir %temp%\T1119_command_prompt_collection >nul 2>&1
       dir c: /b /s .docx | findstr /e .docx
-      for /R c: %%f in (*.docx) do copy /Y %%f %temp%\T1119_command_prompt_collection
+      for /R c:\ %f in (*.docx) do copy /Y %f %temp%\T1119_command_prompt_collection
     cleanup_command: |
       del %temp%\T1119_command_prompt_collection /F /Q >nul 2>&1
     name: command_prompt

--- a/atomics/T1564.004/T1564.004.yaml
+++ b/atomics/T1564.004/T1564.004.yaml
@@ -79,7 +79,7 @@ atomic_tests:
   executor:
     command: |
       echo cmd /c echo "Shell code execution."> #{file_name}:#{ads_filename}
-      for /f "usebackq delims=?" %%i in (#{file_name}:#{ads_filename}) do %%i
+      for /f "usebackq delims=?" %i in (#{file_name}:#{ads_filename}) do %i
     cleanup_command: |
       del #{file_name} >nul 2>&1
     name: command_prompt

--- a/atomics/T1564.004/T1564.004.yaml
+++ b/atomics/T1564.004/T1564.004.yaml
@@ -79,7 +79,7 @@ atomic_tests:
   executor:
     command: |
       echo cmd /c echo "Shell code execution."> #{file_name}:#{ads_filename}
-      for /f "usebackq delims=?" %i in (#{file_name}:#{ads_filename}) do %i
+      for /f "usebackq delims=?" %%i in (#{file_name}:#{ads_filename}) do %%i
     cleanup_command: |
       del #{file_name} >nul 2>&1
     name: command_prompt


### PR DESCRIPTION
**Details:**
While using the commands from a batch file the old code wont work because of the way the variable is being called. The addition of '%' fixed the issue.

**Testing:**
Tested manually

**Associated Issues:**
None