### PR TITLE
Fix test T1070.008.yaml

### DIFF
--- a/atomics/T1070.008/T1070.008.yaml
+++ b/atomics/T1070.008/T1070.008.yaml
@@ -23,18 +23,19 @@ atomic_tests:
     Copies and deletes mail data on Linux
   supported_platforms:
   - linux
+  dependencies:
+  - description: |
+      Create dummy file in /var/spool/mail/ if no files exist
+    prereq_command: |
+      if [ -z "$(ls -A /var/spool/mail/)" ]; then exit 1; else exit 0; fi
+    get_prereq_command: |
+      if [ -z "$(ls -A /var/spool/mail/)" ]; then touch /var/spool/mail/temp; fi
   executor:
     command: |
-      mkdir -p /var/spool/mail/copy
-      for file in /var/spool/mail/*; do
-        if [ "$(basename "$file")" != "copy" ]
-        then
-          cp -R "$file" /var/spool/mail/copy/
-        fi
-      done
-      rm -rf /var/spool/mail/copy/*
+      mkdir -p /var/spool/mail/copy && for file in /var/spool/mail/*; do if [ "$(basename "$file")" != "copy" ]; then cp -R "$file" /var/spool/mail/copy/; fi; done && rm -rf /var/spool/mail/copy/*
     cleanup_command: |
       rm -rf /var/spool/mail/copy
+      if [ -f "$(ls -A /var/spool/mail/temp)" ]; then rm /var/spool/mail/temp; fi
     name: bash
     elevation_required: true
 
@@ -76,20 +77,19 @@ atomic_tests:
     Copies and modifies mail data on Linux
   supported_platforms:
   - linux
+  dependencies:
+  - description: |
+      Create dummy file in /var/spool/mail/ if no files exist
+    prereq_command: |
+      if [ -z "$(ls -A /var/spool/mail/)" ]; then exit 1; else exit 0; fi
+    get_prereq_command: |
+      if [ -z "$(ls -A /var/spool/mail/)" ]; then touch /var/spool/mail/temp; fi
   executor:
     command: |
-      mkdir -p /var/spool/mail/copy
-      for file in /var/spool/mail/*; do
-        if [ "$(basename "$file")" != "copy" ]
-        then
-          cp -R "$file" /var/spool/mail/copy/
-          if [ -f "/var/spool/mail/copy/$(basename "$file")" ]; then
-            echo "Modification for Atomic Red Test" >> "/var/spool/mail/copy/$(basename "$file")"
-          fi
-        fi
-      done
+      mkdir -p /var/spool/mail/copy; for file in /var/spool/mail/*; do if [ "$(basename "$file")" != "copy" ]; then cp -R "$file" /var/spool/mail/copy/; if [ -f "/var/spool/mail/copy/$(basename "$file")" ]; then echo "Modification for Atomic Red Test" >> "/var/spool/mail/copy/$(basename "$file")"; fi; fi; done
     cleanup_command: |
       rm -rf /var/spool/mail/copy
+      if [ -f "$(ls -A /var/spool/mail/temp)" ]; then rm /var/spool/mail/temp; fi
     name: bash
     elevation_required: true
 


### PR DESCRIPTION
**Details:**
Both the tests for Linux don't work as expected. Here some screenshots:
<img width="1792" alt="Screenshot 2024-09-18 alle 11 00 37" src="https://github.com/user-attachments/assets/38bd612e-5150-46fd-a26d-aaf253f153c8">

<img width="1792" alt="Screenshot 2024-09-18 alle 11 01 05" src="https://github.com/user-attachments/assets/e50ade7b-9b75-47c1-ace9-ad051d30be15">
I guess that the issue here is how `pwsh` runs bash commands, line by line, according to the `bash -c "command1; command2; command3"` format. This raises errors `if` statements and `for` loops are used. To fix that, I set the commands in only one line.  

This fixed the execution as shown here:
<img width="976" alt="Screenshot 2024-09-18 alle 11 04 47" src="https://github.com/user-attachments/assets/9caaa5f5-cb1e-4b57-916c-e6270efea9b7">

However, the other issue I see here is that sometimes the `/var/spool/mail` folder may be empty. So the use cases are not really reproduced because there are no files to `copy and delete` or `copy and modify.`
To address this issue, I added some prerequisites to create a new dummy and empty file when no other files exist.

Let me know what you think. 

**Testing:**
tested on Ubuntu.
