### PR TITLE
Add atomics to PR

### DIFF
--- a/.github/workflows/generate-counter.yml
+++ b/.github/workflows/generate-counter.yml
@@ -36,6 +36,7 @@ jobs:
           git config user.name "publish bot"
           git config --global push.default simple
           git add README.md
+          git add atomics
           git commit --allow-empty -m "updating atomics count and guids [ci skip]"
           # push quietly to prevent showing the token in log
           # no need to provide any credentials


### PR DESCRIPTION
**Details:**
There's a handful of atomics that currently don't have GUIDs (see #2753). After GUID generation got moved to `generate-counter.yml`, the commit-back phase at the end was not adjusted to capture changes to the `atomics/` folder

**Testing:**
<!-- Note any testing done, local or automated here. -->

**Associated Issues:**
https://github.com/redcanaryco/atomic-red-team/issues/2753