### PR TITLE
[FIX] T1047 - fix tightvnc path

### DIFF
--- a/atomics/T1047/T1047.yaml
+++ b/atomics/T1047/T1047.yaml
@@ -201,12 +201,12 @@ atomic_tests:
   - description: TightVNC must be installed.
     prereq_command: if ((Test-Path "C:\Program Files\TightVNC\tvnviewer.exe")-Or (Test-Path "C:\Program Files (x86)\TightVNC\tvnviewer.exe")) {exit 0} else {exit 1}
     get_prereq_command: |-
-      Invoke-WebRequest 'https://www.tightvnc.com/download/2.8.63/tightvnc-2.8.63-gpl-setup-64bit.msi' -OutFile "PathToAtomicsFolder..\ExternalPayloads\tightvncinstaller.msi"
+      Invoke-WebRequest 'https://www.tightvnc.com/download/2.8.63/tightvnc-2.8.63-gpl-setup-64bit.msi' -OutFile "PathToAtomicsFolder\..\ExternalPayloads\tightvncinstaller.msi"
       start-sleep -s 10
-      msiexec /i "PathToAtomicsFolder..\ExternalPayloads\tightvncinstaller.msi" /qn /norestart
+      msiexec /i "PathToAtomicsFolder\..\ExternalPayloads\tightvncinstaller.msi" /qn /norestart
       start-sleep -s 15
   executor:
     command: wmic /node:"#{node}" product where "name like '#{product}%%'" call uninstall
-    cleanup_command: msiexec /i "PathToAtomicsFolder..\ExternalPayloads\tightvncinstaller.msi" /qn /norestart
+    cleanup_command: msiexec /i "PathToAtomicsFolder\..\ExternalPayloads\tightvncinstaller.msi" /qn /norestart
     name: command_prompt
     elevation_required: true


### PR DESCRIPTION
**Details:**

- T1047-10 (c510d25b-1667-467d-8331-a56d3e9bc4ff): Fix path when downloading TightVNC and installing it. 

**Testing:**

- `Invoke-AtomicTest T1047-10 -GetPrereqs`
- `Invoke-AtomicTest T1047-10`
