### PR TITLE
Update T1059.004.yaml

### DIFF
--- a/atomics/T1059.004/T1059.004.yaml
+++ b/atomics/T1059.004/T1059.004.yaml
@@ -230,3 +230,13 @@ atomic_tests:
       ls -la /tmp/art.txt      
     cleanup_command: |
       rm /tmp/art.txt
+- name: Current kernel information enumeration
+  description: |
+    An adversary may want to enumerate the kernel information to tailor their attacks for that particular kernel. The following command will enumerate the kernel information.
+  supported_platforms:
+  - linux
+  executor:
+    name: sh
+    elevation_required: false
+    command: |
+      uname -srm


### PR DESCRIPTION
**Details:**
Included a check to enumerate the following Kernel information with `uname -srm`:

1. Kernel name
2. Kernel release
3. Machine hardware name

**Testing:**
Locally tested on a number of distros including:

1. Alpine 3.12
2. Debian 11
3. Debian 12
4. Fedora 37
5. Fedora 38
6. Ubuntu Desktop 22.04
7. Ubuntu Server 22.04

**Associated Issues:**
Nil