### PR TITLE
Get Printer Device List via PowerShell Command

### DIFF
--- a/atomics/T1120/T1120.yaml
+++ b/atomics/T1120/T1120.yaml
@@ -33,3 +33,14 @@ atomic_tests:
     command: |-
       fsutil fsinfo drives
     name: command_prompt
+- name: Get Printer Device List via PowerShell Command
+  description: |
+    This test uses PowerShell to list printers on a Windows system, demonstrating a discovery technique attackers might use to 
+    gather details on connected devices. Using Get-Printer, they can view information on all available printers, identifying 
+    potential devices for further targeting.
+  supported_platforms:
+  - windows
+  executor:
+    name: command_prompt
+    command: |
+      powershell.exe -c "Get-Printer"

--- a/atomics/T1120/T1120.yaml
+++ b/atomics/T1120/T1120.yaml
@@ -41,6 +41,6 @@ atomic_tests:
   supported_platforms:
   - windows
   executor:
-    name: command_prompt
+    name: powershell
     command: |
-      powershell.exe -c "Get-Printer"
+      Get-Printer


### PR DESCRIPTION
**Details:**
Using PowerShell to gather printer information on Windows systems. The test checks for connected printers, providing insight into potential peripheral device discovery tactics.

**Testing:**
Confirmed that the Get-Printer command accurately lists all connected printers across tested Windows environments.
