### PR TITLE
Added Splashstop streamer to T1219

### DIFF
--- a/atomics/T1219/T1219.yaml
+++ b/atomics/T1219/T1219.yaml
@@ -340,6 +340,6 @@ atomic_tests:
   executor:
     command: |-
       Start-Process -FilePath "C:Program Files (x86)\Splashtop\Splashtop Remote\Server\#{srserver_exe}"
-  name: powershell
+    name: powershell
     elevation_required: true
 

--- a/atomics/T1219/T1219.yaml
+++ b/atomics/T1219/T1219.yaml
@@ -316,3 +316,30 @@ atomic_tests:
       Stop-Process -Name "strwinclt" -force -erroraction silentlycontinue
     name: powershell
     elevation_required: true
+- name: Splashtop Streamer Execution
+  auto_generated_guid: 
+  description: An adversary may attempt to use Splashtop Streamer to gain unattended remote interactive access. Upon successful execution, Splashtop streamer will be executed.
+  supported_platforms:
+  - windows
+  input_arguments:
+    srserver_exe:
+      description: Splashtop streamer installation executables
+      type: string
+      default: SRServer.exe
+  dependency_executor_name: powershell
+  dependencies:
+  - description: Splashtop Streamer must be installed in the location
+    prereq_command: |
+      if (Test-Path "C:\Program Files (x86)\Splashtop\Splashtop Remote\Server\#{srserver_exe}") {exit 0} else {exit 1}
+    get_prereq_command: |-
+      Write-Host Downloading Splashtop Streamer
+      New-Item -Type Directory "C:\Temp\ExternalPayloads\" -ErrorAction Ignore -Force | Out-Null
+      Invoke-WebRequest "https://download.splashtop.com/win/Splashtop_Streamer_Win_INSTALLER_v3.6.4.1.exe" -OutFile  "C:\Temp\ExternalPayloads\Splashtop.exe"
+      Write-Host Installing Splashtop Streamer
+      Start-Process "c:\Temp\ExternalPayloads\Splashtop.exe" -Wait -ArgumentList "/s"
+  executor:
+    command: |-
+      Start-Process -FilePath "C:Program Files (x86)\Splashtop\Splashtop Remote\Server\#{srserver_exe}"
+  name: powershell
+    elevation_required: true
+


### PR DESCRIPTION
**Details:**
An adversary may attempt to use Splashtop Streamer to gain unattended remote interactive access. Upon successful execution, Splashtop streamer will be executed.

**Testing:**
Successfully tested
