### PR TITLE
Gk atomic red team t1136.003 azure cli

### DIFF
--- a/atomics/T1136.003/T1136.003.yaml
+++ b/atomics/T1136.003/T1136.003.yaml
@@ -63,3 +63,42 @@ atomic_tests:
       New-AzureADUser -DisplayName $username -PasswordProfile $PasswordProfile -UserPrincipalName $userprincipalname -AccountEnabled $true -MailNickName $username      
     cleanup_command: Remove-AzureADUser -ObjectId "#{userprincipalname}"
     name: powershell
+- name: Azure AD - Create a new user via Azure CLI
+  auto_generated_guid: # This key and/or it's value will be added by the CI build after submitting a Pull Request
+  description: Creates a new user in Azure AD via the Azure CLI. Upon successful creation, a new user will be created. Adversaries create new users so that their malicious activity does not interrupt the normal functions of the compromised users and can remain undetected for a long time.
+  supported_platforms:
+  - azure-ad
+  input_arguments:
+    username:
+      description: Display name of the new user to be created in Azure AD
+      type: string
+      default: "atomicredteam"
+    userprincipalname:
+      description: User principal name (UPN) for the new Azure user being created format email address
+      type: String
+      default: "atomicredteam@bwc-demo.com"
+    password:
+      description: Password for the new Azure AD user being created
+      type: string
+      default: "reallylongcredential12345ART-ydsfghsdgfhsdgfhgsdhfg"
+  dependency_executor_name: powershell
+  dependencies:
+  - description: Check if Azure CLI is installed and install manually
+    prereq_command: az account list
+    get_prereq_command: echo "use the following to install Azure CLI mnaually https://aka.ms/installazurecliwindows"
+  - description: Check if Azure CLI is installed and install via PowerShell
+    prereq_command: az account list
+    get_prereq_command: echo "use the following to install Azure CLI $ProgressPreference = 'SilentlyContinue'; Invoke-WebRequest -Uri https://aka.ms/installazurecliwindows -OutFile .\AzureCLI.msi; Start-Process msiexec.exe -Wait -ArgumentList '/I AzureCLI.msi /quiet'; Remove-Item .\AzureCLI.msi"
+  - description: Update the userprincipalname to meet your requirements  
+    prereq_command: Update the input arguments so the userprincipalname value is accurate for your environment
+    get_prereq_command: echo "Update the input arguments in the .yaml file so that the userprincipalname value is accurate for your environment"
+  executor:
+    command: |-
+      az login
+      $userprincipalname = "#{userprincipalname}"
+      $username = "#{username}"      
+      $password = "#{password}"
+      az ad user create --display-name $username --password $password --user-principal-name $userprincipalname
+      az ad user list --upn $userprincipalname      
+    cleanup_command: az ad user delete --upn #{userprincipalname}
+    name: powershell    

--- a/atomics/T1136.003/T1136.003.yaml
+++ b/atomics/T1136.003/T1136.003.yaml
@@ -64,7 +64,7 @@ atomic_tests:
     cleanup_command: Remove-AzureADUser -ObjectId "#{userprincipalname}"
     name: powershell
 - name: Azure AD - Create a new user via Azure CLI
-  auto_generated_guid: # This key and/or it's value will be added by the CI build after submitting a Pull Request
+  auto_generated_guid:
   description: Creates a new user in Azure AD via the Azure CLI. Upon successful creation, a new user will be created. Adversaries create new users so that their malicious activity does not interrupt the normal functions of the compromised users and can remain undetected for a long time.
   supported_platforms:
   - azure-ad

--- a/atomics/T1136.003/T1136.003.yaml
+++ b/atomics/T1136.003/T1136.003.yaml
@@ -26,7 +26,7 @@ atomic_tests:
       aws iam delete-user --user-name #{username}
     name: sh
     elevation_required: false
-- name: Azure AD - Create a new use
+- name: Azure AD - Create a new user
   auto_generated_guid: e62d23ef-3153-4837-8625-fa4a3829134d
   description: Creates a new user in Azure AD. Upon successful creation, a new user will be created. Adversaries create new users so that their malicious activity does not interrupt the normal functions of the compromised users and can remain undetected for a long time.
   supported_platforms:
@@ -76,7 +76,7 @@ atomic_tests:
     userprincipalname:
       description: User principal name (UPN) for the new Azure user being created format email address
       type: String
-      default: "atomicredteam@domain.com"
+      default: "atomicredteam@yourdomain.com"
     password:
       description: Password for the new Azure AD user being created
       type: string
@@ -85,10 +85,10 @@ atomic_tests:
   dependencies:
   - description: Check if Azure CLI is installed and install manually
     prereq_command: az account list
-    get_prereq_command: echo "use the following to install Azure CLI mnaually https://aka.ms/installazurecliwindows"
+    get_prereq_command: echo "use the following to install the Azure CLI manually https://aka.ms/installazurecliwindows"
   - description: Check if Azure CLI is installed and install via PowerShell
     prereq_command: az account list
-    get_prereq_command: echo "use the following to install Azure CLI $ProgressPreference = 'SilentlyContinue'; Invoke-WebRequest -Uri https://aka.ms/installazurecliwindows -OutFile .\AzureCLI.msi; Start-Process msiexec.exe -Wait -ArgumentList '/I AzureCLI.msi /quiet'; Remove-Item .\AzureCLI.msi"
+    get_prereq_command: echo "use the following to install the Azure CLI $ProgressPreference = 'SilentlyContinue'; Invoke-WebRequest -Uri https://aka.ms/installazurecliwindows -OutFile .\AzureCLI.msi; Start-Process msiexec.exe -Wait -ArgumentList '/I AzureCLI.msi /quiet'; Remove-Item .\AzureCLI.msi"
   - description: Update the userprincipalname to meet your requirements  
     prereq_command: Update the input arguments so the userprincipalname value is accurate for your environment
     get_prereq_command: echo "Update the input arguments in the .yaml file so that the userprincipalname value is accurate for your environment"
@@ -101,4 +101,4 @@ atomic_tests:
       az ad user create --display-name $username --password $password --user-principal-name $userprincipalname
       az ad user list --filter "displayname eq 'atomicredteam'"     
     cleanup_command: az ad user delete --id #{userprincipalname}
-    name: powershell    
+    name: powershell

--- a/atomics/T1136.003/T1136.003.yaml
+++ b/atomics/T1136.003/T1136.003.yaml
@@ -64,7 +64,6 @@ atomic_tests:
     cleanup_command: Remove-AzureADUser -ObjectId "#{userprincipalname}"
     name: powershell
 - name: Azure AD - Create a new user via Azure CLI
-  auto_generated_guid:
   description: Creates a new user in Azure AD via the Azure CLI. Upon successful creation, a new user will be created. Adversaries create new users so that their malicious activity does not interrupt the normal functions of the compromised users and can remain undetected for a long time.
   supported_platforms:
   - azure-ad

--- a/atomics/T1136.003/T1136.003.yaml
+++ b/atomics/T1136.003/T1136.003.yaml
@@ -76,7 +76,7 @@ atomic_tests:
     userprincipalname:
       description: User principal name (UPN) for the new Azure user being created format email address
       type: String
-      default: "atomicredteam@bwc-demo.com"
+      default: "atomicredteam@domain.com"
     password:
       description: Password for the new Azure AD user being created
       type: string
@@ -99,6 +99,6 @@ atomic_tests:
       $username = "#{username}"      
       $password = "#{password}"
       az ad user create --display-name $username --password $password --user-principal-name $userprincipalname
-      az ad user list --upn $userprincipalname      
-    cleanup_command: az ad user delete --upn #{userprincipalname}
+      az ad user list --filter "displayname eq 'atomicredteam'"     
+    cleanup_command: az ad user delete --id #{userprincipalname}
     name: powershell    


### PR DESCRIPTION
**Details:**
Added a create user atomic test which uses the Azure CLI. It initially provides pre-requisites and a script to install the azure CLI if not already in place. It then prompts the user running the test to authenticate securely via MFA (if enabled) to azure ad and runs the azure cli command to create a user and then run a check to list whether it was created. There is a clean-up command to delete the user afterwards. I will make this into another atomic for account manipulation / account deletion.

**Testing:**
tested using Invoke-AtomicTest
![image](https://user-images.githubusercontent.com/16122365/224434518-e6eaae3c-8c40-4bb5-a34e-b3a0c1629806.png)

User created
![image](https://user-images.githubusercontent.com/16122365/224434591-f8117438-74e7-4a23-8d1d-b0dd10a8faa8.png)

Cleanup command removes user:
![image](https://user-images.githubusercontent.com/16122365/224434677-d91ccc74-0457-4e59-9101-3b3970c4420a.png)


**Associated Issues:**
None