### PR TITLE
T1059.004 What shells are available

### DIFF
--- a/atomics/T1059.004/T1059.004.yaml
+++ b/atomics/T1059.004/T1059.004.yaml
@@ -98,3 +98,17 @@ atomic_tests:
     cleanup_command: |
       rm -rf #{linenum}
     name: sh
+- name: What shells are available
+  description: |
+    An attacker may want to discover which shell's are available so that they might switch to that shell to tailor their attacks to suit that shell. The following commands will discover what shells are available on the host.
+  supported_platforms:
+  - linux
+  executor:
+    name: sh
+    elevation_required: false
+    command: |
+      which bash 
+      which sh 
+      which csh 
+      which tcsh 
+      which ksh


### PR DESCRIPTION
**Details:**
An attacker may want to discover which shell's are available so that they might switch to that shell to tailor their attacks to suit that shell. The following commands will discover what shells are available on the host.

**Testing:**
Ubuntu 22.04 and rhel 8.7

