### PR TITLE
Adding T1562.004 Test 18 - Blackbit - Disable Windows Firewall using netsh firewall

### DIFF
--- a/atomics/T1562.004/T1562.004.yaml
+++ b/atomics/T1562.004/T1562.004.yaml
@@ -336,6 +336,6 @@ atomic_tests:
     command: |
       netsh firewall set opmode mode=disable
     cleanup_command: |
-      netsh firewall set opmode mode=enable
+      netsh firewall set opmode mode=enable >nul 2>&1
     name: command_prompt
-    elevation_required: true    
+    elevation_required: true  

--- a/atomics/T1562.004/T1562.004.yaml
+++ b/atomics/T1562.004/T1562.004.yaml
@@ -326,4 +326,16 @@ atomic_tests:
        Remove-ItemProperty "HKLM:\SOFTWARE\Policies\Microsoft\WindowsFirewall\DomainProfile"  -Name EnableFirewall -Force -ErrorAction Ignore
        Remove-ItemProperty "HKLM:\SOFTWARE\Policies\Microsoft\WindowsFirewall\StandardProfile" -Name EnableFirewall -Force -ErrorAction Ignore
     name: powershell
-    elevation_required: true 
+    elevation_required: true
+- name: Blackbit - Disable Windows Firewall using netsh firewall
+  description: |
+     An adversary tries to modify the windows firewall configuration using the deprecated netsh firewall command (command still works).     
+  supported_platforms:
+  - windows
+  executor:
+    command: |
+      netsh firewall set opmode mode=disable
+    cleanup_command: |
+      netsh firewall set opmode mode=enable
+    name: command_prompt
+    elevation_required: true    


### PR DESCRIPTION
**Details:**
Adding T1562.004 Test 18 - Blackbit - Disable Windows Firewall using netsh firewall. Within BlackBit ransomware, one of the commands ran is "netsh firewall set opmode mode=disable". While "netsh firewall" has been deprecated and replaced with "netsh advfirewall", the old command still does work, leading to a vector that adversaries can use for firewall disablement.

**Testing:**
Tested on Windows 10.