### PR TITLE
Creation of T1614.yaml and T1016.001.yaml 

### DIFF
--- a/atomics/T1016.001/T1016.001
+++ b/atomics/T1016.001/T1016.001
@@ -1,5 +1,5 @@
 attack_technique: T1614
-display_name: System Network Configuration Discovery - Internet Connection Discovery 
+display_name: 'System Network Configuration Discovery: Internet Connection Discovery'
 atomic_tests:
 - name: Get the IP of the victim machine using curl Windows
   description: |

--- a/atomics/T1016.001/T1016.001
+++ b/atomics/T1016.001/T1016.001
@@ -1,0 +1,80 @@
+attack_technique: T1614
+display_name: System Network Configuration Discovery - Internet Connection Discovery 
+atomic_tests:
+- name: Get the IP of the victim machine using curl Windows
+  description: |
+    Get the IP of the victim machine using curl Windows. The default URL of the IP-Lookup service is https://ipinfo.io/.
+  supported_platforms:
+  - windows
+  input_arguments:
+    ip_lookup_url:
+      description: URL of the IP-Lookup service
+      type: url
+      default: https://ipinfo.io/
+    curl_path:
+      description: path to curl.exe
+      type: path
+      default: C:\Windows\System32\Curl.exe
+  dependency_executor_name: powershell
+  dependencies:
+  - description: |
+      Curl must be installed on system.
+    prereq_command: |
+      if (Test-Path #{curl_path}) {exit 0} else {exit 1}
+    get_prereq_command: |
+      New-Item -Type Directory "PathToAtomicsFolder\..\ExternalPayloads\" -ErrorAction Ignore -Force | Out-Null
+      Invoke-WebRequest "https://curl.se/windows/dl-8.4.0_6/curl-8.4.0_6-win64-mingw.zip" -Outfile "PathToAtomicsFolder\..\ExternalPayloads\curl.zip"
+      Expand-Archive -Path "PathToAtomicsFolder\..\ExternalPayloads\curl.zip" -DestinationPath "PathToAtomicsFolder\..\ExternalPayloads\curl"
+      Copy-Item "PathToAtomicsFolder\..\ExternalPayloads\curl\curl-8.4.0_6-win64-mingw\bin\curl.exe" C:\Windows\System32\Curl.exe
+  executor:
+    name: command_prompt
+    elevation_required: false
+    command: |
+      #{curl_path} -k #{ip_lookup_url}
+- name: Get the IP of the victim machine using curl freebsd, linux or macos
+  description: |
+    Get the IP of the victim machine using curl Windows. The default URL of the IP-Lookup service is https://ipinfo.io/.
+  supported_platforms:
+  - macos
+  - linux
+  input_arguments:
+    ip_lookup_url:
+      description: URL of the IP-Lookup service
+      type: url
+      default: https://ipinfo.io/
+  executor:
+    name: bash
+    elevation_required: false
+    command: |
+      curl -k #{ip_lookup_url}
+- name: Check internet connection using ping Windows
+  description: |
+    Check internet connection using ping on Windows. The default target of the ping is 8.8.8.8 (Google Public DNS).
+  supported_platforms:
+  - windows
+  input_arguments:
+    ping_target:
+      description: target of the ping
+      type: url
+      default: 8.8.8.8
+  executor:
+    name: command_prompt
+    elevation_required: false
+    command: |
+      ping -n 4 #{ping_target}
+- name: Check internet connection using ping freebsd, linux or macos
+  description: |
+    Check internet connection using ping on Linux, MACOS. The default target of the ping is 8.8.8.8 (Google Public DNS).
+  supported_platforms:
+  - macos
+  - linux
+  input_arguments:
+    ping_target:
+      description: target of the ping
+      type: url
+      default: 8.8.8.8
+  executor:
+    name: bash
+    elevation_required: false
+    command: |
+      ping -n 4 #{ping_target}

--- a/atomics/T1016.001/T1016.001
+++ b/atomics/T1016.001/T1016.001
@@ -1,4 +1,4 @@
-attack_technique: T1614
+attack_technique: T1016.001
 display_name: 'System Network Configuration Discovery: Internet Connection Discovery'
 atomic_tests:
 - name: Get the IP of the victim machine using curl Windows

--- a/atomics/T1016.001/T1016.001
+++ b/atomics/T1016.001/T1016.001
@@ -1,52 +1,6 @@
 attack_technique: T1016.001
 display_name: 'System Network Configuration Discovery: Internet Connection Discovery'
 atomic_tests:
-- name: Get the IP of the victim machine using curl Windows
-  description: |
-    Get the IP of the victim machine using curl Windows. The default URL of the IP-Lookup service is https://ipinfo.io/.
-  supported_platforms:
-  - windows
-  input_arguments:
-    ip_lookup_url:
-      description: URL of the IP-Lookup service
-      type: url
-      default: https://ipinfo.io/
-    curl_path:
-      description: path to curl.exe
-      type: path
-      default: C:\Windows\System32\Curl.exe
-  dependency_executor_name: powershell
-  dependencies:
-  - description: |
-      Curl must be installed on system.
-    prereq_command: |
-      if (Test-Path #{curl_path}) {exit 0} else {exit 1}
-    get_prereq_command: |
-      New-Item -Type Directory "PathToAtomicsFolder\..\ExternalPayloads\" -ErrorAction Ignore -Force | Out-Null
-      Invoke-WebRequest "https://curl.se/windows/dl-8.4.0_6/curl-8.4.0_6-win64-mingw.zip" -Outfile "PathToAtomicsFolder\..\ExternalPayloads\curl.zip"
-      Expand-Archive -Path "PathToAtomicsFolder\..\ExternalPayloads\curl.zip" -DestinationPath "PathToAtomicsFolder\..\ExternalPayloads\curl"
-      Copy-Item "PathToAtomicsFolder\..\ExternalPayloads\curl\curl-8.4.0_6-win64-mingw\bin\curl.exe" C:\Windows\System32\Curl.exe
-  executor:
-    name: command_prompt
-    elevation_required: false
-    command: |
-      #{curl_path} -k #{ip_lookup_url}
-- name: Get the IP of the victim machine using curl freebsd, linux or macos
-  description: |
-    Get the IP of the victim machine using curl Windows. The default URL of the IP-Lookup service is https://ipinfo.io/.
-  supported_platforms:
-  - macos
-  - linux
-  input_arguments:
-    ip_lookup_url:
-      description: URL of the IP-Lookup service
-      type: url
-      default: https://ipinfo.io/
-  executor:
-    name: bash
-    elevation_required: false
-    command: |
-      curl -k #{ip_lookup_url}
 - name: Check internet connection using ping Windows
   description: |
     Check internet connection using ping on Windows. The default target of the ping is 8.8.8.8 (Google Public DNS).

--- a/atomics/T1614/T1614.yaml
+++ b/atomics/T1614/T1614.yaml
@@ -1,0 +1,49 @@
+attack_technique: T1614
+display_name: System Location Discovery 
+atomic_tests:
+- name: Get geolocation info through IP-Lookup services using curl Windows
+  description: |
+    Get geolocation info through IP-Lookup services using curl Windows. The default URL of the IP-Lookup service is https://ipinfo.io/. References: https://securelist.com/transparent-tribe-part-1/98127/ and https://news.sophos.com/en-us/2016/05/03/location-based-ransomware-threat-research/
+  supported_platforms:
+  - windows
+  input_arguments:
+    ip_lookup_url:
+      description: URL of the IP-Lookup service
+      type: url
+      default: https://ipinfo.io/
+    curl_path:
+      description: path to curl.exe
+      type: path
+      default: C:\Windows\System32\Curl.exe
+  dependency_executor_name: powershell
+  dependencies:
+  - description: |
+      Curl must be installed on system.
+    prereq_command: |
+      if (Test-Path #{curl_path}) {exit 0} else {exit 1}
+    get_prereq_command: |
+      New-Item -Type Directory "PathToAtomicsFolder\..\ExternalPayloads\" -ErrorAction Ignore -Force | Out-Null
+      Invoke-WebRequest "https://curl.se/windows/dl-8.4.0_6/curl-8.4.0_6-win64-mingw.zip" -Outfile "PathToAtomicsFolder\..\ExternalPayloads\curl.zip"
+      Expand-Archive -Path "PathToAtomicsFolder\..\ExternalPayloads\curl.zip" -DestinationPath "PathToAtomicsFolder\..\ExternalPayloads\curl"
+      Copy-Item "PathToAtomicsFolder\..\ExternalPayloads\curl\curl-8.4.0_6-win64-mingw\bin\curl.exe" C:\Windows\System32\Curl.exe
+  executor:
+    name: command_prompt
+    elevation_required: false
+    command: |
+      #{curl_path} -k #{ip_lookup_url}
+- name: Get geolocation info through IP-Lookup services using curl freebsd, linux or macos
+  description: |
+    Get geolocation info through IP-Lookup services using curl Windows. The default URL of the IP-Lookup service is https://ipinfo.io/. References: https://securelist.com/transparent-tribe-part-1/98127/ and https://news.sophos.com/en-us/2016/05/03/location-based-ransomware-threat-research/
+  supported_platforms:
+  - macos
+  - linux
+  input_arguments:
+    ip_lookup_url:
+      description: URL of the IP-Lookup service
+      type: url
+      default: https://ipinfo.io/
+  executor:
+    name: bash
+    elevation_required: false
+    command: |
+      curl -k #{ip_lookup_url}


### PR DESCRIPTION
**Details:**
Following the template of T1048.002.yaml, I created T1614.yaml focusing only on getting geolocation info through IP-Lookup services using curl to ipinfo.io (windows, linux, macos).
- Test 1: curl to ipinfo.io for windows (ipinfo.io is a parameter)
- Test 2: curl to ipinfo.io for linux, macos, freebsd (ipinfo.io is a parameter)

ATT&CK reference: https://attack.mitre.org/techniques/T1614/

On top of that, I created T1016.001.yaml slightly changing the yaml of T1614. It has 4 tests:
- Test 1: curl to ipinfo.io for windows (same as T1614, ipinfo.io is a parameter)
- Test 2: curl to ipinfo.io for linux, macos, freebsd (same as T1614, ipinfo.io is a parameter)
- Test 3: ping to 8.8.8.8 for windows (8.8.8.8 is a parameter)
- Test 4: ping to 8.8.8.8 for linux, macos, freebsd (8.8.8.8 is a parameter)

ATT&CK reference: https://attack.mitre.org/techniques/T1016/001/

I included both files in a single pull request since they're very similar to each other. 




