### PR TITLE
Incorrect  Dependency Executor on T1218,12.yaml

### DIFF
--- a/atomics/T1218/T1218.yaml
+++ b/atomics/T1218/T1218.yaml
@@ -313,6 +313,7 @@ atomic_tests:
       description: Path to ie4uinit.exe
       type: path
       default: c:\windows\system32\ie4uinit.exe
+  dependency_executor_name: powershell
   dependencies:
   - description: |
       ieuinit.inf must exist on disk at specified location (#{Path_inf})


### PR DESCRIPTION
Dependency Executor Needs to be explicitly defined

**Details:**
Apologies. The prereqs also require "powershell" to be explicitly defined as the executor.

**Testing:**
This was already tested before. I just forgot to copy the line defining the executor for the prereqs as "powershell" in my previous commit  #2596 
