### PR TITLE
Modified the Prereq_command of Test Unload Sysmon Filter Driver

### DIFF
--- a/atomics/T1562.001/T1562.001.yaml
+++ b/atomics/T1562.001/T1562.001.yaml
@@ -188,7 +188,7 @@ atomic_tests:
 - name: Unload Sysmon Filter Driver
   auto_generated_guid: 811b3e76-c41b-430c-ac0d-e2380bfaa164
   description: |
-    Unloads the Sysinternals Sysmon filter driver without stopping the Sysmon service. To verify successful execution, o verify successful execution,
+    Unloads the Sysinternals Sysmon filter driver without stopping the Sysmon service. To verify successful execution,
     run the prereq_command's and it should fail with an error of "sysmon filter must be loaded".
   supported_platforms:
   - windows

--- a/atomics/T1562.001/T1562.001.yaml
+++ b/atomics/T1562.001/T1562.001.yaml
@@ -202,7 +202,7 @@ atomic_tests:
   - description: |
       Sysmon must be downloaded
     prereq_command: |
-      if (-not (cmd.exe /c "where.exe Sysmon.exe 2> nul | findstr Sysmon 2> nul") -or (Test-Path "PathToAtomicsFolder\..\ExternalPayloads\Sysmon\Sysmon.exe")) { exit 0 } else { exit 1 }
+      if ((cmd.exe /c "where.exe Sysmon.exe 2> nul | findstr /i Sysmon 2> nul") -or (Test-Path "PathToAtomicsFolder\..\ExternalPayloads\Sysmon\Sysmon.exe")) { exit 0 } else { exit 1 }
     get_prereq_command: |
       New-Item -Type Directory "PathToAtomicsFolder\..\ExternalPayloads\" -ErrorAction Ignore -Force | Out-Null
       Invoke-WebRequest "https://download.sysinternals.com/files/Sysmon.zip" -OutFile "PathToAtomicsFolder\..\ExternalPayloads\Sysmon.zip"


### PR DESCRIPTION
**Details:**
1. Modified the Prereq_command on the test "Unload Sysmon Filter Driver", It was not downloading sysmon even when sysmon was not present.  Because the prereq command was returning 0 when sysmon was not there. So corrected that by removing the "-not" from the prereq command.
2. Also addded "/i" flag to findStr to make it case insensitive 

**Testing:**
1. Tested and its working

