### PR TITLE
Added ExternalPayloads dir creation

### DIFF
--- a/atomics/T1087.002/T1087.002.yaml
+++ b/atomics/T1087.002/T1087.002.yaml
@@ -288,7 +288,7 @@ atomic_tests:
     prereq_command: |
       if (test-path "PathToAtomicsFolder\..\ExternalPayloads\username.txt"){exit 0} else {exit 1}
     get_prereq_command: |
-      New-Item -Type Directory (split-path PathToAtomicsFolder\..\ExternalPayloads\username.txt -ErrorAction ignore -Force | Out-Null
+      New-Item -Type Directory "PathToAtomicsFolder\..\ExternalPayloads\" -ErrorAction ignore -Force | Out-Null
       invoke-webrequest "https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1087.002/src/username.txt?raw=true" -outfile "PathToAtomicsFolder\..\ExternalPayloads\username.txt"
   executor:
     command: |-

--- a/atomics/T1087.002/T1087.002.yaml
+++ b/atomics/T1087.002/T1087.002.yaml
@@ -281,12 +281,14 @@ atomic_tests:
     prereq_command: |
       if (test-path "PathToAtomicsFolder\..\ExternalPayloads\kerbrute.exe"){exit 0} else {exit 1}
     get_prereq_command: |
+      New-Item -Type Directory "PathToAtomicsFolder\..\ExternalPayloads\" -ErrorAction ignore -Force | Out-Null
       invoke-webrequest "https://github.com/ropnop/kerbrute/releases/download/v1.0.3/kerbrute_windows_386.exe" -outfile "PathToAtomicsFolder\..\ExternalPayloads\kerbrute.exe"
   - description: |
       username text file must exist in PathToAtomicsFolder\..\ExternalPayloads.
     prereq_command: |
       if (test-path "PathToAtomicsFolder\..\ExternalPayloads\username.txt"){exit 0} else {exit 1}
     get_prereq_command: |
+      New-Item -Type Directory (split-path PathToAtomicsFolder\..\ExternalPayloads\username.txt -ErrorAction ignore -Force | Out-Null
       invoke-webrequest "https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1087.002/src/username.txt?raw=true" -outfile "PathToAtomicsFolder\..\ExternalPayloads\username.txt"
   executor:
     command: |-

--- a/atomics/T1090.003/T1090.003.yaml
+++ b/atomics/T1090.003/T1090.003.yaml
@@ -25,15 +25,17 @@ atomic_tests:
   - description: |
       The Psiphon executable must exist in the Downloads folder
     prereq_command: |
-      if (Test-Path $env:UserProfile\Downloads\psiphon3.exe) {exit 0} else {exit 1}
+      if (Test-Path "PathToAtomicsFolder\..\ExternalPayloads\psiphon3.exe") {exit 0} else {exit 1}
     get_prereq_command: |
-      Invoke-WebRequest -OutFile "$env:UserProfile\Downloads\psiphon3.exe" "https://s3.amazonaws.com/0ubz-2q11-gi9y/psiphon3.exe"
+      New-Item -Type Directory "PathToAtomicsFolder\..\ExternalPayloads\" -ErrorAction ignore -Force | Out-Null
+      Invoke-WebRequest "https://s3.amazonaws.com/0ubz-2q11-gi9y/psiphon3.exe" -OutFile "PathToAtomicsFolder\..\ExternalPayloads\psiphon3.exe" 
   - description: |
       Batch file containing commands to run must be in src directory 
     prereq_command: |
       if (Test-Path "PathToAtomicsFolder\T1090.003\src\Psiphon.bat") {exit 0} else {exit 1}
     get_prereq_command: |
-      Invoke-WebRequest -OutFile "PathToAtomicsFolder\T1090.003\src\Psiphon.bat" "https://github.com/redcanaryco/atomic-red-team/raw/master/atomics/T1090.003/src/Psiphon.bat"
+      New-Item -Type Directory "PathToAtomicsFolder\T1090.003\src\" -ErrorAction ignore -Force | Out-Null
+      Invoke-WebRequest "https://github.com/redcanaryco/atomic-red-team/raw/master/atomics/T1090.003/src/Psiphon.bat" -OutFile "PathToAtomicsFolder\T1090.003\src\Psiphon.bat"
   executor:
     name: powershell
     command: |

--- a/atomics/T1559/T1559.yaml
+++ b/atomics/T1559/T1559.yaml
@@ -17,6 +17,7 @@ atomic_tests:
     prereq_command: |
       if ((Test-Path "PathToAtomicsFolder\..\ExternalPayloads\build\namedpipes_executor.exe") -and (Test-Path "PathToAtomicsFolder\..\ExternalPayloads\build\namedpipes_client.exe") -and (Test-Path "PathToAtomicsFolder\..\ExternalPayloads\build\namedpipes_server.exe")) {exit 0} else {exit 1}
     get_prereq_command: |
+      New-Item -Type Directory "PathToAtomicsFolder\..\ExternalPayloads\" -ErrorAction ignore -Force | Out-Null
       [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
       IEX (iwr "https://raw.githubusercontent.com/redcanaryco/invoke-atomicredteam/master/Public/Invoke-FetchFromZip.ps1" -UseBasicParsing)
       $zipUrl  = "https://github.com/center-for-threat-informed-defense/adversary_emulation_library/raw/master/micro_emulation_plans/src/named_pipes/named_pipes.zip"

--- a/atomics/T1559/T1559.yaml
+++ b/atomics/T1559/T1559.yaml
@@ -42,6 +42,7 @@ atomic_tests:
     prereq_command: |
       if ((Test-Path "PathToAtomicsFolder\..\ExternalPayloads\build\namedpipes_executor.exe") -and (Test-Path "PathToAtomicsFolder\..\ExternalPayloads\build\namedpipes_client.exe") -and (Test-Path "PathToAtomicsFolder\..\ExternalPayloads\build\namedpipes_server.exe")) {exit 0} else {exit 1}
     get_prereq_command: |
+      New-Item -Type Directory "PathToAtomicsFolder\..\ExternalPayloads\" -ErrorAction ignore -Force | Out-Null
       [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
       IEX (iwr "https://raw.githubusercontent.com/redcanaryco/invoke-atomicredteam/master/Public/Invoke-FetchFromZip.ps1" -UseBasicParsing)
       $zipUrl  = "https://github.com/center-for-threat-informed-defense/adversary_emulation_library/raw/master/micro_emulation_plans/src/named_pipes/named_pipes.zip"
@@ -66,6 +67,7 @@ atomic_tests:
     prereq_command: |
       if ((Test-Path "PathToAtomicsFolder\..\ExternalPayloads\build\namedpipes_executor.exe") -and (Test-Path "PathToAtomicsFolder\..\ExternalPayloads\build\namedpipes_client.exe") -and (Test-Path "PathToAtomicsFolder\..\ExternalPayloads\build\namedpipes_server.exe")) {exit 0} else {exit 1}
     get_prereq_command: |
+      New-Item -Type Directory "PathToAtomicsFolder\..\ExternalPayloads\" -ErrorAction ignore -Force | Out-Null
       [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
       IEX (iwr "https://raw.githubusercontent.com/redcanaryco/invoke-atomicredteam/master/Public/Invoke-FetchFromZip.ps1" -UseBasicParsing)
       $zipUrl  = "https://github.com/center-for-threat-informed-defense/adversary_emulation_library/raw/master/micro_emulation_plans/src/named_pipes/named_pipes.zip"
@@ -90,6 +92,7 @@ atomic_tests:
     prereq_command: |
       if ((Test-Path "PathToAtomicsFolder\..\ExternalPayloads\build\namedpipes_executor.exe") -and (Test-Path "PathToAtomicsFolder\..\ExternalPayloads\build\namedpipes_client.exe") -and (Test-Path "PathToAtomicsFolder\..\ExternalPayloads\build\namedpipes_server.exe")) {exit 0} else {exit 1}
     get_prereq_command: |
+      New-Item -Type Directory "PathToAtomicsFolder\..\ExternalPayloads\" -ErrorAction ignore -Force | Out-Null
       [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
       IEX (iwr "https://raw.githubusercontent.com/redcanaryco/invoke-atomicredteam/master/Public/Invoke-FetchFromZip.ps1" -UseBasicParsing)
       $zipUrl  = "https://github.com/center-for-threat-informed-defense/adversary_emulation_library/raw/master/micro_emulation_plans/src/named_pipes/named_pipes.zip"
@@ -114,6 +117,7 @@ atomic_tests:
     prereq_command: |
       if ((Test-Path "PathToAtomicsFolder\..\ExternalPayloads\build\namedpipes_executor.exe") -and (Test-Path "PathToAtomicsFolder\..\ExternalPayloads\build\namedpipes_client.exe") -and ("Test-Path PathToAtomicsFolder\..\ExternalPayloads\build\namedpipes_server.exe")) {exit 0} else {exit 1}
     get_prereq_command: |
+      New-Item -Type Directory "PathToAtomicsFolder\..\ExternalPayloads\" -ErrorAction ignore -Force | Out-Null
       [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
       IEX (iwr "https://raw.githubusercontent.com/redcanaryco/invoke-atomicredteam/master/Public/Invoke-FetchFromZip.ps1" -UseBasicParsing)
       $zipUrl  = "https://github.com/center-for-threat-informed-defense/adversary_emulation_library/raw/master/micro_emulation_plans/src/named_pipes/named_pipes.zip"


### PR DESCRIPTION
**Details:**
I added the Powershell command for creating the ExternalPayloads directory for both get_prereq_commands for procedure f450461c-18d1-4452-9f0d-2c42c3f08624

**Testing:**
I tested locally and the directory is successfully created and the files successfully download to the created directory.

**Associated Issues:**
N/A