### PR TITLE
Added new atomic test: Update T1001.002.yaml

### DIFF
--- a/atomics/T1001.002/T1001.002.yaml
+++ b/atomics/T1001.002/T1001.002.yaml
@@ -148,7 +148,6 @@ atomic_tests:
         Remove-Item -Path "$HOME\decoded.ps1" -Force -ErrorAction Ignore        
 
   - name: Execute Embedded Script in Image via Steganography
-    auto_generated_guid: 
     description: This atomic test demonstrates the execution of an embedded script in an image file using steganography techniques. The script is first encoded in base64 and then embedded within the pixels of the image. The modified image is created, and the script is extracted and executed on the target system.
     supported_platforms:
     - linux

--- a/atomics/T1001.002/T1001.002.yaml
+++ b/atomics/T1001.002/T1001.002.yaml
@@ -146,3 +146,30 @@ atomic_tests:
         Remove-Item -Path "$HOME\result.ps1" -Force -ErrorAction Ignore 
         Remove-Item -Path "$HOME\textExtraction.ps1" -Force -ErrorAction Ignore
         Remove-Item -Path "$HOME\decoded.ps1" -Force -ErrorAction Ignore
+
+    - name: Execute Embedded Script in Image via Steganography
+      auto_generated_guid: 
+      description: This atomic test demonstrates the execution of an embedded script in an image file using steganography techniques. The script is first encoded in base64 and then embedded within the pixels of the image. The modified image is created, and the script is extracted and executed on the target system.
+      supported_platforms:
+      - linux
+      input_arguments:
+        script:
+          description: Shell Script file to be embedded and executed
+          type: String
+          default: PathToAtomicsFolder/script.sh
+        evil_image:
+          description: The modified image with embedded script
+          type: String
+          default: PathToAtomicsFolder/evil_image.jpg
+        image:
+          description: Image file to be embedded
+          type: String
+          default: PathToAtomicsFolder/image.jpg
+      dependency_executor_name: 
+      dependencies: 
+      executor:
+        command: cat "#{script}" | base64 | xxd -p | sed 's/../& /g' | xargs -n1 | xxd -r -p | cat "#{image}" - > "#{evil_image}"; strings "#{evil_image}" | tail -n 1 | base64 -d | sh
+        cleanup_command: rm "#{evil_image}"
+        name: sh
+        elevation_required: false
+      

--- a/atomics/T1001.002/T1001.002.yaml
+++ b/atomics/T1001.002/T1001.002.yaml
@@ -145,31 +145,31 @@ atomic_tests:
         Set-ExecutionPolicy Bypass -Scope Process -Force -ErrorAction Ignore
         Remove-Item -Path "$HOME\result.ps1" -Force -ErrorAction Ignore 
         Remove-Item -Path "$HOME\textExtraction.ps1" -Force -ErrorAction Ignore
-        Remove-Item -Path "$HOME\decoded.ps1" -Force -ErrorAction Ignore
+        Remove-Item -Path "$HOME\decoded.ps1" -Force -ErrorAction Ignore        
 
-    - name: Execute Embedded Script in Image via Steganography
-      auto_generated_guid: 
-      description: This atomic test demonstrates the execution of an embedded script in an image file using steganography techniques. The script is first encoded in base64 and then embedded within the pixels of the image. The modified image is created, and the script is extracted and executed on the target system.
-      supported_platforms:
-      - linux
-      input_arguments:
-        script:
-          description: Shell Script file to be embedded and executed
-          type: String
-          default: PathToAtomicsFolder/script.sh
-        evil_image:
-          description: The modified image with embedded script
-          type: String
-          default: PathToAtomicsFolder/evil_image.jpg
-        image:
-          description: Image file to be embedded
-          type: String
-          default: PathToAtomicsFolder/image.jpg
-      dependency_executor_name: 
-      dependencies: 
-      executor:
-        command: cat "#{script}" | base64 | xxd -p | sed 's/../& /g' | xargs -n1 | xxd -r -p | cat "#{image}" - > "#{evil_image}"; strings "#{evil_image}" | tail -n 1 | base64 -d | sh
-        cleanup_command: rm "#{evil_image}"
-        name: sh
-        elevation_required: false
-      
+  - name: Execute Embedded Script in Image via Steganography
+  auto_generated_guid: 
+  description: This atomic test demonstrates the execution of an embedded script in an image file using steganography techniques. The script is first encoded in base64 and then embedded within the pixels of the image. The modified image is created, and the script is extracted and executed on the target system.
+  supported_platforms:
+  - linux
+  input_arguments:
+    script:
+      description: Shell Script file to be embedded and executed
+      type: String
+      default: PathToAtomicsFolder/script.sh
+    evil_image:
+      description: The modified image with embedded script
+      type: String
+      default: PathToAtomicsFolder/evil_image.jpg
+    image:
+      description: Image file to be embedded
+      type: String
+      default: PathToAtomicsFolder/image.jpg
+  dependency_executor_name: 
+  dependencies: 
+  executor:
+    command: cat "#{script}" | base64 | xxd -p | sed 's/../& /g' | xargs -n1 | xxd -r -p | cat "#{image}" - > "#{evil_image}"; strings "#{evil_image}" | tail -n 1 | base64 -d | sh
+    cleanup_command: rm "#{evil_image}"
+    name: sh
+    elevation_required: false
+        

--- a/atomics/T1001.002/T1001.002.yaml
+++ b/atomics/T1001.002/T1001.002.yaml
@@ -148,26 +148,27 @@ atomic_tests:
         Remove-Item -Path "$HOME\decoded.ps1" -Force -ErrorAction Ignore        
 
   - name: Execute Embedded Script in Image via Steganography
-  auto_generated_guid: 
-  description: This atomic test demonstrates the execution of an embedded script in an image file using steganography techniques. The script is first encoded in base64 and then embedded within the pixels of the image. The modified image is created, and the script is extracted and executed on the target system.
-  supported_platforms:
-   - linux
-  input_arguments:
-    script:
-      description: Shell Script file to be embedded and executed
-      type: String
-      default: PathToAtomicsFolder/script.sh
-    evil_image:
-      description: The modified image with embedded script
-      type: String
-      default: PathToAtomicsFolder/evil_image.jpg
-    image:
-      description: Image file to be embedded
-      type: String
-      default: PathToAtomicsFolder/image.jpg
-  executor:
-    command: cat "#{script}" | base64 | xxd -p | sed 's/../& /g' | xargs -n1 | xxd -r -p | cat "#{image}" - > "#{evil_image}"; strings "#{evil_image}" | tail -n 1 | base64 -d | sh
-    cleanup_command: rm "#{evil_image}"
-    name: sh
-    elevation_required: false
-        
+    auto_generated_guid: 
+    description: This atomic test demonstrates the execution of an embedded script in an image file using steganography techniques. The script is first encoded in base64 and then embedded within the pixels of the image. The modified image is created, and the script is extracted and executed on the target system.
+    supported_platforms:
+    - linux
+    input_arguments:
+      script:
+        description: Shell Script file to be embedded and executed
+        type: String
+        default: PathToAtomicsFolder/script.sh
+      evil_image:
+        description: The modified image with embedded script
+        type: String
+        default: PathToAtomicsFolder/evil_image.jpg
+      image:
+        description: Image file to be embedded
+        type: String
+        default: PathToAtomicsFolder/image.jpg
+    dependency_executor_name: 
+    dependencies: 
+    executor:
+      command: cat "#{script}" | base64 | xxd -p | sed 's/../& /g' | xargs -n1 | xxd -r -p | cat "#{image}" - > "#{evil_image}"; strings "#{evil_image}" | tail -n 1 | base64 -d | sh
+      cleanup_command: rm "#{evil_image}"
+      name: sh
+      elevation_required: false

--- a/atomics/T1001.002/T1001.002.yaml
+++ b/atomics/T1001.002/T1001.002.yaml
@@ -164,8 +164,6 @@ atomic_tests:
         description: Image file to be embedded
         type: String
         default: PathToAtomicsFolder/image.jpg
-    dependency_executor_name: 
-    dependencies: 
     executor:
       command: cat "#{script}" | base64 | xxd -p | sed 's/../& /g' | xargs -n1 | xxd -r -p | cat "#{image}" - > "#{evil_image}"; strings "#{evil_image}" | tail -n 1 | base64 -d | sh
       cleanup_command: rm "#{evil_image}"

--- a/atomics/T1001.002/T1001.002.yaml
+++ b/atomics/T1001.002/T1001.002.yaml
@@ -151,7 +151,7 @@ atomic_tests:
   auto_generated_guid: 
   description: This atomic test demonstrates the execution of an embedded script in an image file using steganography techniques. The script is first encoded in base64 and then embedded within the pixels of the image. The modified image is created, and the script is extracted and executed on the target system.
   supported_platforms:
-  - linux
+   - linux
   input_arguments:
     script:
       description: Shell Script file to be embedded and executed
@@ -165,8 +165,6 @@ atomic_tests:
       description: Image file to be embedded
       type: String
       default: PathToAtomicsFolder/image.jpg
-  dependency_executor_name: 
-  dependencies: 
   executor:
     command: cat "#{script}" | base64 | xxd -p | sed 's/../& /g' | xargs -n1 | xxd -r -p | cat "#{image}" - > "#{evil_image}"; strings "#{evil_image}" | tail -n 1 | base64 -d | sh
     cleanup_command: rm "#{evil_image}"


### PR DESCRIPTION
**Details:**
<!-- Insert details about this change here. Please include as much detail as possible -->
This pull request adds a new atomic test for T1001.002 for Linux. This atomic test demonstrates the execution of an embedded script in an image file using steganography techniques. The script is first encoded in base64 and then embedded within the pixels of the image. The modified image is created, and the script is extracted and executed on the target system.
   
**Testing:**
<!-- Note any testing done, local or automated here. -->
In this example, script `mal.sh`  is embedded in image `8bit.jpg`. The new malicious image file `evil_image.jpg` can be used to run the script.

<img width="913" alt="image" src="https://github.com/redcanaryco/atomic-red-team/assets/25433956/e58e83b3-6098-4a08-ac0b-fcdab5c96358">

The Evil image can be used to execute the embedded script:
 
<img width="603" alt="image" src="https://github.com/redcanaryco/atomic-red-team/assets/25433956/1a3c217f-d46d-47a7-a28a-11afcee6dd12">

Both images are identical to a normal user:

<img width="115" alt="image" src="https://github.com/redcanaryco/atomic-red-team/assets/25433956/28f7dbe4-d642-41e3-9971-59ebd7ef62b3">

**Associated Issues:**
<!-- Please link any issues that this pull request impacts or fixes. -->