### PR TITLE
Adding missing auto_generated_guid

### DIFF
--- a/atomics/T1546/T1546.yaml
+++ b/atomics/T1546/T1546.yaml
@@ -170,6 +170,7 @@ atomic_tests:
     name: command_prompt
     elevation_required: true
 - name: Persistence using STARTUP-PATH in MS-WORD
+  auto_generated_guid: 853255c3-8d3a-4d87-a354-ab6ba1122003
   description: |-
     When Word starts, it searches for the registry key HKCU\Software\Microsoft\Office\<version>\Word\Options\STARTUP-PATH and if it exists,
     it will treat it as a user specific start-up folder and load the contents of the folder with file extensions of .wll,.lnk,.dotm,.dot,.dotx

--- a/atomics/T1574.001/T1574.001.yaml
+++ b/atomics/T1574.001/T1574.001.yaml
@@ -43,6 +43,7 @@ atomic_tests:
     name: command_prompt
     elevation_required: true    
 - name: Phantom Dll Hijacking - ualapi.dll
+  auto_generated_guid: 5eff1f07-2c27-4e39-92fc-7e1039ab8506
   description: |
     Re-starting the Print Spooler service leads to C:\Windows\System32\ualapi.dll being loaded
     A malicious ualapi.dll placed in the System32 directory will lead to its execution whenever the system starts

--- a/atomics/T1614/T1614.yaml
+++ b/atomics/T1614/T1614.yaml
@@ -2,6 +2,7 @@ attack_technique: T1614
 display_name: System Location Discovery 
 atomic_tests:
 - name: Get geolocation info through IP-Lookup services using curl Windows
+  auto_generated_guid: be62f54e-f7fe-46b0-b2b6-cfd0b03980ed
   description: |
     Get geolocation info through IP-Lookup services using curl Windows. The default URL of the IP-Lookup service is https://ipinfo.io/. References: https://securelist.com/transparent-tribe-part-1/98127/ and https://news.sophos.com/en-us/2016/05/03/location-based-ransomware-threat-research/
   supported_platforms:
@@ -32,6 +33,7 @@ atomic_tests:
     command: |
       #{curl_path} -k #{ip_lookup_url}
 - name: Get geolocation info through IP-Lookup services using curl freebsd, linux or macos
+  auto_generated_guid: 8b336178-bf7f-41e4-95ab-89c1e457b1b7
   description: |
     Get geolocation info through IP-Lookup services using curl Windows. The default URL of the IP-Lookup service is https://ipinfo.io/. References: https://securelist.com/transparent-tribe-part-1/98127/ and https://news.sophos.com/en-us/2016/05/03/location-based-ransomware-threat-research/
   supported_platforms:


### PR DESCRIPTION
Several atomics were missing their auto-generated guids, as revealed by our ART Repo parsing tool.
I have added the guids to the relevant detections. 