### PR TITLE
T1654 - Fix to PowerShell Command

### DIFF
--- a/atomics/T1654/T1654.yaml
+++ b/atomics/T1654/T1654.yaml
@@ -13,7 +13,7 @@ atomic_tests:
   supported_platforms:
   - windows
   executor:
-    command: powershell -c "get-eventlog 'Security' | where {$_.Message -like '*SYSTEM*'} | export-csv $env:temp\T1654_events.txt"
+    command: powershell -c {get-eventlog 'Security' | where {$_.Message -like '*SYSTEM*'} | export-csv $env:temp\T1654_events.txt}
     cleanup_command: powershell -c "remove-item $env:temp\T1654_events.txt -ErrorAction Ignore"
     name: powershell
     elevation_required: true


### PR DESCRIPTION
**Details:**
The original PowerShell command for T1654 makes use of a script block and must use braces ({}). Without the braces this caused the script to misunderstand `$_.message` as not part of the output from `get-eventlog`. This PR fixes that issue.

**Testing:**
Local testing of the atomic has been conducted successfully. 

**Associated Issues:**
None - but can add an issue if required.