### PR TITLE
rearrange to have success exit code

### DIFF
--- a/atomics/T1069.002/T1069.002.yaml
+++ b/atomics/T1069.002/T1069.002.yaml
@@ -26,7 +26,7 @@ atomic_tests:
     user:
       description: User to identify what groups a user is a member of
       type: string
-      default: administrator
+      default: $env:USERNAME
   executor:
     command: |
       get-ADPrincipalGroupMembership #{user} | select name

--- a/atomics/T1069.002/T1069.002.yaml
+++ b/atomics/T1069.002/T1069.002.yaml
@@ -40,10 +40,10 @@ atomic_tests:
   - windows
   executor:
     command: |
-      net group /domai "Domain Admins"
       net groups "Account Operators" /doma
       net groups "Exchange Organization Management" /doma
       net group "BUILTIN\Backup Operators" /doma
+      net group /domai "Domain Admins"
     name: command_prompt
 - name: Find machines where user has local admin access (PowerView)
   auto_generated_guid: a2d71eee-a353-4232-9f86-54f4288dd8c1

--- a/atomics/T1069.002/T1069.002.yaml
+++ b/atomics/T1069.002/T1069.002.yaml
@@ -12,8 +12,8 @@ atomic_tests:
     command: |
       net localgroup
       net group /domain
-      net group "domain admins" /domain
       net group "enterprise admins" /domain
+      net group "domain admins" /domain
     name: command_prompt
 - name: Permission Groups Discovery PowerShell (Domain)
   auto_generated_guid: 6d5d8c96-3d2a-4da9-9d6d-9a9d341899a7


### PR DESCRIPTION
not all domains have enterprise admin group, but we still want a successful exit code returned

Also, default to current user for domain group membership check