### PR TITLE
bumped ruby to 3.0

### DIFF
--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -43,7 +43,7 @@ jobs:
       - name: setup ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7
+          ruby-version: 3.0
           bundler-cache: true
 
       - name: generate markdown docs for atomics


### PR DESCRIPTION
Looks like we ran into a [dependency](https://github.com/redcanaryco/atomic-red-team/actions/runs/10361863419/job/28682903316#step:9:51) error with Ruby because our CI job is using a older version. I bumped it to 3.0 and tested our doc generation scripts. They seem to be working still under the updated version. 

```
jhernandez in ~/splunk/atomic-red-teamwith 3.0.7 on fix_ruby_deps ● ● λ ruby bin/generate-atomic-docs.rb
Generating docs for /Users/jhernandez/splunk/atomic-red-team/atomics/T1654/T1654.yaml => /Users/jhernandez/splunk/atomic-red-team/atomics/T1654/T1654.md => OK

Generated docs for 313 techniques, 0 failures
Generated ATT&CK matrix at ./atomics/Indexes/Matrices/matrix.md
Generated ATT&CK matrix at ./atomics/Indexes/Matrices/windows-matrix.md
Generated ATT&CK matrix at ./atomics/Indexes/Matrices/macos-matrix.md
Generated ATT&CK matrix at ./atomics/Indexes/Matrices/linux-matrix.md
```