### PR TITLE
Add new atomic - T1518.001.yaml

### DIFF
--- a/atomics/T1518.001/T1518.001.yaml
+++ b/atomics/T1518.001/T1518.001.yaml
@@ -152,3 +152,15 @@ atomic_tests:
       Get-NetFirewallRule | select DisplayName, Enabled, Description
     name: powershell 
     elevation_required: true
+- name: Get Windows Defender exclusion settings using WMIC
+  description: |
+    In this test, a WMIC command is used to probe the local Windows system for the configuration of Windows Defender's exclusions. This command targets the MSFT_MpPreference 
+    class within the Windows Management Instrumentation (WMI) namespace, allowing the retrieval of critical settings such as disabled real-time monitoring and specified 
+    exclusion paths, file extensions, and processes. Attackers might use this approach to understand what is excluded from antivirus scans, enabling further exploitation.
+  supported_platforms:
+  - windows
+  executor:
+    name: command_prompt
+    elevation_required: true
+    command: |
+      wmic /Node:localhost /Namespace:\\root\Microsoft\Windows\Defender Path MSFT_MpPreference Get /format:list | findstr /i /C:"DisableRealtimeMonitoring" /C:"ExclusionPath" /C:"ExclusionExtension" /C:"ExclusionProcess"


### PR DESCRIPTION
**Details:**
This update adds a new atomic test to execute a WMIC command that retrieves Windows Defender exclusion settings. It helps simulate how attackers might identify configurations that disable real-time monitoring or specify excluded paths, file types, and processes.

**Testing:**
Tested on a local windows machine, confirming that the WMIC command correctly retrieves the desired configuration details without errors. Screenshot below.

![image](https://github.com/user-attachments/assets/0409c777-31cc-4cda-8a37-076a8c9045e5)
