### PR TITLE
Update T1012.yaml

### DIFF
--- a/atomics/T1012/T1012.yaml
+++ b/atomics/T1012/T1012.yaml
@@ -126,3 +126,11 @@ atomic_tests:
       reg.exe query hklm\software\microsoft\windows\softwareinventorylogging /v collectionstate /reg:64
     name: command_prompt
     elevation_required: true
+- name: Inspect SystemStartOptions Value in Registry
+  description: The objective of this test is to query the SystemStartOptions key under HKLM\SYSTEM\CurrentControlSet\Control in the Windows registry. This action could be used to uncover specific details about how the system is configured to start, potentially aiding in understanding boot parameters or identifying security-related settings.
+    key is.
+  supported_platforms:
+  - windows
+  executor:
+    name: command_prompt
+    command: reg.exe query HKLM\SYSTEM\CurrentControlSet\Control /v SystemStartOptions

--- a/atomics/T1012/T1012.yaml
+++ b/atomics/T1012/T1012.yaml
@@ -1,4 +1,4 @@
-attack_technique: T1012
+  attack_technique: T1012
 display_name: Query Registry
 atomic_tests:
 - name: Query Registry
@@ -133,4 +133,5 @@ atomic_tests:
   - windows
   executor:
     name: command_prompt
-    command: reg.exe query HKLM\SYSTEM\CurrentControlSet\Control /v SystemStartOptions
+    command: |
+      reg.exe query HKLM\SYSTEM\CurrentControlSet\Control /v SystemStartOptions

--- a/atomics/T1012/T1012.yaml
+++ b/atomics/T1012/T1012.yaml
@@ -1,4 +1,4 @@
-  attack_technique: T1012
+attack_technique: T1012
 display_name: Query Registry
 atomic_tests:
 - name: Query Registry


### PR DESCRIPTION
New atomic added.

**Details:**
This atomic test adds a new method to query the `SystemStartOptions` registry key located under `HKLM\SYSTEM\CurrentControlSet\Control`. The purpose of this test is to simulate a technique that an attacker might use to retrieve system startup configurations, which could provide insight into how the system boots or is configured.

**Testing:**
The test was executed locally on a Windows system to ensure that the command correctly retrieves the value of the `SystemStartOptions `key. Successful execution returned the current configuration value without any errors.

**Associated Issues:**
No associated issues linked to this pull request.