### PR TITLE
modified T1053 to use schtasks instead of the deprecated at.exe

### DIFF
--- a/atomics/T1053.002/T1053.002.yaml
+++ b/atomics/T1053.002/T1053.002.yaml
@@ -2,20 +2,19 @@ attack_technique: T1053.002
 display_name: 'Scheduled Task/Job: At'
 
 atomic_tests:
-- name: At.exe Scheduled task
-  auto_generated_guid: 4a6c0dc4-0f2a-4203-9298-a5a9bdc21ed8
+- name: schtasks.exe Scheduled task
   description: |
     Executes cmd.exe
-    Note: deprecated in Windows 8+
-
-    Upon successful execution, cmd.exe will spawn at.exe and create a scheduled task that will spawn cmd at a specific time.
+    Upon successful execution, powershell will spawn schtasks.exe and create a scheduled task that will spawn cmd at a specific time.
   supported_platforms:
   - windows
   executor:
     name: command_prompt
     elevation_required: false
     command: |
-      at 13:20 /interactive cmd
+      schtasks /create /tn "InteractiveCmdTask" /tr "cmd.exe" /sc once /st 13:20 /it
+    cleanup_command: |
+      schtasks /delete /tn "InteractiveCmdTask" /f
 - name: At - Schedule a job
   auto_generated_guid: 7266d898-ac82-4ec0-97c7-436075d0d08e
   description: |


### PR DESCRIPTION
**Details:**
<!-- Insert details about this change here. Please include as much detail as possible -->
This pull request updates the atomic test T1053.002 to replace the usage of the deprecated at.exe command with the recommended schtasks.exe utility. The at.exe command has been deprecated, and it is important to use the updated approach for scheduling tasks in Windows systems.

Replaced the usage of at.exe with schtasks.exe in the atomic test T1053.002.
Updated the command and provided the necessary parameters to schedule the task using schtasks.exe.
Added appropriate comments and clean up command in the updated atomic test.

**Testing:**
<!-- Note any testing done, local or automated here. -->
Tested on windows powershell and windows cmd.

**Associated Issues:**
<!-- Please link any issues that this pull request impacts or fixes. -->