### PR TITLE
Fix `T1056.001.yaml`

### DIFF
--- a/atomics/T1056.001/T1056.001.yaml
+++ b/atomics/T1056.001/T1056.001.yaml
@@ -200,7 +200,7 @@ atomic_tests:
     command: |
       auditctl -a always,exit -F arch=b64 -S execve -k CMDS 
       auditctl -a always,exit -F arch=b32 -S execve -k CMDS
-      whoami; ausearch -i --start $(date +"%m/%d/%y %H:%M:%S")
+      whoami; ausearch -i --start now
     cleanup_command: |
       systemctl restart auditd
 - name: MacOS Swift Keylogger

--- a/atomics/T1056.001/T1056.001.yaml
+++ b/atomics/T1056.001/T1056.001.yaml
@@ -200,7 +200,7 @@ atomic_tests:
     command: |
       auditctl -a always,exit -F arch=b64 -S execve -k CMDS 
       auditctl -a always,exit -F arch=b32 -S execve -k CMDS
-      whoami; ausearch -i --start $(date +"%d/%m/%y %H:%M:%S") 
+      whoami; ausearch -i --start $(date +"%m/%d/%y %H:%M:%S")
     cleanup_command: |
       systemctl restart auditd
 - name: MacOS Swift Keylogger


### PR DESCRIPTION
**Details:**
Replacing the date format in the `ausearch` command. This command depends on the date format, which may depend on your locale. To make it more generic, we can replace the current date and time command with `now`, which is documented in the official docs.

Here is the current execution result, that prints out `<no matches>` because of the not supported date format:

![Screenshot 2024-09-10 alle 11 17 31](https://github.com/user-attachments/assets/f45e32b2-a26a-4221-91ce-a120fb9a560d)

Here, instead, is the fixed version result using `now`:
 
![Screenshot 2024-09-10 alle 11 35 47](https://github.com/user-attachments/assets/1bfc2c83-7b36-4632-ab7b-a21d59a27227)


**Testing:**
Tested on Ubuntu
