### PR TITLE
fix: Fix unescaped backslash in description

### DIFF
--- a/atomic_red_team/atomic_doc_template.md.erb
+++ b/atomic_red_team/atomic_doc_template.md.erb
@@ -1,7 +1,7 @@
 # <%= technique['identifier'] %> - <%= technique['name'] -%>
 
 ## [Description from ATT&CK](https://attack.mitre.org/techniques/<%= technique['identifier'].gsub(/\./, '/') %>)
-<blockquote><%= technique['description'] %></blockquote>
+<blockquote><%= technique['description'].gsub("%\\<", "%<") %></blockquote>
 
 ## Atomic Tests
 <% atomic_yaml['atomic_tests'].each_with_index do |test, test_number| -%>


### PR DESCRIPTION
**Details:**

When generating markdown documents, certain commands were not being parsed correctly when rendering strings from Mitre ATT&CK JSON objects. This PR fixes that issue by replacing double backslash with null strings in the technique['description'] portion of the ERB template.

**Testing:**

Generated docs and the only document/technique effected by this change is T1546.008. I know it's small but it helps.

**Associated Issues:**

fixed #1539