### PR TITLE
Replacing File.exists? with File.exist? for Ruby 3.2.2 support

### DIFF
--- a/atomic_red_team/atomic_red_team.rb
+++ b/atomic_red_team/atomic_red_team.rb
@@ -78,7 +78,7 @@ class AtomicRedTeam
     yaml_file = "#{ATOMICS_DIRECTORY}/#{technique_identifier}/#{technique_identifier}.yaml"
     markdown_file = "#{ATOMICS_DIRECTORY}/#{technique_identifier}/#{technique_identifier}.md"
 
-    if atomic_yaml_has_test_for_platform(yaml_file, only_platform) && (File.exists? markdown_file)
+    if atomic_yaml_has_test_for_platform(yaml_file, only_platform) && (File.exist? markdown_file)
       # we have a file for this technique, so link to it's Markdown file
       "[#{link_display}](../../#{technique_identifier}/#{technique_identifier}.md)"
     else
@@ -89,7 +89,7 @@ class AtomicRedTeam
 
   def atomic_yaml_has_test_for_platform(yaml_file, only_platform)
     has_test_for_platform = false
-    if File.exists? yaml_file
+    if File.exist? yaml_file
       yaml = YAML.load_file(yaml_file)
       yaml['atomic_tests'].each_with_index do |atomic, i|
         if atomic["supported_platforms"].any? {|platform| platform.downcase =~ only_platform}

--- a/atomic_red_team/attack_api.rb
+++ b/atomic_red_team/attack_api.rb
@@ -107,7 +107,7 @@ class Attack
     @attack_stix ||= begin
       # load the full attack library
       local_attack_json_to_try = "#{File.dirname(__FILE__)}/enterprise-attack.json"
-      if File.exists? local_attack_json_to_try
+      if File.exist? local_attack_json_to_try
         JSON.parse File.read(local_attack_json_to_try)
       else
         JSON.parse open('https://raw.githubusercontent.com/mitre/cti/master/enterprise-attack/enterprise-attack.json').read

--- a/bin/new-atomic.rb
+++ b/bin/new-atomic.rb
@@ -25,7 +25,7 @@ usage! if technique_id.nil?
 technique_id = technique_id.upcase
 technique_atomic_test_file = "#{File.dirname(File.dirname(__FILE__))}/atomics/#{technique_id}/#{technique_id}.yaml"
 
-if File.exists? technique_atomic_test_file
+if File.exist? technique_atomic_test_file
   puts "Atomic tests for #{technique_id} already exist - adding a new atomic test to the end"
   File.open(technique_atomic_test_file, 'a') { |f| f.write("\n#{template_technique_atomic_test}") }
 


### PR DESCRIPTION
**Details:**
After upgrading to Ruby 3.2.0, it appears that `File.exists?` is no longer supported. Since this is the only issue I've noticed and I believe `File.exist?` works with older versions of Ruby, this would be a subtle change.

```
root@b1a1bd803e42:/$ ruby --version
ruby 3.2.2 (2023-03-30 revision e51014f9c0) [x86_64-linux]
root@b1a1bd803e42:/$ irb
irb(main):001:0> File.exists?
(irb):1:in `<main>': undefined method `exists?' for File:Class (NoMethodError)
Did you mean?  exist?
        from /usr/local/lib/ruby/gems/3.2.0/gems/irb-1.6.2/exe/irb:11:in `<top (required)>'
        from /usr/local/bin/irb:25:in `load'
        from /usr/local/bin/irb:25:in `<main>'
irb(main):002:0>
```

**Testing:**
I have confirmed that using `File.exist?` instead of `File.exists?` does not break anything. It appears that `File.exists?` has been [phasing out since Ruby 2.2.0](https://docs.ruby-lang.org/en/2.2.0/File.html).