### PR TITLE
Added test "Discover Specific Process - tasklist"

### DIFF
--- a/atomics/T1057/T1057.yaml
+++ b/atomics/T1057/T1057.yaml
@@ -70,3 +70,19 @@ atomic_tests:
     command: |
       wmic process get /format:list
     name: command_prompt
+- name: Discover Specific Process - tasklist
+  auto_generated_guid: 
+  description: |
+    Adversaries may use command line tools to discover specific processes in preparation of further attacks. 
+    Examples of this could be discovering the PID of lsass.exe to dump its memory or discovering whether specific security processes (e.g. AV or EDR) are running.
+  supported_platforms:
+  - windows
+  input_arguments:
+    process_to_enumerate:
+      description: Process name string to search for.
+      type: string
+      default: 'lsass'
+  executor:
+    command: |
+      tasklist | findstr #{process_to_enumerate}
+    name: command_prompt


### PR DESCRIPTION
This test is meant to simulate process discovery activity that targets specific process names. The default process here is lsass to simulate what is seen in https://www.whiteoaksecurity.com/blog/attacks-defenses-dumping-lsass-no-mimikatz/.

**Testing:**
<!-- Note any testing done, local or automated here. -->
<img width="321" alt="image" src="https://user-images.githubusercontent.com/59199225/225893075-38b59320-d368-4835-be62-4b94300b914c.png">