### PR TITLE
Added the "-c" option to adfind commands.

### DIFF
--- a/atomics/T1016/T1016.yaml
+++ b/atomics/T1016/T1016.yaml
@@ -137,6 +137,11 @@ atomic_tests:
     reference- http://www.joeware.net/freetools/tools/adfind/, https://www.fireeye.com/blog/threat-research/2019/04/pick-six-intercepting-a-fin6-intrusion.html
   supported_platforms:
   - windows
+  input_arguments:
+    optional_args:
+      description: Allows defining arguments to add to the adfind command to tailor it to the specific needs of the environment. Use "-arg" notation to add arguments separated by spaces.
+      type: string
+      default:
   dependency_executor_name: powershell
   dependencies:
   - description: |
@@ -148,7 +153,7 @@ atomic_tests:
       Invoke-WebRequest -Uri "https://github.com/redcanaryco/atomic-red-team/raw/master/atomics/T1087.002/bin/AdFind.exe" -OutFile "PathToAtomicsFolder\..\ExternalPayloads\AdFind.exe"
   executor:
     command: |
-      "PathToAtomicsFolder\..\ExternalPayloads\AdFind.exe" -f (objectcategory=subnet) -c
+      "PathToAtomicsFolder\..\ExternalPayloads\AdFind.exe" -f (objectcategory=subnet) #{optional_args}
     name: command_prompt
 
 - name: Qakbot Recon

--- a/atomics/T1016/T1016.yaml
+++ b/atomics/T1016/T1016.yaml
@@ -148,7 +148,7 @@ atomic_tests:
       Invoke-WebRequest -Uri "https://github.com/redcanaryco/atomic-red-team/raw/master/atomics/T1087.002/bin/AdFind.exe" -OutFile "PathToAtomicsFolder\..\ExternalPayloads\AdFind.exe"
   executor:
     command: |
-      "PathToAtomicsFolder\..\ExternalPayloads\AdFind.exe" -f (objectcategory=subnet)
+      "PathToAtomicsFolder\..\ExternalPayloads\AdFind.exe" -f (objectcategory=subnet) -c
     name: command_prompt
 
 - name: Qakbot Recon

--- a/atomics/T1018/T1018.yaml
+++ b/atomics/T1018/T1018.yaml
@@ -198,6 +198,11 @@ atomic_tests:
     reference- http://www.joeware.net/freetools/tools/adfind/, https://www.fireeye.com/blog/threat-research/2019/04/pick-six-intercepting-a-fin6-intrusion.html
   supported_platforms:
   - windows
+  input_arguments:
+    optional_args:
+      description: Allows defining arguments to add to the adfind command to tailor it to the specific needs of the environment. Use "-arg" notation to add arguments separated by spaces.
+      type: string
+      default:
   dependency_executor_name: powershell
   dependencies:
   - description: |
@@ -209,7 +214,7 @@ atomic_tests:
       Invoke-WebRequest -Uri "https://github.com/redcanaryco/atomic-red-team/raw/master/atomics/T1087.002/bin/AdFind.exe" -OutFile "PathToAtomicsFolder\..\ExternalPayloads\AdFind.exe"
   executor:
     command: |
-      "PathToAtomicsFolder\..\ExternalPayloads\AdFind.exe" -f (objectcategory=computer) -c
+      "PathToAtomicsFolder\..\ExternalPayloads\AdFind.exe" -f (objectcategory=computer) #{optional_args}
     name: command_prompt
 - name: Adfind - Enumerate Active Directory Domain Controller Objects
   auto_generated_guid: 5838c31e-a0e2-4b9f-b60a-d79d2cb7995e
@@ -218,6 +223,11 @@ atomic_tests:
     reference- http://www.joeware.net/freetools/tools/adfind/, https://www.fireeye.com/blog/threat-research/2019/04/pick-six-intercepting-a-fin6-intrusion.html
   supported_platforms:
   - windows
+  input_arguments:
+    optional_args:
+      description: Allows defining arguments to add to the adfind command to tailor it to the specific needs of the environment. Use "-arg" notation to add arguments separated by spaces.
+      type: string
+      default:
   dependency_executor_name: powershell
   dependencies:
   - description: |
@@ -229,7 +239,7 @@ atomic_tests:
       Invoke-WebRequest -Uri "https://github.com/redcanaryco/atomic-red-team/raw/master/atomics/T1087.002/bin/AdFind.exe" -OutFile "PathToAtomicsFolder\..\ExternalPayloads\AdFind.exe"
   executor:
     command: |
-      "PathToAtomicsFolder\..\ExternalPayloads\AdFind.exe" -c -sc dclist
+      "PathToAtomicsFolder\..\ExternalPayloads\AdFind.exe" #{optional_args} -sc dclist
     name: command_prompt
 
 - name: Remote System Discovery - ip neighbour

--- a/atomics/T1018/T1018.yaml
+++ b/atomics/T1018/T1018.yaml
@@ -209,7 +209,7 @@ atomic_tests:
       Invoke-WebRequest -Uri "https://github.com/redcanaryco/atomic-red-team/raw/master/atomics/T1087.002/bin/AdFind.exe" -OutFile "PathToAtomicsFolder\..\ExternalPayloads\AdFind.exe"
   executor:
     command: |
-      "PathToAtomicsFolder\..\ExternalPayloads\AdFind.exe" -f (objectcategory=computer)
+      "PathToAtomicsFolder\..\ExternalPayloads\AdFind.exe" -f (objectcategory=computer) -c
     name: command_prompt
 - name: Adfind - Enumerate Active Directory Domain Controller Objects
   auto_generated_guid: 5838c31e-a0e2-4b9f-b60a-d79d2cb7995e
@@ -229,7 +229,7 @@ atomic_tests:
       Invoke-WebRequest -Uri "https://github.com/redcanaryco/atomic-red-team/raw/master/atomics/T1087.002/bin/AdFind.exe" -OutFile "PathToAtomicsFolder\..\ExternalPayloads\AdFind.exe"
   executor:
     command: |
-      "PathToAtomicsFolder\..\ExternalPayloads\AdFind.exe" -sc dclist
+      "PathToAtomicsFolder\..\ExternalPayloads\AdFind.exe" -c -sc dclist
     name: command_prompt
 
 - name: Remote System Discovery - ip neighbour

--- a/atomics/T1069.002/T1069.002.yaml
+++ b/atomics/T1069.002/T1069.002.yaml
@@ -127,7 +127,7 @@ atomic_tests:
       Invoke-WebRequest -Uri "https://github.com/redcanaryco/atomic-red-team/raw/master/atomics/T1087.002/bin/AdFind.exe" -OutFile "PathToAtomicsFolder\..\ExternalPayloads\AdFind.exe"
   executor:
     command: |
-      "PathToAtomicsFolder\..\ExternalPayloads\AdFind.exe" -f (objectcategory=group)
+      "PathToAtomicsFolder\..\ExternalPayloads\AdFind.exe" -f (objectcategory=group) -c
     name: command_prompt
 - name: Enumerate Active Directory Groups with Get-AdGroup
   auto_generated_guid: 3d1fcd2a-e51c-4cbe-8d84-9a843bad8dc8

--- a/atomics/T1069.002/T1069.002.yaml
+++ b/atomics/T1069.002/T1069.002.yaml
@@ -115,6 +115,11 @@ atomic_tests:
     reference- http://www.joeware.net/freetools/tools/adfind/, https://www.fireeye.com/blog/threat-research/2019/04/pick-six-intercepting-a-fin6-intrusion.html
   supported_platforms:
   - windows
+  input_arguments:
+    optional_args:
+      description: Allows defining arguments to add to the adfind command to tailor it to the specific needs of the environment. Use "-arg" notation to add arguments separated by spaces.
+      type: string
+      default:
   dependency_executor_name: powershell
   dependencies:
   - description: |
@@ -127,7 +132,7 @@ atomic_tests:
       Invoke-WebRequest -Uri "https://github.com/redcanaryco/atomic-red-team/raw/master/atomics/T1087.002/bin/AdFind.exe" -OutFile "PathToAtomicsFolder\..\ExternalPayloads\AdFind.exe"
   executor:
     command: |
-      "PathToAtomicsFolder\..\ExternalPayloads\AdFind.exe" -f (objectcategory=group) -c
+      "PathToAtomicsFolder\..\ExternalPayloads\AdFind.exe" -f (objectcategory=group) #{optional_args}
     name: command_prompt
 - name: Enumerate Active Directory Groups with Get-AdGroup
   auto_generated_guid: 3d1fcd2a-e51c-4cbe-8d84-9a843bad8dc8

--- a/atomics/T1087.002/T1087.002.yaml
+++ b/atomics/T1087.002/T1087.002.yaml
@@ -74,6 +74,11 @@ atomic_tests:
     reference- http://www.joeware.net/freetools/tools/adfind/, https://social.technet.microsoft.com/wiki/contents/articles/7535.adfind-command-examples.aspx
   supported_platforms:
   - windows
+  input_arguments:
+    optional_args:
+      description: Allows defining arguments to add to the adfind command to tailor it to the specific needs of the environment. Use "-arg" notation to add arguments separated by spaces.
+      type: string
+      default:
   dependency_executor_name: powershell
   dependencies:
   - description: |
@@ -85,7 +90,7 @@ atomic_tests:
       Invoke-WebRequest -Uri "https://github.com/redcanaryco/atomic-red-team/raw/master/atomics/T1087.002/bin/AdFind.exe" -OutFile "PathToAtomicsFolder\..\ExternalPayloads\AdFind.exe"
   executor:
     command: |
-      "PathToAtomicsFolder\..\ExternalPayloads\AdFind.exe" -c -default -s base lockoutduration lockoutthreshold lockoutobservationwindow maxpwdage minpwdage minpwdlength pwdhistorylength pwdproperties
+      "PathToAtomicsFolder\..\ExternalPayloads\AdFind.exe" #{optional_args} -default -s base lockoutduration lockoutthreshold lockoutobservationwindow maxpwdage minpwdage minpwdlength pwdhistorylength pwdproperties
     name: command_prompt
 - name: Adfind - Enumerate Active Directory Admins
   auto_generated_guid: b95fd967-4e62-4109-b48d-265edfd28c3a
@@ -94,6 +99,11 @@ atomic_tests:
     reference- http://www.joeware.net/freetools/tools/adfind/, https://stealthbits.com/blog/fun-with-active-directorys-admincount-attribute/
   supported_platforms:
   - windows
+  input_arguments:
+    optional_args:
+      description: Allows defining arguments to add to the adfind command to tailor it to the specific needs of the environment. Use "-arg" notation to add arguments separated by spaces.
+      type: string
+      default:
   dependency_executor_name: powershell
   dependencies:
   - description: |
@@ -105,7 +115,7 @@ atomic_tests:
       Invoke-WebRequest -Uri "https://github.com/redcanaryco/atomic-red-team/raw/master/atomics/T1087.002/bin/AdFind.exe" -OutFile "PathToAtomicsFolder\..\ExternalPayloads\AdFind.exe"
   executor:
     command: |
-      "PathToAtomicsFolder\..\ExternalPayloads\AdFind.exe" -sc admincountdmp -c
+      "PathToAtomicsFolder\..\ExternalPayloads\AdFind.exe" -sc admincountdmp #{optional_args}
     name: command_prompt
 - name: Adfind - Enumerate Active Directory User Objects
   auto_generated_guid: e1ec8d20-509a-4b9a-b820-06c9b2da8eb7
@@ -114,6 +124,11 @@ atomic_tests:
     reference- http://www.joeware.net/freetools/tools/adfind/, https://www.fireeye.com/blog/threat-research/2019/04/pick-six-intercepting-a-fin6-intrusion.html
   supported_platforms:
   - windows
+  input_arguments:
+    optional_args:
+      description: Allows defining arguments to add to the adfind command to tailor it to the specific needs of the environment. Use "-arg" notation to add arguments separated by spaces.
+      type: string
+      default:
   dependency_executor_name: powershell
   dependencies:
   - description: |
@@ -125,7 +140,7 @@ atomic_tests:
       Invoke-WebRequest -Uri "https://github.com/redcanaryco/atomic-red-team/raw/master/atomics/T1087.002/bin/AdFind.exe" -OutFile "PathToAtomicsFolder\..\ExternalPayloads\AdFind.exe"
   executor:
     command: |
-      "PathToAtomicsFolder\..\ExternalPayloads\AdFind.exe" -f (objectcategory=person) -c
+      "PathToAtomicsFolder\..\ExternalPayloads\AdFind.exe" -f (objectcategory=person) #{optional_args}
     name: command_prompt
 - name: Adfind - Enumerate Active Directory Exchange AD Objects
   auto_generated_guid: 5e2938fb-f919-47b6-8b29-2f6a1f718e99
@@ -134,6 +149,11 @@ atomic_tests:
     reference- http://www.joeware.net/freetools/tools/adfind/, https://www.fireeye.com/blog/threat-research/2019/04/pick-six-intercepting-a-fin6-intrusion.html
   supported_platforms:
   - windows
+  input_arguments:
+    optional_args:
+      description: Allows defining arguments to add to the adfind command to tailor it to the specific needs of the environment. Use "-arg" notation to add arguments separated by spaces.
+      type: string
+      default:
   dependency_executor_name: powershell
   dependencies:
   - description: |
@@ -145,7 +165,7 @@ atomic_tests:
       Invoke-WebRequest -Uri "https://github.com/redcanaryco/atomic-red-team/raw/master/atomics/T1087.002/bin/AdFind.exe" -OutFile "PathToAtomicsFolder\..\ExternalPayloads\AdFind.exe"
   executor:
     command: |
-      "PathToAtomicsFolder\..\ExternalPayloads\AdFind.exe" -sc exchaddresses -c
+      "PathToAtomicsFolder\..\ExternalPayloads\AdFind.exe" -sc exchaddresses #{optional_args}
     name: command_prompt
 - name: Enumerate Default Domain Admin Details (Domain)
   auto_generated_guid: c70ab9fd-19e2-4e02-a83c-9cfa8eaa8fef
@@ -361,13 +381,17 @@ atomic_tests:
   supported_platforms:
   - windows
   input_arguments:
+    optional_args:
+      description: Allows defining arguments to add to the adfind command to tailor it to the specific needs of the environment. Use "-arg" notation to add arguments separated by spaces.
+      type: string
+      default:
     domain:
       description: Domain of the host
       type: string
       default: $env:USERDOMAIN
   executor:
     command: |
-      & "PathToAtomicsFolder\..\ExternalPayloads\AdFind.exe" -c -h #{domain} -s subtree -f "objectclass=computer" *
+      & "PathToAtomicsFolder\..\ExternalPayloads\AdFind.exe" #{optional_args} -h #{domain} -s subtree -f "objectclass=computer" *
     cleanup_command: 
     name: powershell
     elevation_required: false
@@ -378,13 +402,17 @@ atomic_tests:
   supported_platforms:
   - windows
   input_arguments:
+    optional_args:
+      description: Allows defining arguments to add to the adfind command to tailor it to the specific needs of the environment. Use "-arg" notation to add arguments separated by spaces.
+      type: string
+      default:
     domain:
       description: Domain of the host
       type: string
       default: $env:USERDOMAIN
   executor:
     command: |
-      & "PathToAtomicsFolder\..\ExternalPayloads\AdFind.exe" -c -h #{domain} -s subtree -f "objectclass=computer" ms-Mcs-AdmPwd, ms-Mcs-AdmPwdExpirationTime
+      & "PathToAtomicsFolder\..\ExternalPayloads\AdFind.exe" #{optional_args} -h #{domain} -s subtree -f "objectclass=computer" ms-Mcs-AdmPwd, ms-Mcs-AdmPwdExpirationTime
     cleanup_command: 
     name: powershell
     elevation_required: false

--- a/atomics/T1087.002/T1087.002.yaml
+++ b/atomics/T1087.002/T1087.002.yaml
@@ -85,7 +85,7 @@ atomic_tests:
       Invoke-WebRequest -Uri "https://github.com/redcanaryco/atomic-red-team/raw/master/atomics/T1087.002/bin/AdFind.exe" -OutFile "PathToAtomicsFolder\..\ExternalPayloads\AdFind.exe"
   executor:
     command: |
-      "PathToAtomicsFolder\..\ExternalPayloads\AdFind.exe" -default -s base lockoutduration lockoutthreshold lockoutobservationwindow maxpwdage minpwdage minpwdlength pwdhistorylength pwdproperties
+      "PathToAtomicsFolder\..\ExternalPayloads\AdFind.exe" -c -default -s base lockoutduration lockoutthreshold lockoutobservationwindow maxpwdage minpwdage minpwdlength pwdhistorylength pwdproperties
     name: command_prompt
 - name: Adfind - Enumerate Active Directory Admins
   auto_generated_guid: b95fd967-4e62-4109-b48d-265edfd28c3a
@@ -105,7 +105,7 @@ atomic_tests:
       Invoke-WebRequest -Uri "https://github.com/redcanaryco/atomic-red-team/raw/master/atomics/T1087.002/bin/AdFind.exe" -OutFile "PathToAtomicsFolder\..\ExternalPayloads\AdFind.exe"
   executor:
     command: |
-      "PathToAtomicsFolder\..\ExternalPayloads\AdFind.exe" -sc admincountdmp
+      "PathToAtomicsFolder\..\ExternalPayloads\AdFind.exe" -sc admincountdmp -c
     name: command_prompt
 - name: Adfind - Enumerate Active Directory User Objects
   auto_generated_guid: e1ec8d20-509a-4b9a-b820-06c9b2da8eb7
@@ -125,7 +125,7 @@ atomic_tests:
       Invoke-WebRequest -Uri "https://github.com/redcanaryco/atomic-red-team/raw/master/atomics/T1087.002/bin/AdFind.exe" -OutFile "PathToAtomicsFolder\..\ExternalPayloads\AdFind.exe"
   executor:
     command: |
-      "PathToAtomicsFolder\..\ExternalPayloads\AdFind.exe" -f (objectcategory=person)
+      "PathToAtomicsFolder\..\ExternalPayloads\AdFind.exe" -f (objectcategory=person) -c
     name: command_prompt
 - name: Adfind - Enumerate Active Directory Exchange AD Objects
   auto_generated_guid: 5e2938fb-f919-47b6-8b29-2f6a1f718e99
@@ -145,7 +145,7 @@ atomic_tests:
       Invoke-WebRequest -Uri "https://github.com/redcanaryco/atomic-red-team/raw/master/atomics/T1087.002/bin/AdFind.exe" -OutFile "PathToAtomicsFolder\..\ExternalPayloads\AdFind.exe"
   executor:
     command: |
-      "PathToAtomicsFolder\..\ExternalPayloads\AdFind.exe" -sc exchaddresses
+      "PathToAtomicsFolder\..\ExternalPayloads\AdFind.exe" -sc exchaddresses -c
     name: command_prompt
 - name: Enumerate Default Domain Admin Details (Domain)
   auto_generated_guid: c70ab9fd-19e2-4e02-a83c-9cfa8eaa8fef
@@ -367,7 +367,7 @@ atomic_tests:
       default: $env:USERDOMAIN
   executor:
     command: |
-      & "PathToAtomicsFolder\..\ExternalPayloads\AdFind.exe" -h #{domain} -s subtree -f "objectclass=computer" *
+      & "PathToAtomicsFolder\..\ExternalPayloads\AdFind.exe" -c -h #{domain} -s subtree -f "objectclass=computer" *
     cleanup_command: 
     name: powershell
     elevation_required: false
@@ -384,7 +384,7 @@ atomic_tests:
       default: $env:USERDOMAIN
   executor:
     command: |
-      & "PathToAtomicsFolder\..\ExternalPayloads\AdFind.exe" -h #{domain} -s subtree -f "objectclass=computer" ms-Mcs-AdmPwd, ms-Mcs-AdmPwdExpirationTime
+      & "PathToAtomicsFolder\..\ExternalPayloads\AdFind.exe" -c -h #{domain} -s subtree -f "objectclass=computer" ms-Mcs-AdmPwd, ms-Mcs-AdmPwdExpirationTime
     cleanup_command: 
     name: powershell
     elevation_required: false

--- a/atomics/T1482/T1482.yaml
+++ b/atomics/T1482/T1482.yaml
@@ -70,6 +70,11 @@ atomic_tests:
     reference- http://www.joeware.net/freetools/tools/adfind/, https://www.fireeye.com/blog/threat-research/2019/04/pick-six-intercepting-a-fin6-intrusion.html
   supported_platforms:
   - windows
+  input_arguments:
+    optional_args:
+      description: Allows defining arguments to add to the adfind command to tailor it to the specific needs of the environment. Use "-arg" notation to add arguments separated by spaces.
+      type: string
+      default:
   dependency_executor_name: powershell
   dependencies:
   - description: |
@@ -81,7 +86,7 @@ atomic_tests:
       Invoke-WebRequest -Uri "https://github.com/redcanaryco/atomic-red-team/raw/master/atomics/T1087.002/bin/AdFind.exe" -OutFile "PathToAtomicsFolder\..\ExternalPayloads\AdFind.exe"
   executor:
     command: |
-      "PathToAtomicsFolder\..\ExternalPayloads\AdFind.exe" -f (objectcategory=organizationalUnit) -c
+      "PathToAtomicsFolder\..\ExternalPayloads\AdFind.exe" -f (objectcategory=organizationalUnit) #{optional_args}
     name: command_prompt
 - name: Adfind - Enumerate Active Directory Trusts
   auto_generated_guid: 15fe436d-e771-4ff3-b655-2dca9ba52834
@@ -90,6 +95,11 @@ atomic_tests:
     reference- http://www.joeware.net/freetools/tools/adfind/, https://www.fireeye.com/blog/threat-research/2019/04/pick-six-intercepting-a-fin6-intrusion.html
   supported_platforms:
   - windows
+  input_arguments:
+    optional_args:
+      description: Allows defining arguments to add to the adfind command to tailor it to the specific needs of the environment. Use "-arg" notation to add arguments separated by spaces.
+      type: string
+      default:
   dependency_executor_name: powershell
   dependencies:
   - description: |
@@ -101,7 +111,7 @@ atomic_tests:
       Invoke-WebRequest -Uri "https://github.com/redcanaryco/atomic-red-team/raw/master/atomics/T1087.002/bin/AdFind.exe" -OutFile "PathToAtomicsFolder\..\ExternalPayloads\AdFind.exe"
   executor:
     command: |
-      "PathToAtomicsFolder\..\ExternalPayloads\AdFind.exe" -c -gcb -sc trustdmp
+      "PathToAtomicsFolder\..\ExternalPayloads\AdFind.exe" #{optional_args} -gcb -sc trustdmp
     name: command_prompt
 
 - name: Get-DomainTrust with PowerView

--- a/atomics/T1482/T1482.yaml
+++ b/atomics/T1482/T1482.yaml
@@ -81,7 +81,7 @@ atomic_tests:
       Invoke-WebRequest -Uri "https://github.com/redcanaryco/atomic-red-team/raw/master/atomics/T1087.002/bin/AdFind.exe" -OutFile "PathToAtomicsFolder\..\ExternalPayloads\AdFind.exe"
   executor:
     command: |
-      "PathToAtomicsFolder\..\ExternalPayloads\AdFind.exe" -f (objectcategory=organizationalUnit)
+      "PathToAtomicsFolder\..\ExternalPayloads\AdFind.exe" -f (objectcategory=organizationalUnit) -c
     name: command_prompt
 - name: Adfind - Enumerate Active Directory Trusts
   auto_generated_guid: 15fe436d-e771-4ff3-b655-2dca9ba52834
@@ -101,7 +101,7 @@ atomic_tests:
       Invoke-WebRequest -Uri "https://github.com/redcanaryco/atomic-red-team/raw/master/atomics/T1087.002/bin/AdFind.exe" -OutFile "PathToAtomicsFolder\..\ExternalPayloads\AdFind.exe"
   executor:
     command: |
-      "PathToAtomicsFolder\..\ExternalPayloads\AdFind.exe" -gcb -sc trustdmp
+      "PathToAtomicsFolder\..\ExternalPayloads\AdFind.exe" -c -gcb -sc trustdmp
     name: command_prompt
 
 - name: Get-DomainTrust with PowerView


### PR DESCRIPTION
**Details:**
Added the "-c" option to adfind commands. This will cause it to print a count of the returned objects instead of the actual objects. This is very useful for large environments and allows it run quicker without actually exposing any sensitive information.

**Testing:**
Tested on Windows 10 VM
