### PR TITLE
Update typo and small grammar details in T1071.yaml

### DIFF
--- a/atomics/T1071/T1071.yaml
+++ b/atomics/T1071/T1071.yaml
@@ -4,13 +4,13 @@ atomic_tests:
 - name: Telnet C2
   auto_generated_guid: 3b0df731-030c-4768-b492-2a3216d90e53
   description: |
-    An adversary may establish telnet communication from compromised endpoint to command and control (C2) server to be able to operate more attack on objectives.
+    An adversary may establish Telnet communication from a compromised endpoint to a command and control (C2) server in order to carry out additional attacks on objectives.
   supported_platforms:
   - windows
   dependency_executor_name: powershell
   dependencies:
   - description: |
-      Command and Control (C2) server cam be established by running PathToAtomicsFolder\T1071\bin\telnet_server.exe on specified server with specified IP that must be reachable by client (telnet_client.exe)
+      A command and control (C2) server can be established by running PathToAtomicsFolder\T1071\bin\telnet_server.exe on a specified server with a specified IP that must be reachable by a client (telnet_client.exe)
     prereq_command: |
       $connection = Test-NetConnection -ComputerName #{server_ip} -Port #{server_port}
       if ($connection.TcpTestSucceeded) {exit 0} else {exit 1}
@@ -20,7 +20,7 @@ atomic_tests:
     server_ip:
       description: C2 server IP or URL
       type: url
-      default: 127.0.0.1  # Replace "example.com" with the actual IP or URL
+      default: 127.0.0.1  # Replace "127.0.0.1" with the actual IP or URL
     client_path:
       description: Client agent path
       type: path


### PR DESCRIPTION
**Details:**
I found a typo in in T1071, _**cam** be established_ so I fixed that. I reformulated the test description, changed a couple of uppercase and lowercase letters and added some articles that were missing here and there. I changed also a comment in the input argument (C2 server IP or URL) default to match the actual value. See the Files changed tab for the full details

