### PR TITLE
Fix nonstandard capitalization in "type" field

### DIFF
--- a/atomics/T1071/T1071.yaml
+++ b/atomics/T1071/T1071.yaml
@@ -27,7 +27,7 @@ atomic_tests:
       default: PathToAtomicsFolder\T1071\bin\telnet_client.exe  # Update the path if needed
     server_port:
       description: C2 server port
-      type: Integer
+      type: integer
       default: 23
   executor:
     command: |


### PR DESCRIPTION
**Details:**
All other "type" fields use `type: integer`, however this field was `type: Integer`. This fix is extremely minor, but good for the sake of consistency. Looking through the rest of the project, this appear to be the only place where nonstandard field value capitalization occurs.

**Testing:**
I have my own validation framework which parses and validates all Atomic YMLs into [Pydantic](https://docs.pydantic.dev/latest/) Objects (making them easier to use in the context of a larger project). Rather than just treating them as dictionaries, they are real Python classes.  That is how this issue was identified.  
If there is interest, I am happy to share that code back to the project as well!

**Associated Issues:**
None


**Additional Comments:**
I'm not entirely sure how this schema is used, but there seem to be some duplicate fields:
https://github.com/redcanaryco/atomic-red-team/blob/42dae0db828161bdd66a4e50ff826ff38b38f41a/bin/validate/atomic-red-team.schema.yaml#L79-L81 (both integer and Integer defined)
https://github.com/redcanaryco/atomic-red-team/blob/42dae0db828161bdd66a4e50ff826ff38b38f41a/bin/validate/atomic-red-team.schema.yaml#L93-L98 (string/String and url/Url defined)