### PR TITLE
New test: T1542.001 - 'UEFI Persistence via Wpbbin.exe File Creation'

### DIFF
--- a/atomics/T1542.001/T1542.001.yaml
+++ b/atomics/T1542.001/T1542.001.yaml
@@ -1,0 +1,20 @@
+attack_technique: T1542.001
+display_name: "Pre-OS Boot: System Firmware"
+atomic_tests:
+- name: UEFI Persistence via Wpbbin.exe File Creation
+  description: |
+    Creates Wpbbin.exe in %systemroot%. This technique can be used for UEFI-based pre-OS boot persistence mechanisms.
+    - https://grzegorztworek.medium.com/using-uefi-to-inject-executable-files-into-bitlocker-protected-drives-8ff4ca59c94c
+    - http://download.microsoft.com/download/8/a/2/8a2fb72d-9b96-4e2d-a559-4a27cf905a80/windows-platform-binary-table.docx
+    - https://github.com/tandasat/WPBT-Builder
+  supported_platforms:
+  - windows
+  executor:
+    name: powershell
+    command: |
+      echo "Creating %systemroot%\wpbbin.exe"      
+      New-Item -ItemType File -Path "$env:SystemRoot\System32\wpbbin.exe"
+    cleanup_command: |
+      echo "Removing %systemroot%\wpbbin.exe" 
+      Remove-Item -Path "$env:SystemRoot\System32\wpbbin.exe"
+    elevation_required: true


### PR DESCRIPTION
**Details:**
Created an atomic for adding wpbbin.exe in %systemroot%\System32\. This technique can be used for UEFI-based pre-OS boot persistence. Note that the command presently only creates an empty file.

    - https://grzegorztworek.medium.com/using-uefi-to-inject-executable-files-into-bitlocker-protected-drives-8ff4ca59c94c
    - http://download.microsoft.com/download/8/a/2/8a2fb72d-9b96-4e2d-a559-4a27cf905a80/windows-platform-binary-table.docx
    - https://github.com/tandasat/WPBT-Builder

**Testing:**
Tested the command and cleanup locally on Windows Server 2022. 

**Associated Issues:**
<!-- Please link any issues that this pull request impacts or fixes. -->