### PR TITLE
Update test `T1069.001.yaml`

### DIFF
--- a/atomics/T1069.001/T1069.001.yaml
+++ b/atomics/T1069.001/T1069.001.yaml
@@ -120,7 +120,7 @@ atomic_tests:
   executor:
     command: |-
       docker build -t t1069 $PathtoAtomicsFolder/T1069.001/src/
-      docker run --name t1069_container  -d -t t1069
+      docker run --name t1069_container --rm -d -t t1069
       docker exec t1069_container ./test.sh
     cleanup_command: |-
       docker stop t1069_container


### PR DESCRIPTION
**Details:**
Adding the `--rm` option to the docker run command ensures that the container is deleted once it is stopped. This allows this test to be run multiple times without raising the "container name already exists" error.

**Testing:**
Tested on Ubuntu. 

**Associated Issues:**
