### PR TITLE
Fix T1071.001 Test #2

### DIFF
--- a/atomics/T1071.001/T1071.001.md
+++ b/atomics/T1071.001/T1071.001.md
@@ -98,9 +98,9 @@ if (Test-Path #{curl_path}) {exit 0} else {exit 1}
 ##### Get Prereq Commands:
 ```powershell
 New-Item -Type Directory "PathToAtomicsFolder\..\ExternalPayloads\" -ErrorAction Ignore -Force | Out-Null
-Invoke-WebRequest "https://curl.haxx.se/windows/dl-7.71.1/curl-7.71.1-win32-mingw.zip" -Outfile "PathToAtomicsFolder\..\ExternalPayloads\curl.zip"
+Invoke-WebRequest "https://curl.se/windows/dl-8.6.0_2/curl-8.6.0_2-win32-mingw.zip" -Outfile "PathToAtomicsFolder\..\ExternalPayloads\curl.zip"
 Expand-Archive -Path "PathToAtomicsFolder\..\ExternalPayloads\curl.zip" -DestinationPath "PathToAtomicsFolder\..\ExternalPayloads\curl"
-Copy-Item "PathToAtomicsFolder\..\ExternalPayloads\curl\curl-7.71.1-win32-mingw\bin\curl.exe" #{curl_path}
+Copy-Item "PathToAtomicsFolder\..\ExternalPayloads\curl\curl-8.6.0_2-win32-mingw\bin\curl.exe" #{curl_path}
 Remove-Item "PathToAtomicsFolder\..\ExternalPayloads\curl"
 Remove-Item "PathToAtomicsFolder\..\ExternalPayloads\curl.zip"
 ```

--- a/atomics/T1071.001/T1071.001.yaml
+++ b/atomics/T1071.001/T1071.001.yaml
@@ -48,9 +48,9 @@ atomic_tests:
       if (Test-Path #{curl_path}) {exit 0} else {exit 1}
     get_prereq_command: |
       New-Item -Type Directory "PathToAtomicsFolder\..\ExternalPayloads\" -ErrorAction Ignore -Force | Out-Null
-      Invoke-WebRequest "https://curl.haxx.se/windows/dl-7.71.1/curl-7.71.1-win32-mingw.zip" -Outfile "PathToAtomicsFolder\..\ExternalPayloads\curl.zip"
+      Invoke-WebRequest "https://curl.se/windows/dl-8.6.0_2/curl-8.6.0_2-win32-mingw.zip" -Outfile "PathToAtomicsFolder\..\ExternalPayloads\curl.zip"
       Expand-Archive -Path "PathToAtomicsFolder\..\ExternalPayloads\curl.zip" -DestinationPath "PathToAtomicsFolder\..\ExternalPayloads\curl"
-      Copy-Item "PathToAtomicsFolder\..\ExternalPayloads\curl\curl-7.71.1-win32-mingw\bin\curl.exe" #{curl_path}
+      Copy-Item "PathToAtomicsFolder\..\ExternalPayloads\curl\curl-8.6.0_2-win32-mingw\bin\curl.exe" #{curl_path}
       Remove-Item "PathToAtomicsFolder\..\ExternalPayloads\curl"
       Remove-Item "PathToAtomicsFolder\..\ExternalPayloads\curl.zip"
   executor:


### PR DESCRIPTION
Test 2 for T1071.001 is currently not working properly, since the pre-requisite command is incorrect. This change is to fix the .md and .yaml file to update the URL for curl.

Details: 

The URL existing in the test files currently is: :"https://curl.haxx.se/windows/dl-7.71.1/curl-7.71.1-win32-mingw.zip"
This returns a 404 error.

Replacing this URL with: "https://curl.se/windows/dl-8.6.0_2/curl-8.6.0_2-win32-mingw.zip" works.
![404 Error](https://github.com/redcanaryco/atomic-red-team/assets/57437797/76739537-71fa-47c9-a240-3c58f459e43b)