### PR TITLE
Adding new test for T1654 for Enumerate Windows Security Log

### DIFF
--- a/atomics/T1654/T1654.yaml
+++ b/atomics/T1654/T1654.yaml
@@ -17,3 +17,16 @@ atomic_tests:
     cleanup_command: powershell -c "remove-item $env:temp\T1654_events.txt -ErrorAction Ignore"
     name: powershell
     elevation_required: true
+- name: Enumerate Windows Security Log via WevtUtil
+  description: |- 
+  WevtUtil is a command line tool that can be utilised by adversaries to gather intelligence on a targeted Windows system's logging infrastructure. 
+  
+  By executing this command, malicious actors can enumerate all available event logs, including both default logs such as Application, Security, and System
+  as well as any custom logs created by administrators. 
+  
+  This information provides valuable insight into the system's logging mechanisms, potentially allowing attackers to identify gaps or weaknesses in the logging configuration
+  supported_platforms:
+  - windows
+  executor:
+    command: wevtutil enum-logs
+    name: command_prompt

--- a/atomics/T1654/T1654.yaml
+++ b/atomics/T1654/T1654.yaml
@@ -19,12 +19,12 @@ atomic_tests:
     elevation_required: true
 - name: Enumerate Windows Security Log via WevtUtil
   description: |- 
-  WevtUtil is a command line tool that can be utilised by adversaries to gather intelligence on a targeted Windows system's logging infrastructure. 
+    WevtUtil is a command line tool that can be utilised by adversaries to gather intelligence on a targeted Windows system's logging infrastructure. 
   
-  By executing this command, malicious actors can enumerate all available event logs, including both default logs such as Application, Security, and System
-  as well as any custom logs created by administrators. 
+    By executing this command, malicious actors can enumerate all available event logs, including both default logs such as Application, Security, and System
+    as well as any custom logs created by administrators. 
   
-  This information provides valuable insight into the system's logging mechanisms, potentially allowing attackers to identify gaps or weaknesses in the logging configuration
+    This information provides valuable insight into the system's logging mechanisms, potentially allowing attackers to identify gaps or weaknesses in the logging configuration
   supported_platforms:
   - windows
   executor:


### PR DESCRIPTION
…Util

Adding new test for T1654 for Enumerate Windows Security Log via WevtUtil

**Details:**
<!-- WevtUtil can also be used to enumerate the logs available on a host which may also expose information about custom applications -->

**Testing:**
<!-- Tested using a non-admin account and running the command wevtutil enum-logs-->

**Associated Issues:**
<!-- Please link any issues that this pull request impacts or fixes. -->