### PR TITLE
Improvements to "Azure AD - adding permission to application"

### DIFF
--- a/atomics/T1098/T1098.yaml
+++ b/atomics/T1098/T1098.yaml
@@ -419,9 +419,9 @@ atomic_tests:
 - name: Azure AD - adding permission to application
   auto_generated_guid: 94ea9cc3-81f9-4111-8dde-3fb54f36af4b
   description: |
-    The adversaries want to add permission to new created application. Application could be then use for persistence or for further operation in the attacked infrastructure. Permissions like AppRoleAssignment.ReadWrite.All or RoleManagement.ReadWrite.Directory in particular can be a valuable target for a threat actor.
-    You can use Get-AzureADApplication instead of New-AzureADServicePrincipal to use an existing application.
-    The DirectoryRecommendations.Read.All permissions have been selected as the default
+    The adversaries want to add permission to newly created application. Application could be then used for persistence or for further operation in the attacked infrastructure. Permissions like AppRoleAssignment.ReadWrite.All or RoleManagement.ReadWrite.Directory in particular can be a valuable target for a threat actor.
+    This technique will create a new app, with the provided name, and give it the provided permission. But if you prefer to add credentials to an existing app, replace in the code: "Get-AzureADApplication" instead of "New-AzureADServicePrincipal".
+    The DirectoryRecommendations.Read.All permissions has been selected as the default.
 
     The account you use to run the PowerShell command should have Global Administrator/Application Administrator/Cloud Application Administrator role in your Azure AD.
 
@@ -443,11 +443,11 @@ atomic_tests:
       type: string
       default: p4sswd
     application_name:
-      description: Name of the targeted application
+      description: Name of the targeted application that will be created
       type: string
       default: test_app
     application_permission:
-      description: Permission from Microsoft Graph Resource API that will be add to application
+      description: Permission from Microsoft Graph Resource API that will be added to application
       type: string
       default: DirectoryRecommendations.Read.All
   dependencies:
@@ -500,7 +500,7 @@ atomic_tests:
       #Set permissions in existing Azure AD App
       Set-AzureADApplication -ObjectId $aadApplication.ObjectId -RequiredResourceAccess $requiredResourcesAccess
 
-      $servicePrincipal = Get-AzureADServicePrincipal -Filter "AppId eq '$aadApplication.AppId'"
+      $servicePrincipal = Get-AzureADServicePrincipal -Filter "AppId eq '$($aadApplication.AppId)'"
 
       New-AzureADServiceAppRoleAssignment -ObjectId $servicePrincipal.ObjectId -PrincipalId $servicePrincipal.ObjectId -ResourceId $graphSP.ObjectId -Id $reqPermission.Id
 
@@ -509,9 +509,23 @@ atomic_tests:
       $PWord = ConvertTo-SecureString -String "#{password}" -AsPlainText -Force
       $Credential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList "#{username}", $Pword
       Connect-AzureAD -Credential $Credential
-
-      $aadApplication = Get-AzureADApplication -Filter "DisplayName eq '#{application_name}'"
-      Remove-AzureADApplication -ObjectId $aadApplication.ObjectId
+      
+      $aadApplication = @(Get-AzureADApplication -Filter "DisplayName eq '#{application_name}'")
+      If ($aadApplication.Count -eq 0)
+      {
+        Write-Host "App not found: cannot delete it"
+        exit
+      }
+      ElseIf ($aadApplication.Count -gt 1)
+      {
+        Write-Host "Found several app with name '#{application_name}': one is likely the one this technique created, but as a precaution, none will be deleted. Manual cleanup is required."
+        exit
+      }
+      Else
+      {
+        Remove-AzureADApplication -ObjectId $aadApplication[0].ObjectId
+        Write-Host "Successfully deleted app"
+      }
 
     name: powershell
     elevation_required: false


### PR DESCRIPTION
**Details:**
- Make it clearer that this test will create an app, instead of using an existing one
- If the user ignored this, a second app with the same name as the one they wanted to use will be created. So when using the -Cleanup feature it cannot know which one to delete. Shows a warning then (instead of crashing)
- Some minor English fixes

**Testing:**
I tested all cases in a lab AAD env

**Associated Issues:**
Some modifications are also present in https://github.com/redcanaryco/atomic-red-team/pull/2340 and https://github.com/redcanaryco/atomic-red-team/pull/2339