### PR TITLE
Remove dependencies from one of T1070.006 tests

### DIFF
--- a/atomics/T1070.006/T1070.006.yaml
+++ b/atomics/T1070.006/T1070.006.yaml
@@ -96,15 +96,9 @@ atomic_tests:
       description: Path of reference file to read timestamps from
       type: path
       default: /bin/sh
-  dependencies:
-  - description: |
-      The file must exist in order to be timestomped
-    prereq_command: |
-      test -e #{target_file_path} && exit 0 || exit 1
-    get_prereq_command: |
-      echo 'T1070.006 reference file timestomp test' > #{target_file_path}
   executor:
     command: |
+      touch #{target_file_path}
       touch -acmr #{reference_file_path} #{target_file_path}
     cleanup_command: |
       rm -f #{target_file_path}


### PR DESCRIPTION
Remove dependencies from T1070.006's `Modify file timestamps using reference file`

**Details:**
Instead of having the file to be target file as a dependency, I think it's better to create it in test directly. As there is a -c command, we need to modify the file anyway. If people are automatically creating tests from this repo, the approach where the file is created as part of the script is better

**Testing:**
Local testing was done and the command is working
