### PR TITLE
Update T1070.003.yaml

### DIFF
--- a/atomics/T1070.003/T1070.003.yaml
+++ b/atomics/T1070.003/T1070.003.yaml
@@ -151,11 +151,6 @@ atomic_tests:
     Clears Docker container logs using the Docker CLI and the truncate command, removing all log entries.
   supported_platforms:
   - linux
-  dependencies:
-    - description: |
-        Install Docker CLI
-      prereq_command: |
-        (which docker >/dev/null) || (curl -fsSL https://get.docker.com/ | sh)
   executor:
     command: |
       docker container prune -f && sudo truncate -s 0 /var/lib/docker/containers/*/*-json.log

--- a/atomics/T1070.003/T1070.003.yaml
+++ b/atomics/T1070.003/T1070.003.yaml
@@ -146,7 +146,6 @@ atomic_tests:
     name: sh
     
 - name: Clear Docker Container Logs
-  auto_generated_guid: cfa159ba-9846-4858-b287-6b97411cbdaf
   description: |
     Clears Docker container logs using the Docker CLI and the truncate command, removing all log entries.
   supported_platforms:

--- a/atomics/T1070.003/T1070.003.yaml
+++ b/atomics/T1070.003/T1070.003.yaml
@@ -144,6 +144,22 @@ atomic_tests:
     cleanup_command: |
       [ "$(uname)" = 'FreeBSD' ] && rmuser -y testuser1 || userdel -f testuser1
     name: sh
+    
+- name: Clear Docker Container Logs
+  auto_generated_guid: cfa159ba-9846-4858-b287-6b97411cbdaf
+  description: |
+    Clears Docker container logs using the Docker CLI and the truncate command, removing all log entries.
+  supported_platforms:
+  - linux
+  dependencies:
+    - description: |
+        Install Docker CLI
+      prereq_command: |
+        (which docker >/dev/null) || (curl -fsSL https://get.docker.com/ | sh)
+  executor:
+    command: |
+      docker container prune -f && sudo truncate -s 0 /var/lib/docker/containers/*/*-json.log
+      
 - name:  Prevent Powershell History Logging
   auto_generated_guid: 2f898b81-3e97-4abb-bc3f-a95138988370
   description: |

--- a/atomics/T1070.003/T1070.003.yaml
+++ b/atomics/T1070.003/T1070.003.yaml
@@ -152,6 +152,7 @@ atomic_tests:
   supported_platforms:
   - linux
   executor:
+    name: bash
     command: |
       docker container prune -f && sudo truncate -s 0 /var/lib/docker/containers/*/*-json.log
       


### PR DESCRIPTION
Clear Docker Container Logs

**Details:**
This pull request adds a new test to clear Docker container logs using the Docker CLI and the truncate command. It ensures that the logs are emptied of any entries, relevant for testing the T1070.003 tactic related to log manipulation.

**Testing:**
Tested locally on Linux using Docker. Verified that the Docker container logs were cleared successfully after running the provided command.

**Associated Issues:**
N/A
