### PR TITLE
Update T1562.004.md

### DIFF
--- a/atomics/T1562.004/T1562.004.md
+++ b/atomics/T1562.004/T1562.004.md
@@ -76,7 +76,7 @@ netsh advfirewall set currentprofile state off
 
 #### Cleanup Commands:
 ```cmd
-netsh advfirewall set currentprofile state on >nul 2>&1
+netsh advfirewall set currentprofile state on >null 2>&1
 ```
 
 


### PR DESCRIPTION
command correction for cleanup "null"

**Details:**
Cleanup command was not working due to typo "nul" instead of "null"

**Testing:**
Tested on personal deployment
![image](https://github.com/redcanaryco/atomic-red-team/assets/6753178/e1d04869-ee19-44bb-8266-8a6e4f138c27)


**Associated Issues:**
N/A