### PR TITLE
adding new test in T1176 - Load unpacked extension with command line

### DIFF
--- a/atomics/T1176/T1176.yaml
+++ b/atomics/T1176/T1176.yaml
@@ -75,9 +75,6 @@ atomic_tests:
 
   supported_platforms:
   - windows
-  input_arguments: 
-  dependency_executor_name: 
-  dependencies: 
   executor:
     command: |-
 

--- a/atomics/T1176/T1176.yaml
+++ b/atomics/T1176/T1176.yaml
@@ -64,3 +64,44 @@ atomic_tests:
       2. Click 'Get'
     name: manual
 
+- name: Google Chrome Load Unpacked Extension With Command Line
+  auto_generated_guid: 
+
+  description: |-
+    This test loads an unpacked extension in Google Chrome with the `--load-extension` parameter. This technique was previously used by the Grandoreiro malware to load a malicious extension that would capture the browsing history, steal cookies and other user information. Other malwares also leverage this technique to hijack searches, steal passwords, inject ads, and more.
+    
+    References:
+    https://attack.mitre.org/techniques/T1176/
+    https://securityintelligence.com/posts/grandoreiro-malware-now-targeting-banks-in-spain/
+
+  supported_platforms:
+  - windows
+  input_arguments: 
+  dependency_executor_name: 
+  dependencies: 
+  executor:
+    command: |-
+
+      # Chromium
+      $chromium =  "https://commondatastorage.googleapis.com/chromium-browser-snapshots/Win_x64/1153778/chrome-win.zip"
+
+      # uBlock Origin Lite to test side-loading
+      $extension = "https://github.com/gorhill/uBlock/releases/download/uBOLite_0.1.23.6055/uBOLite_0.1.23.6055.chromium.mv3.zip"
+
+      Set-Location $env:TEMP
+
+      Invoke-WebRequest -URI $chromium -OutFile $env:TEMP\chrome.zip
+      Invoke-WebRequest -URI $extension -OutFile $env:TEMP\extension.zip
+
+
+      Expand-Archive chrome.zip -DestinationPath $env:TEMP -Force
+      Expand-Archive extension.zip -Force
+
+      $chrome = Start-Process .\chrome-win\chrome.exe --load-extension="$env:TEMP\extension\" -PassThru
+
+    cleanup_command: |-
+      Stop-Process -Id $chrome.Id
+      Remove-Item .\chrome.zip, .\chrome-win, .\extension, .\extension.zip -Recurse -Force
+
+    name: powershell
+    elevation_required: true

--- a/atomics/T1176/T1176.yaml
+++ b/atomics/T1176/T1176.yaml
@@ -65,7 +65,6 @@ atomic_tests:
     name: manual
 
 - name: Google Chrome Load Unpacked Extension With Command Line
-  auto_generated_guid: 
 
   description: |-
     This test loads an unpacked extension in Google Chrome with the `--load-extension` parameter. This technique was previously used by the Grandoreiro malware to load a malicious extension that would capture the browsing history, steal cookies and other user information. Other malwares also leverage this technique to hijack searches, steal passwords, inject ads, and more.

--- a/atomics/T1176/T1176.yaml
+++ b/atomics/T1176/T1176.yaml
@@ -75,6 +75,11 @@ atomic_tests:
 
   supported_platforms:
   - windows
+    input_arguments:
+      working_dir:
+        description: Working directory where the files will be downloaded and extracted
+        type: string
+        default: $env:TEMP
   executor:
     command: |-
 
@@ -84,20 +89,23 @@ atomic_tests:
       # uBlock Origin Lite to test side-loading
       $extension = "https://github.com/gorhill/uBlock/releases/download/uBOLite_0.1.23.6055/uBOLite_0.1.23.6055.chromium.mv3.zip"
 
-      Set-Location $env:TEMP
+      Set-Location "#{working_dir}"
 
-      Invoke-WebRequest -URI $chromium -OutFile $env:TEMP\chrome.zip
-      Invoke-WebRequest -URI $extension -OutFile $env:TEMP\extension.zip
+      Set-Variable ProgressPreference SilentlyContinue
+      Invoke-WebRequest -URI $chromium -OutFile "#{working_dir}\chrome.zip"
+      Invoke-WebRequest -URI $extension -OutFile "#{working_dir}\extension.zip"
 
 
-      Expand-Archive chrome.zip -DestinationPath $env:TEMP -Force
+      Expand-Archive chrome.zip -DestinationPath "#{working_dir}" -Force
       Expand-Archive extension.zip -Force
 
-      $chrome = Start-Process .\chrome-win\chrome.exe --load-extension="$env:TEMP\extension\" -PassThru
+      Start-Process .\chrome-win\chrome.exe --load-extension="#{working_dir}\extension\" -PassThru
 
     cleanup_command: |-
-      Stop-Process -Id $chrome.Id
+      Set-Location "#{working_dir}"
+      Stop-Process -Name chrome -Force
       Remove-Item .\chrome.zip, .\chrome-win, .\extension, .\extension.zip -Recurse -Force
+      Set-Variable ProgressPreference Continue
 
     name: powershell
     elevation_required: true

--- a/atomics/T1176/T1176.yaml
+++ b/atomics/T1176/T1176.yaml
@@ -75,11 +75,11 @@ atomic_tests:
 
   supported_platforms:
   - windows
-    input_arguments:
-      working_dir:
-        description: Working directory where the files will be downloaded and extracted
-        type: string
-        default: $env:TEMP
+  input_arguments:
+    working_dir:
+      description: Working directory where the files will be downloaded and extracted
+      type: string
+      default: $env:TEMP
   executor:
     command: |-
 


### PR DESCRIPTION
**Details:**
This test simulates an attack similar to what the Grandoreiro malware did by loading an unpacked extension in Google Chrome with the --load-extension argument.

Reference: https://securityintelligence.com/posts/grandoreiro-malware-now-targeting-banks-in-spain/

**Testing:**
Windows 10 22H2 with Google Chrome and Chromium

**Associated Issues:**
N/A