### PR TITLE
Escaping '\' character in Markdown

### DIFF
--- a/atomics/T1048.002/T1048.002.md
+++ b/atomics/T1048.002/T1048.002.md
@@ -53,9 +53,9 @@ if (Test-Path #{curl_path}) {exit 0} else {exit 1}
 ##### Get Prereq Commands:
 ```powershell
 New-Item -Type Directory "PathToAtomicsFolder\..\ExternalPayloads\" -ErrorAction Ignore -Force | Out-Null
-Invoke-WebRequest "https://curl.se/windows/dl-7.79.1/curl-7.79.1-win64-mingw.zip" -Outfile "PathToAtomicsFolder\..\ExternalPayloads\curl.zip"
-Expand-Archive -Path "PathToAtomicsFolder\..\ExternalPayloads\curl.zip -DestinationPath" "PathToAtomicsFolder\..\ExternalPayloads\curl"
-Copy-Item "PathToAtomicsFolder\..\ExternalPayloads\curl\curl-7.79.1-win64-mingw\bin\curl.exe" C:\Windows\System32\Curl.exe
+Invoke-WebRequest "https://curl.se/windows/dl-8.4.0_6/curl-8.4.0_6-win64-mingw.zip" -Outfile "PathToAtomicsFolder\..\ExternalPayloads\curl.zip"
+Expand-Archive -Path "PathToAtomicsFolder\..\ExternalPayloads\curl.zip" -DestinationPath "PathToAtomicsFolder\..\ExternalPayloads\curl"
+Copy-Item "PathToAtomicsFolder\..\ExternalPayloads\curl\curl-8.4.0_6-win64-mingw\bin\curl.exe" C:\Windows\System32\Curl.exe
 ```
 ##### Description: #{input_file} must be exist on system.
 ##### Check Prereq Commands:

--- a/atomics/T1070.004/T1070.004.md
+++ b/atomics/T1070.004/T1070.004.md
@@ -368,7 +368,7 @@ rm -rf / --no-preserve-root > /dev/null 2> /dev/null
 <br/>
 
 ## Atomic Test #9 - Delete Prefetch File
-Delete a single prefetch file.  Deletion of prefetch files is a known anti-forensic technique. To verify execution, Run "(Get-ChildItem -Path "$Env:SystemRoot\prefetch\*.pf" | Measure-Object).Count"
+Delete a single prefetch file.  Deletion of prefetch files is a known anti-forensic technique. To verify execution, Run "(Get-ChildItem -Path "$Env:SystemRoot\prefetch\\*.pf" | Measure-Object).Count"
 before and after the test to verify that the number of prefetch files decreases by 1.
 
 **Supported Platforms:** Windows


### PR DESCRIPTION
**Details:**
Since the command "(Get-ChildItem -Path "$Env:SystemRoot\prefetch\*.pf" | Measure-Object).Count" is not in a codebox, the '*' character is being escaped by Markdown.

It can be whether added to a codebox or escaped in the Markdown text. I've done the later.