### PR TITLE
Removing REM from T1112 - causing incorrect execution

### DIFF
--- a/atomics/T1112/T1112.yaml
+++ b/atomics/T1112/T1112.yaml
@@ -507,7 +507,6 @@ atomic_tests:
       reg  add HKCU\Software\Policies\Microsoft\Windows\PowerShell\ScriptBlockLogging /v EnableScriptBlockLogging /t REG_DWORD /d 0 /f
       reg  add HKCU\Software\Policies\Microsoft\Windows\PowerShell\Transcription /v EnableTranscripting /t REG_DWORD /d 0 /f
       reg  add HKCU\Software\Policies\Microsoft\Windows\PowerShell /v EnableScripts /t REG_DWORD /d 0 /f
-      REM do a little cleanup immediately to avoid execution issues with later tests
       reg delete HKCU\Software\Policies\Microsoft\Windows\PowerShell /v EnableScripts /f >nul 2>&1
     cleanup_command: |
       reg delete HKCU\Software\Policies\Microsoft\Windows\PowerShell\ModuleLogging /v EnableModuleLogging /f >nul 2>&1


### PR DESCRIPTION
**Details:**
During an execution run I noticed that atomics were failing due to PowerShell scripts not being enabled on the host system. I traced the issue back to `T1112:95b25212-91a7-42ff-9613-124aca6845a8` and specifically the `REM` command that is used in place of a comment. I don't know the specifics as to why this command stops execution but it results in the subsequent deletion command not being executed. 

This screenshot shows execution of the atomic with the REM command in place, note the EnableScripts registry value remains 
<img width="1658" alt="Screenshot 2024-02-05 at 22 47 18" src="https://github.com/redcanaryco/atomic-red-team/assets/6080638/6f408f6c-7119-4b37-b306-5affd0e1706b">

This screenshot shows execution of the same atomic with the REM command removed, note the removal of the registry value.
<img width="1658" alt="Screenshot 2024-02-05 at 22 48 11" src="https://github.com/redcanaryco/atomic-red-team/assets/6080638/8b37e576-bbbe-4544-aee1-f473e57953b2">

**Testing:**
Tested on W10

**Associated Issues:**
None