### PR TITLE
T1059.004 What shell is running

### DIFF
--- a/atomics/T1059.004/T1059.004.yaml
+++ b/atomics/T1059.004/T1059.004.yaml
@@ -98,3 +98,15 @@ atomic_tests:
     cleanup_command: |
       rm -rf #{linenum}
     name: sh
+- name: What shell is running
+  description: |
+    An attacker will want to discover what shell is running so that they can tailor their attacks accordingly. The following commands will discover what shell is running.
+  supported_platforms:
+  - linux
+  executor:
+    name: sh
+    elevation_required: false
+    command: |
+      echo $0
+      env |grep SHELL
+      printenv SHELL


### PR DESCRIPTION
**Details:**
An attacker will want to discover what shell is running so that they can tailor their attacks accordingly. The following commands will discover what shell is running.

**Testing:**
Ubuntu 22.04 and rhel 8.7
