### PR TITLE
added a new test for base64 encoded shebang shells

### DIFF
--- a/atomics/T1140/T1140.yaml
+++ b/atomics/T1140/T1140.yaml
@@ -171,3 +171,47 @@ atomic_tests:
       echo $ENCODED > #{encoded_file} && xxd -r -p < #{encoded_file}
       echo $ENCODED > #{encoded_file} && cat #{encoded_file} | xxd -r -p
       echo $ENCODED > #{encoded_file} && cat < #{encoded_file} | xxd -r -p
+- name: Linux Base64 Encoded Shebang in CLI
+  auto_generated_guid: 3a15c372-67c1-4430-ac8e-ec06d641ce4d
+  description: |
+    Using Linux Base64 Encoded shell scripts that have Shebang in them. This is commonly how attackers obfuscate passing and executing a shell script. 
+  supported_platforms:
+  - linux
+  - macos
+  input_arguments:
+    bash_encoded:
+      description: Encoded #!/bin/bash script
+      type: string
+      default: IyEvYmluL2Jhc2gKZWNobyAiaHR0cHM6Ly93d3cueW91dHViZS5jb20vQGF0b21pY3NvbmFmcmlkYXkgRlRXIgo=
+    dash_encoded:
+      description: Encoded #!/bin/dash script
+      type: string
+      default: IyEvYmluL2Rhc2gKZWNobyAiaHR0cHM6Ly93d3cueW91dHViZS5jb20vQGF0b21pY3NvbmFmcmlkYXkgRlRXIgo=
+    zsh_encoded:
+      description: Encoded #!/bin/zsh script
+      type: string
+      default: IyEvYmluL3pzaAplY2hvICJodHRwczovL3d3dy55b3V0dWJlLmNvbS9AYXRvbWljc29uYWZyaWRheSBGVFciCg==
+    fish_encoded:
+      description: Encoded #!/bin/fish script
+      type: string
+      default: IyEvYmluL2Rhc2gKZWNobyAiaHR0cHM6Ly93d3cueW91dHViZS5jb20vQGF0b21pY3NvbmFmcmlkYXkgRlRXIgo=
+    sh_encoded:
+      description: Encoded #!/bin/sh script
+      type: string
+      default: IyEvYmluL3NoCmVjaG8gImh0dHBzOi8vd3d3LnlvdXR1YmUuY29tL0BhdG9taWNzb25hZnJpZGF5IEZUVyIK
+  dependencies:
+  - description: |
+      base64 must be present
+    prereq_command: |
+      which base64
+    get_prereq_command: |
+      echo "please install base64"
+  executor:
+    name: sh
+    elevation_required: false
+    command: |
+      echo #{bash_encoded} | base64 -d | bash
+      echo #{dash_encoded} | base64 -d | bash
+      echo #{fish_encoded} | base64 -d | bash
+      echo #{sh_encoded} | base64 -d | bash
+      


### PR DESCRIPTION
**Details:**
Using Linux Base64 Encoded shell scripts that have Shebang in them. This is commonly how attackers obfuscate passing and executing a shell script. Seen [here](https://www.trendmicro.com/pl_pl/research/20/i/the-evolution-of-malicious-shell-scripts.html) by TrendMicro, as well as [LinPEAS](https://github.com/carlospolop/PEASS-ng/tree/master/linPEAS). Also, there is a great Sigma rule [here](https://github.com/SigmaHQ/sigma/blob/master/rules/linux/process_creation/proc_creation_lnx_base64_shebang_cli.yml) for it.  The tests work very simply by passing in encoded shells as input args that can be easily changed by anyone. 

**Testing:**
![Screenshot from 2023-03-01 16-58-25](https://user-images.githubusercontent.com/1476868/222275066-629aab86-3961-4da3-85bf-dffe29d19533.png)

**Associated Issues:**
<!-- Please link any issues that this pull request impacts or fixes. -->