### PR TITLE
minor cleanup to dependencies and exit codes

### DIFF
--- a/atomics/T1056.001/T1056.001.yaml
+++ b/atomics/T1056.001/T1056.001.yaml
@@ -48,9 +48,10 @@ atomic_tests:
   supported_platforms:
   - linux
   executor:
-    command: if sudo test -f /etc/pam.d/password-auth; then sudo cp /etc/pam.d/password-auth
-      /tmp/password-auth.bk; fi; if sudo test -f /etc/pam.d/system-auth; then sudo
-      cp /etc/pam.d/system-auth /tmp/system-auth.bk; fi; sudo touch /tmp/password-auth.bk
+    command: |
+      if sudo test -f /etc/pam.d/password-auth; then sudo cp /etc/pam.d/password-auth /tmp/password-auth.bk; fi;
+      if sudo test -f /etc/pam.d/system-auth; then sudo cp /etc/pam.d/system-auth /tmp/system-auth.bk; fi;
+      sudo touch /tmp/password-auth.bk
       sudo touch /tmp/system-auth.bk sudo echo "session    required    pam_tty_audit.so
       enable=* log_password" >> /etc/pam.d/password-auth sudo echo "session    required    pam_tty_audit.so
       enable=* log_password" >> /etc/pam.d/system-auth

--- a/atomics/T1082/T1082.yaml
+++ b/atomics/T1082/T1082.yaml
@@ -53,6 +53,7 @@ atomic_tests:
   supported_platforms:
   - linux
   executor:
+    elevation_required: true
     command: |
       if [ -f /sys/class/dmi/id/bios_version ]; then cat /sys/class/dmi/id/bios_version | grep -i amazon; fi
       if [ -f /sys/class/dmi/id/product_name ]; then cat /sys/class/dmi/id/product_name | grep -i "Droplet\|HVM\|VirtualBox\|VMware"; fi

--- a/atomics/T1552.001/T1552.001.yaml
+++ b/atomics/T1552.001/T1552.001.yaml
@@ -43,6 +43,7 @@ atomic_tests:
   executor:
     command: |
       grep -ri password #{file_path}
+      exit 0
     name: sh
 - name: Extracting passwords with findstr
   auto_generated_guid: 0e56bf29-ff49-4ea5-9af4-3b81283fd513
@@ -77,12 +78,16 @@ atomic_tests:
   supported_platforms:
   - macos
   - linux
-
+  input_arguments:
+    file_path:
+      description: Path to search
+      type: String
+      default: /home
   executor:
     name: bash
-    elevation_required: false # Indicates whether command must be run with admin privileges. If the elevation_required attribute is not defined, the value is assumed to be false.
+    elevation_required: false
     command: |
-      for file in $(find / -name .netrc 2> /dev/null);do echo $file ; cat $file ; done 
+      for file in $(find #{file_path} -type f -name .netrc 2> /dev/null);do echo $file ; cat $file ; done
 - name: WinPwn - sensitivefiles
   auto_generated_guid: 114dd4e3-8d1c-4ea7-bb8d-8d8f6aca21f0
   description: Search for sensitive files on this local system using the SensitiveFiles function of WinPwn

--- a/atomics/T1552.004/T1552.004.yaml
+++ b/atomics/T1552.004/T1552.004.yaml
@@ -32,6 +32,7 @@ atomic_tests:
   executor:
     command: |
       find #{search_path} -name id_rsa 2>/dev/null >> #{output_file}
+      exit 0
     cleanup_command: |
       rm #{output_file}
     name: sh
@@ -54,6 +55,7 @@ atomic_tests:
     command: |
       mkdir #{output_folder}
       find #{search_path} -name id_rsa 2>/dev/null -exec cp --parents {} #{output_folder} \;
+      exit 0
     cleanup_command: |
       rm -rf #{output_folder}
     name: sh
@@ -77,6 +79,7 @@ atomic_tests:
     command: |
       mkdir #{output_folder}
       find #{search_path} -name id_rsa 2>/dev/null -exec rsync -R {} #{output_folder} \;
+      exit 0
     cleanup_command: |
       rm -rf #{output_folder}
     name: sh
@@ -100,6 +103,7 @@ atomic_tests:
     command: |
       mkdir #{output_folder}
       find #{search_path} -type d -name '.gnupg' 2>/dev/null -exec rsync -Rr {} #{output_folder} \;
+      exit 0
     cleanup_command: |
       rm -rf #{output_folder}
     name: sh

--- a/atomics/T1560.001/T1560.001.yaml
+++ b/atomics/T1560.001/T1560.001.yaml
@@ -230,7 +230,7 @@ atomic_tests:
     prereq_command: |
       test -e #{input_file_folder}
     get_prereq_command: |
-      echo Please set input_file_folder argument to a folder that exists
+      mkdir -p #{input_file_folder} && touch #{input_file_folder}/file1
   executor:
     name: sh
     elevation_required: false

--- a/atomics/T1560.002/T1560.002.yaml
+++ b/atomics/T1560.002/T1560.002.yaml
@@ -22,12 +22,14 @@ atomic_tests:
   - description: |
       Requires Python
     prereq_command: |
-      which_python=`which python`; $which_python -V
+      which python || which python3
     get_prereq_command: |
+      echo "please install python to run this test"; exit 1
   executor:
     name: bash
     elevation_required: false
     command: |
+      which_python=`which python || which python3`
       $which_python -c "import gzip;input_file=open('#{path_to_input_file}', 'rb');content=input_file.read();input_file.close();output_file=gzip.GzipFile('#{path_to_output_file}','wb',compresslevel=6);output_file.write(content);output_file.close();"
     cleanup_command: |
       rm #{path_to_output_file}
@@ -51,12 +53,14 @@ atomic_tests:
   - description: |
       Requires Python
     prereq_command: |
-      which_python=`which python`; $which_python -V
+      which python || which python3
     get_prereq_command: |
+      echo "please install python to run this test"; exit 1
   executor:
     name: bash
     elevation_required: false
     command: |
+      which_python=`which python || which python3`
       $which_python -c "import bz2;input_file=open('#{path_to_input_file}','rb');content=input_file.read();input_file.close();bz2content=bz2.compress(content,compresslevel=9);output_file=open('#{path_to_output_file}','w+');output_file.write(str(bz2content));output_file.close();"
     cleanup_command: |
       rm #{path_to_output_file}
@@ -80,12 +84,14 @@ atomic_tests:
   - description: |
       Requires Python
     prereq_command: |
-      which_python=`which python`; $which_python -V
+      which python || which python3
     get_prereq_command: |
+      echo "please install python to run this test"; exit 1
   executor:
     name: bash
     elevation_required: false
     command: |
+      which_python=`which python || which python3`
       $which_python -c "from zipfile import ZipFile; ZipFile('#{path_to_output_file}', mode='w').write('#{path_to_input_file}')"
     cleanup_command: |
       rm #{path_to_output_file}
@@ -109,12 +115,14 @@ atomic_tests:
   - description: |
       Requires Python
     prereq_command: |
-      which_python=`which python`; $which_python -V
+      which python || which python3
     get_prereq_command: |
+      echo "please install python to run this test"; exit 1
   executor:
     name: bash
     elevation_required: false
     command: |
+      which_python=`which python || which python3`
       $which_python -c "from zipfile import ZipFile; ZipFile('#{path_to_output_file}', mode='w').write('#{path_to_input_file}')" 
     cleanup_command: |
       rm #{path_to_output_file}

--- a/atomics/T1562.001/T1562.001.yaml
+++ b/atomics/T1562.001/T1562.001.yaml
@@ -62,6 +62,13 @@ atomic_tests:
     Disables SELinux enforcement
   supported_platforms:
   - linux
+  dependencies:
+    - description: |
+        SELinux must be installed
+      prereq_command: |
+        which setenforce
+      get_prereq_command: |
+        echo "SELinux is not installed"; exit 1
   executor:
     command: |
       setenforce 0

--- a/atomics/T1571/T1571.yaml
+++ b/atomics/T1571/T1571.yaml
@@ -37,7 +37,16 @@ atomic_tests:
       description: Specify target hostname
       type: string
       default: google.com
+  dependency_executor_name: sh
+  dependencies:
+    - description: |
+        Requires telnet
+      prereq_command: |
+        which telnet
+      get_prereq_command: |
+        echo "please install telnet to run this test"; exit 1
   executor:
     command: |
-      telnet #{domain} #{port}
+      echo quit | telnet #{domain} #{port}
+      exit 0
     name: sh


### PR DESCRIPTION
**Details:**
This is a collection of small fixes to input args, dependencies and exit codes.  They are needed to reliably run these tests in automation.
- dependency step should create file or dir if needed
- executor scripts should return 0 success if it ran.  The runner needs to know if the commands were executed, doesn't care about status of grep (pattern not found, etc).

**Testing:**
tested on Ubuntu 20.04

**Associated Issues:**
none that I am aware of.