### PR TITLE
Adding codebox so '\' characters shows up well in Markdown

### DIFF
--- a/atomics/T1070.004/T1070.004.yaml
+++ b/atomics/T1070.004/T1070.004.yaml
@@ -178,7 +178,7 @@ atomic_tests:
 - name: Delete Prefetch File
   auto_generated_guid: 36f96049-0ad7-4a5f-8418-460acaeb92fb
   description: |
-    Delete a single prefetch file.  Deletion of prefetch files is a known anti-forensic technique. To verify execution, Run "(Get-ChildItem -Path "$Env:SystemRoot\prefetch\*.pf" | Measure-Object).Count"
+    Delete a single prefetch file.  Deletion of prefetch files is a known anti-forensic technique. To verify execution, Run `(Get-ChildItem -Path "$Env:SystemRoot\prefetch\*.pf" | Measure-Object).Count`
     before and after the test to verify that the number of prefetch files decreases by 1.
   supported_platforms:
   - windows


### PR DESCRIPTION
**Details:**
Since the command "(Get-ChildItem -Path "$Env:SystemRoot\prefetch*.pf" | Measure-Object).Count" is not in a codebox, the '*' character is being escaped by Markdown.

Resubmitting as suggested on https://github.com/redcanaryco/atomic-red-team/pull/2581