### PR TITLE
T1547.005

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 # Atomic Red Team
 
-![GitHub Action Status](https://github.com/redcanaryco/atomic-red-team/actions/workflows/validate-atomics.yml/badge.svg?branch=master) ![Atomics](https://img.shields.io/badge/Atomics-1274-flat.svg) ![GitHub Action Status](https://github.com/redcanaryco/atomic-red-team/actions/workflows/generate-docs.yml/badge.svg?branch=master)
+![GitHub Action Status](https://github.com/redcanaryco/atomic-red-team/actions/workflows/validate-atomics.yml/badge.svg?branch=master) ![Atomics](https://img.shields.io/badge/Atomics-1357-flat.svg) ![GitHub Action Status](https://github.com/redcanaryco/atomic-red-team/actions/workflows/generate-docs.yml/badge.svg?branch=master)
 
 
 

--- a/atomics/T1547.005/T1547.005.yaml
+++ b/atomics/T1547.005/T1547.005.yaml
@@ -3,25 +3,22 @@ display_name: 'Boot or Logon Autostart Execution: Security Support Provider'
 atomic_tests:
 - name: Modify HKLM:\System\CurrentControlSet\Control\Lsa Security Support Provider configuration in registry
   auto_generated_guid: afdfd7e3-8a0b-409f-85f7-886fdf249c9e
-  description: Add a value to a Windows registry SSP key, simulating an adversarial modification of those keys.
+  description: |
+    Add a value to a Windows registry Security Support Provider pointing to a payload .dll which will normally need to be copied in the system32 folder.
+    A common DLL used with this techquite is the minilib.dll from mimikatz, see https://pentestlab.blog/2019/10/21/persistence-security-support-provider/
   supported_platforms:
   - windows
-  input_arguments:
-    payload:
-      description: Value added to registry key. Normally refers to a DLL name in C:\Windows\System32.
-      type: string
-      default: not-a-ssp
   executor:
     command: |
       $oldvalue = $(Get-ItemProperty HKLM:\System\CurrentControlSet\Control\Lsa -Name 'Security Packages' | Select-Object -ExpandProperty 'Security Packages');
       Set-ItemProperty -Path "HKLM:\System\CurrentControlSet\Control\Lsa" -Name 'Security Packages old' -Value "$oldvalue";
-      $newvalue = $oldvalue + " #{payload}";
-      HKLM:\SYSTEM\CurrentControlSet\Control\Lsa -Name 'Security Packages' -Value $newvalue
+      $newvalue = "AtomicTest.dll";
+      Set-ItemProperty HKLM:\SYSTEM\CurrentControlSet\Control\Lsa -Name 'Security Packages' -Value $newvalue
       
     cleanup_command: |-
-      $oldvalue = $(Get-ItemPropertyValue -Path  "HKLM:\System\CurrentControlSet\Control\Lsa" -Name 'Security Packages old' | Select-Object -ExpandProperty 'Security Packages');
+      $oldvalue = $(Get-ItemPropertyValue -Path  "HKLM:\System\CurrentControlSet\Control\Lsa" -Name 'Security Packages old' | Select-Object -ExpandProperty 'Security Packages old');
       Set-ItemProperty -Path HKLM:\System\CurrentControlSet\Control\Lsa -Name 'Security Packages' -Value "$oldvalue";
-      Remove-ItemProperty -Path  "HKLM:\System\CurrentControlSet\Control\Lsa" -Name 'Security Packages old'
+      Remove-ItemProperty -Path  "HKLM:\System\CurrentControlSet\Control\Lsa" -Name 'Security Packages old';
     name: powershell
     elevation_required: true
 
@@ -29,21 +26,16 @@ atomic_tests:
   description: Add a value to a Windows registry SSP key, simulating an adversarial modification of those keys.
   supported_platforms:
   - windows
-  input_arguments:
-    payload:
-      description: Value added to registry key. Normally refers to a DLL name in C:\Windows\System32.
-      type: string
-      default: not-a-ssp
   executor:
     command: |
       $oldvalue = $(Get-ItemProperty HKLM:\System\CurrentControlSet\Control\Lsa\OSConfig -Name 'Security Packages' | Select-Object -ExpandProperty 'Security Packages');
       Set-ItemProperty -Path "HKLM:\System\CurrentControlSet\Control\Lsa\OSConfig" -Name 'Security Packages old' -Value "$oldvalue";
-      $newvalue = $oldvalue + " #{payload}";
-      HKLM:\SYSTEM\CurrentControlSet\Control\Lsa\OSConfig -Name 'Security Packages' -Value $newvalue
+      $newvalue = "AtomicTest.dll";
+      Set-ItemProperty HKLM:\SYSTEM\CurrentControlSet\Control\Lsa\OSConfig -Name 'Security Packages' -Value $newvalue
       
     cleanup_command: |-
-      $oldvalue = $(Get-ItemPropertyValue -Path  "HKLM:\System\CurrentControlSet\Control\Lsa\OSConfig" -Name 'Security Packages old' | Select-Object -ExpandProperty 'Security Packages');
+      $oldvalue = $(Get-ItemPropertyValue -Path  "HKLM:\System\CurrentControlSet\Control\Lsa\OSConfig" -Name 'Security Packages old' | Select-Object -ExpandProperty 'Security Packages old');
       Set-ItemProperty -Path HKLM:\System\CurrentControlSet\Control\Lsa\OSConfig -Name 'Security Packages' -Value "$oldvalue";
-      Remove-ItemProperty -Path  "HKLM:\System\CurrentControlSet\Control\Lsa\OSConfig" -Name 'Security Packages old'
+      Remove-ItemProperty -Path  "HKLM:\System\CurrentControlSet\Control\Lsa\OSConfig" -Name 'Security Packages old';
     name: powershell
     elevation_required: true

--- a/atomics/T1547.005/T1547.005.yaml
+++ b/atomics/T1547.005/T1547.005.yaml
@@ -1,25 +1,49 @@
 attack_technique: T1547.005
 display_name: 'Boot or Logon Autostart Execution: Security Support Provider'
 atomic_tests:
-- name: Modify SSP configuration in registry
+- name: Modify HKLM:\System\CurrentControlSet\Control\Lsa SSP configuration in registry
   auto_generated_guid: afdfd7e3-8a0b-409f-85f7-886fdf249c9e
   description: Add a value to a Windows registry SSP key, simulating an adversarial modification of those keys.
   supported_platforms:
   - windows
   input_arguments:
-    fake_ssp_dll:
+    payload:
       description: Value added to registry key. Normally refers to a DLL name in C:\Windows\System32.
       type: string
       default: not-a-ssp
   executor:
     command: |
-      # run these in sequence
-      $SecurityPackages = Get-ItemProperty HKLM:\System\CurrentControlSet\Control\Lsa -Name 'Security Packages' | Select-Object -ExpandProperty 'Security Packages'
-      $SecurityPackagesUpdated = $SecurityPackages
-      $SecurityPackagesUpdated += "#{fake_ssp_dll}"
-      Set-ItemProperty HKLM:\SYSTEM\CurrentControlSet\Control\Lsa -Name 'Security Packages' -Value $SecurityPackagesUpdated
+      $oldvalue = $(Get-ItemProperty HKLM:\System\CurrentControlSet\Control\Lsa -Name 'Security Packages' | Select-Object -ExpandProperty 'Security Packages');
+      Set-ItemProperty -Path "HKLM:\System\CurrentControlSet\Control\Lsa" -Name 'Security Packages old' -Value "$oldvalue";
+      $newvalue = $oldvalue + " #{payload}";
+      HKLM:\SYSTEM\CurrentControlSet\Control\Lsa -Name 'Security Packages' -Value $newvalue
+      
+    cleanup_command: |-
+      $oldvalue = $(Get-ItemPropertyValue -Path  "HKLM:\System\CurrentControlSet\Control\Lsa" -Name 'Security Packages old' | Select-Object -ExpandProperty 'Security Packages');
+      Set-ItemProperty -Path HKLM:\System\CurrentControlSet\Control\Lsa -Name 'Security Packages' -Value "$oldvalue";
+      Remove-ItemProperty -Path  "HKLM:\System\CurrentControlSet\Control\Lsa" -Name 'Security Packages old'
+    name: powershell
+    elevation_required: true
 
-      # revert (before reboot)
-      Set-ItemProperty HKLM:\SYSTEM\CurrentControlSet\Control\Lsa -Name 'Security Packages' -Value $SecurityPackages
+- name: Modify HKLM:\System\CurrentControlSet\Control\Lsa\OSConfig SSP configuration in registry
+  description: Add a value to a Windows registry SSP key, simulating an adversarial modification of those keys.
+  supported_platforms:
+  - windows
+  input_arguments:
+    payload:
+      description: Value added to registry key. Normally refers to a DLL name in C:\Windows\System32.
+      type: string
+      default: not-a-ssp
+  executor:
+    command: |
+      $oldvalue = $(Get-ItemProperty HKLM:\System\CurrentControlSet\Control\Lsa\OSConfig -Name 'Security Packages' | Select-Object -ExpandProperty 'Security Packages');
+      Set-ItemProperty -Path "HKLM:\System\CurrentControlSet\Control\Lsa\OSConfig" -Name 'Security Packages old' -Value "$oldvalue";
+      $newvalue = $oldvalue + " #{payload}";
+      HKLM:\SYSTEM\CurrentControlSet\Control\Lsa\OSConfig -Name 'Security Packages' -Value $newvalue
+      
+    cleanup_command: |-
+      $oldvalue = $(Get-ItemPropertyValue -Path  "HKLM:\System\CurrentControlSet\Control\Lsa\OSConfig" -Name 'Security Packages old' | Select-Object -ExpandProperty 'Security Packages');
+      Set-ItemProperty -Path HKLM:\System\CurrentControlSet\Control\Lsa\OSConfig -Name 'Security Packages' -Value "$oldvalue";
+      Remove-ItemProperty -Path  "HKLM:\System\CurrentControlSet\Control\Lsa\OSConfig" -Name 'Security Packages old'
     name: powershell
     elevation_required: true

--- a/atomics/T1547.005/T1547.005.yaml
+++ b/atomics/T1547.005/T1547.005.yaml
@@ -1,7 +1,7 @@
 attack_technique: T1547.005
 display_name: 'Boot or Logon Autostart Execution: Security Support Provider'
 atomic_tests:
-- name: Modify HKLM:\System\CurrentControlSet\Control\Lsa SSP configuration in registry
+- name: Modify HKLM:\System\CurrentControlSet\Control\Lsa Security Support Provider configuration in registry
   auto_generated_guid: afdfd7e3-8a0b-409f-85f7-886fdf249c9e
   description: Add a value to a Windows registry SSP key, simulating an adversarial modification of those keys.
   supported_platforms:
@@ -25,7 +25,7 @@ atomic_tests:
     name: powershell
     elevation_required: true
 
-- name: Modify HKLM:\System\CurrentControlSet\Control\Lsa\OSConfig SSP configuration in registry
+- name: Modify HKLM:\System\CurrentControlSet\Control\Lsa\OSConfig Security Support Provider configuration in registry
   description: Add a value to a Windows registry SSP key, simulating an adversarial modification of those keys.
   supported_platforms:
   - windows


### PR DESCRIPTION
**Details:**
Fixed the execution and cleanup commands. 
Before, the execution was storing the old value to a variable and the code was running the cleanup during the test execution. 
The old value is now stored in a temporary key value and the cleanup can be run from a  separate PowerShell session. 

Added links to using this technique with the mimikatz dll, attempted using the same DLL as for T1547.002 but it was preventing proper reboot (I'll test further in the future)

Added a new test for an alternate registry location for this technique as documented in https://attack.mitre.org/techniques/T1547/005/

**Testing:**
 windows 10 VM

**Associated Issues:**
N/A