### PR TITLE
Added new atomic test: Update T1490.yaml

### DIFF
--- a/atomics/T1490/T1490.yaml
+++ b/atomics/T1490/T1490.yaml
@@ -173,4 +173,12 @@ atomic_tests:
       sc sdset VSS D:(D;;GA;;;NU)(D;;GA;;;WD)(D;;GA;;;AN)S:(AU;FA;GA;;;WD)(AU;OIIOFA;GA;;;WD)
     cleanup_command: |
       sc sdset VSS D:(A;;CCLCSWRPWPDTLOCRRC;;;SY)(A;;CCDCLCSWRPWPDTLOCRSDRCWDWO;;;BA)(A;;LC;;;BU)S:(AU;FA;CCDCLCSWRPWPDTLOCRSDRCWDWO;;;WD)
-
+- name: Disable Time Machine 
+  description: |
+     Disables Time Machine which is Apple's automated backup utility software. Attackers can use this to prevent backups from occurring and hinder the victim's ability to recover from any damage.
+  supported_platforms:
+  - macos
+  executor:
+    command: sudo tmutil disable
+    name: sh
+    elevation_required: true

--- a/atomics/T1490/T1490.yaml
+++ b/atomics/T1490/T1490.yaml
@@ -180,5 +180,6 @@ atomic_tests:
   - macos
   executor:
     command: sudo tmutil disable
+    cleanup_command: sudo tmutil enable
     name: sh
     elevation_required: true


### PR DESCRIPTION
**Details:**
<!-- Insert details about this change here. Please include as much detail as possible -->
Added a new atomic test for T1490 (Inhibit System Recovery) to disable Time Machine on macOS using `tmutil`. Attackers can use this to prevent backups from occurring and hinder the victim's ability to recover from any damage.

<img width="887" alt="image" src="https://github.com/redcanaryco/atomic-red-team/assets/25433956/1a13adb2-c842-4ce1-b681-1fb3df6fbce6">
<img width="632" alt="image" src="https://github.com/redcanaryco/atomic-red-team/assets/25433956/f6b814f0-c671-4d03-9aaf-fdf4811bcc10">

 
**Testing:**
<!-- Note any testing done, local or automated here. -->

**Associated Issues:**
<!-- Please link any issues that this pull request impacts or fixes. -->