### PR TITLE
Fix test `T1053.006-1`

### DIFF
--- a/atomics/T1053.006/T1053.006.yaml
+++ b/atomics/T1053.006/T1053.006.yaml
@@ -52,6 +52,7 @@ atomic_tests:
       rm #{path_to_systemd_timer}
       systemctl daemon-reload
     name: bash
+    elevation_required: true
 
 - name: Create a user level transient systemd service and timer
   auto_generated_guid: 3de33f5b-62e5-4e63-a2a0-6fd8808c80ec


### PR DESCRIPTION
**Details:**
Test 1 requires privileged execution in order to properly create a new service and reload the linux daemon.

**Testing:**
The current execution prompts for the password, exactly as documented in this other PR: https://github.com/redcanaryco/atomic-red-team/pull/2893 
