### PR TITLE
Adding T1135 Test - Enumerate All Network Shares with Snaffler

### DIFF
--- a/atomics/T1135/T1135.yaml
+++ b/atomics/T1135/T1135.yaml
@@ -210,3 +210,31 @@ atomic_tests:
     cleanup_command: remove-item "#{output_path}" -force -erroraction silentlycontinue
     name: powershell
     elevation_required: false
+- name: Enumerate All Network Shares with Snaffler
+  description: |
+    Snaffler is an open-source tool that has been used by various threat groups, including Scattered Spider/Muddled Libra, to enumerate accessible shares and credential-containing files within a domain. 
+    [Reference](https://unit42.paloaltonetworks.com/muddled-libra/)
+  supported_platforms:
+  - windows
+  input_arguments:
+    output_path:
+      description: File to output enumeration results to
+      type: String
+      default: '$env:temp\T1135SnafflerOutput.txt'
+    snaffler_path:
+      description: Path to the Snaffler executable
+      type: String
+      default: PathToAtomicsFolder\..\ExternalPayloads\Snaffler.exe
+  dependency_executor_name: powershell
+  dependencies:
+  - description: The Snaffler executable must exist on disk
+    prereq_command: if (Test-Path "PathToAtomicsFolder\..\ExternalPayloads\Snaffler.exe") {exit 0} else {exit 1}
+    get_prereq_command: |-
+      New-Item -Type Directory "PathToAtomicsFolder\..\ExternalPayloads\" -ErrorAction Ignore -Force | Out-Null
+      Invoke-WebRequest "https://github.com/SnaffCon/Snaffler/releases/download/1.0.150/Snaffler.exe" -OutFile "PathToAtomicsFolder\..\ExternalPayloads\Snaffler.exe"
+  executor:
+    command: |
+      invoke-expression 'cmd /c start powershell -command { cmd /c "#{snaffler_path}" -a -o "#{output_path}" }; start-sleep 90; stop-process -name "snaffler"'
+    cleanup_command: remove-item "#{output_path}" -force -erroraction silentlycontinue
+    name: powershell
+    elevation_required: false        


### PR DESCRIPTION
**Details:**
Snaffler is an open source tool that has previously been used by threat groups, including Scattered Spider, to enumerate network shares, as well as search for files that potentially contain credentials/other secrets. Upon successful execution of this test, Snaffler will enumerate accessible network shares and output it to a text file.
Reference: https://unit42.paloaltonetworks.com/muddled-libra/

**Testing:**
Tested on Windows 10 
