### PR TITLE
Update generate-counter.yml

### DIFF
--- a/.github/workflows/generate-counter.yml
+++ b/.github/workflows/generate-counter.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.12' 
+          python-version: '3.11.2' 
           cache: 'poetry'
       - name: Generate shields.io URL
         run: python generate_shield.py atomics/


### PR DESCRIPTION
ci was failing due to wrong python version

<img width="1653" alt="image" src="https://user-images.githubusercontent.com/1476868/228429024-9dcd6325-5ec0-4b2b-a367-cd428e34102c.png">


checked manifest `3.11.2` should be the right one.


**Details:**
<!-- Insert details about this change here. Please include as much detail as possible -->

**Testing:**
<!-- Note any testing done, local or automated here. -->

**Associated Issues:**
<!-- Please link any issues that this pull request impacts or fixes. -->