### PR TITLE
block regedit and cmd.exe

### DIFF
--- a/atomics/T1112/T1112.yaml
+++ b/atomics/T1112/T1112.yaml
@@ -674,20 +674,21 @@ atomic_tests:
       reg delete HKLM\SOFTWARE\Policies\Microsoft\Windows Defender\Reporting /v DisableEnhancedNotifications /f >nul 2>&1
     name: command_prompt
     elevation_required: true
-- name: DisallowRun Execution Of Certain Application
+- name: DisallowRun Execution Of Certain Applications
   auto_generated_guid: 71db768a-5a9c-4047-b5e7-59e01f188e84
   description: |
     Modify the registry of the currently logged in user using reg.exe via cmd console to prevent user running specific computer programs that could aid them in manually removing malware or detecting it 
     using security product.
-    See how azorult malware abuses this technique- https://app.any.run/tasks/a6f2ffe2-e6e2-4396-ae2e-04ea0143f2d8/
   supported_platforms:
   - windows
   executor:
     command: |
       reg add HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Policies\Explorer /v DisallowRun /t REG_DWORD /d 1 /f
-      reg add HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Policies\Explorer\DisallowRun /v DisableEnhancedNotifications /t REG_DWORD /d 1 /f
+      reg add HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Policies\Explorer\DisallowRun /f /t REG_SZ /v art1 /d "regedit.exe"
+      reg add HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Policies\Explorer\DisallowRun /f /t REG_SZ /v art2 /d "cmd.exe"
     cleanup_command: |
       reg delete HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Policies\Explorer /v DisallowRun /f >nul 2>&1
-      reg delete HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Policies\Explorer\DisallowRun /v 1 /f >nul 2>&1
+      reg delete HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Policies\Explorer\DisallowRun /v art1 /f >nul 2>&1
+      reg delete HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Policies\Explorer\DisallowRun /v art2 /f >nul 2>&1
     name: command_prompt
     elevation_required: true


### PR DESCRIPTION
Modify test to actually block a few example programs. Removed link to azorult malware because I couldn't find this technique being used there.