### PR TITLE
Fix T1219 test

### DIFF
--- a/atomics/T1219/T1219.yaml
+++ b/atomics/T1219/T1219.yaml
@@ -248,6 +248,10 @@ atomic_tests:
       description: Path of MSP360 executable
       type: path
       default: $env:ProgramFiles\Connect\Connect.exe
+    MSP360_Download_Url:
+      description: URL to download MSP360 Connect from
+      type: url
+      default:
   dependency_executor_name: powershell
   dependencies:
   - description: |
@@ -256,7 +260,7 @@ atomic_tests:
       if (Test-Path #{MSP360_Connect_Path}) {exit 0} else {exit 1}
     get_prereq_command: |
       New-Item -Type Directory "PathToAtomicsFolder\..\ExternalPayloads\" -ErrorAction Ignore -Force | Out-Null
-      Invoke-WebRequest -OutFile "PathToAtomicsFolder\..\ExternalPayloads\msp360connect.exe" "https://s3.amazonaws.com/cb_setups/_current/cbra/setup.exe?X-Amz-Expires=604800&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIA2WIZE3YN7NOSY65U/20230515/us-east-1/s3/aws4_request&X-Amz-Date=20230515T024742Z&X-Amz-SignedHeaders=host&response-content-disposition=attachment;filename=ConnectStandaloneSetup_v3.3.0.15_netv4.5.1_cFA9100C6.exe&X-Amz-Signature=1fe3ddf93f8431b182fac90341f80a4ebf8665ddcc0e36dd385ee20d0ce865c9"
+      Invoke-WebRequest -OutFile "PathToAtomicsFolder\..\ExternalPayloads\msp360connect.exe" "#{MSP360_Download_Url}"
       start-process "PathToAtomicsFolder\..\ExternalPayloads\msp360connect.exe" /S    
   executor:
     command: |


### PR DESCRIPTION
**Details:**
There is a AWS secret in the T1219 test which causes the pipelines to fail. Making this an argument and removing the S3 URL to fix this issue. 
