### PR TITLE
"Modify Directory Permissions (Linux)"

### DIFF
--- a/atomics/T1490/T1490.yaml
+++ b/atomics/T1490/T1490.yaml
@@ -145,3 +145,16 @@ atomic_tests:
     command: 'vssadmin resize shadowstorage /For=C: /On=C: /MaxSize=20%'
     name: powershell
     elevation_required: true
+    
+- name: "Modify Directory Permissions (Linux)"
+  auto_generated_guid: "cbddf7ab-a93b-4257-a0a8-45a46fbd68a7"
+  description: |
+    Modify permissions of a directory on a Linux system. This test alters the security settings of the directory, potentially impacting access to its contents. It should be conducted only in a controlled environment. The executor must have administrative privileges or root access to modify directory permissions. Note that this test does not include a cleanup command; thus, the changes will persist after execution. Ensure that you have a backup or a recovery plan in place before running this test. Running this test on a production system or critical environment is not recommended without proper precautions.
+  supported_platforms:
+    - linux
+  executor:
+    name: "bash_shell"
+    elevation_required: true
+    command: |
+      # Example command to create a temporary directory '/tmp/my_directory' and give read and write permissions to the owner
+      mkdir -p /tmp/my_directory && chmod u+rw /tmp/my_directory


### PR DESCRIPTION
## Modify Directory Permissions (Linux)

**Details:**
Modify permissions of a directory on a Linux system. This test alters the security settings of the directory, potentially impacting access to its contents. It should be conducted only in a controlled environment. The executor must have administrative privileges or root access to modify directory permissions. Note that this test does not include a cleanup command; thus, the changes will persist after execution. Ensure that you have a backup or a recovery plan in place before running this test. Running this test on a production system or critical environment is not recommended without proper precautions.

**Testing:**
- This test has been manually tested on a Linux system running codespace linux machine

**Associated Issues:**
NA