### PR TITLE
Update T1057.yaml Process Discovery - Get-WmiObject Win32_Process | s…

### DIFF
--- a/atomics/T1057/T1057.yaml
+++ b/atomics/T1057/T1057.yaml
@@ -86,3 +86,16 @@ atomic_tests:
     command: |
       tasklist | findstr #{process_to_enumerate}
     name: command_prompt
+- name: Process Discovery - Get-WmiObject Win32_Process | select Processname, ProcessId
+  auto_generated_guid: f6eea8e5-88a1-458e-9ac2-5a085fa8edcf
+  description: |
+    Simulate the discovery of processes using the `Get-WmiObject Win32_Process` cmdlet on Windows systems.
+    Use `Get-WmiObject` to query the `Win32_Process` class and select the "Processname" and "ProcessId" properties to retrieve information about running processes.
+  supported_platforms:
+    - windows
+  input_arguments: {}
+  executor:
+    command: |
+      Get-WmiObject Win32_Process | select Processname, ProcessId
+    cleanup_command: ""
+    name: powershell


### PR DESCRIPTION
**Details:**
This Atomic Test, named "Process Discovery - Get-WmiObject Win32_Process | select Processname, ProcessId," is designed to simulate the discovery of processes on Windows systems. The test leverages PowerShell to utilize the `Get-WmiObject` cmdlet, which queries the `Win32_Process` class. Specifically, it selects the "Processname" and "ProcessId" properties to retrieve vital information about currently running processes on the system. This Atomic Test aids in evaluating the effectiveness of process discovery techniques and can be a valuable part of assessing security controls.

**Testing:**
The test has undergone comprehensive testing on Windows systems to ensure its functionality and accuracy in process discovery. Local testing has been performed, validating that the PowerShell command correctly retrieves the desired process information. The test results have been consistent and reliable in various Windows environments.

**Associated Issues:**
This pull request does not impact or fix any specific issues. It is intended to enhance the Atomic Red Team repository by adding a new Atomic Test for process discovery.
