### PR TITLE
Add missing guids to atomic_tests in two files

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Atomic Red Team
 
-![GitHub Action Status](https://github.com/redcanaryco/atomic-red-team/actions/workflows/validate-atomics.yml/badge.svg?branch=master) ![Atomics](https://img.shields.io/badge/Atomics-1544-flat.svg) ![GitHub Action Status](https://github.com/redcanaryco/atomic-red-team/actions/workflows/generate-docs.yml/badge.svg?branch=master)
+![GitHub Action Status](https://github.com/redcanaryco/atomic-red-team/actions/workflows/validate-atomics.yml/badge.svg?branch=master) ![Atomics](https://img.shields.io/badge/Atomics-1545-flat.svg) ![GitHub Action Status](https://github.com/redcanaryco/atomic-red-team/actions/workflows/generate-docs.yml/badge.svg?branch=master)
 
 Atomic Red Team™ is a library of tests mapped to the
 [MITRE ATT&CK®](https://attack.mitre.org/) framework. Security teams can use

--- a/atomics/T1105/T1105.yaml
+++ b/atomics/T1105/T1105.yaml
@@ -873,6 +873,7 @@ atomic_tests:
     name: command_prompt
     elevation_required: true
 - name: File download via nscurl
+  auto_generated_guid: 8039d960-2bba-4d27-839a-b6eee9a41421
   description: |
      Use nscurl to download and write a file/payload from the internet.
      -k = Disable certificate checking

--- a/atomics/T1114.002/T1114.002.yaml
+++ b/atomics/T1114.002/T1114.002.yaml
@@ -2,6 +2,7 @@ attack_technique: T1114.002
 display_name: 'Email Collection: Remote Email Collection'
 atomic_tests:
 - name: Office365 - Remote Mail Collected
+  auto_generated_guid: ee3dc7b9-fb24-4007-8ee5-2cf970793f10
   description: |
     Create and register an entra application that downloads emails from a tenant's Office 365 mailboxes using the Microsoft Graph API app-only access. This can be used by an adversary to collect an organization's sensitive information. 
   supported_platforms:


### PR DESCRIPTION
**Details:**
Two atomic_tests were missing guids.  These guids were generated with calls to uuid.uuid4() in Python and updated

**Testing:**
Validated updated yaml files against schema

**Associated Issues:**
None