### PR TITLE
Add test for keychain dump

### DIFF
--- a/atomics/T1555.001/T1555.001.yaml
+++ b/atomics/T1555.001/T1555.001.yaml
@@ -28,3 +28,16 @@ atomic_tests:
       security find-certificate -a -p > #{cert_export}
       security import #{cert_export} -k
     name: sh
+
+- name: Keychain Dump
+  auto_generated_guid: 
+  description: |-
+    This command will dump keychain credential information from login.keychain. 
+    Source: https://www.loobins.io/binaries/security/
+  supported_platforms:
+  - macos
+  executor:
+    command: sudo security dump-keychain -d login.keychain
+    cleanup_command: 
+    name: sh
+    elevation_required: true

--- a/atomics/T1555.001/T1555.001.yaml
+++ b/atomics/T1555.001/T1555.001.yaml
@@ -29,8 +29,7 @@ atomic_tests:
       security import #{cert_export} -k
     name: sh
 
-- name: Keychain Dump
-  auto_generated_guid: 
+- name: Keychain Dump 
   description: |-
     This command will dump keychain credential information from login.keychain. 
     Source: https://www.loobins.io/binaries/security/
@@ -38,6 +37,5 @@ atomic_tests:
   - macos
   executor:
     command: sudo security dump-keychain -d login.keychain
-    cleanup_command: 
     name: sh
     elevation_required: true


### PR DESCRIPTION
**Details:**
When executed with sufficient privileges, command dumps credential info from keychain.

**Testing:**
Tested successfully on OSX 14.1.1 (Sonoma).

**Associated Issues:**
I also plan to submit a separate pull request to rework/organize this Atomic's (T1555.001) related certificate tests.