### PR TITLE
feat: more cloud credential discovery

### DIFF
--- a/atomics/T1552.001/T1552.001.yaml
+++ b/atomics/T1552.001/T1552.001.yaml
@@ -2,7 +2,6 @@ attack_technique: T1552.001
 display_name: 'Unsecured Credentials: Credentials In Files'
 atomic_tests:
 - name: Find AWS credentials
-  auto_generated_guid: 2b93758e-a8d7-4e3b-bc7b-d3aa8d7ecb17
   description: |
     Find local AWS credentials from file, defaults to using / as the look path.
   supported_platforms:
@@ -15,7 +14,7 @@ atomic_tests:
       default: /
   executor:
     command: |
-      find #{file_path} -name "credentials" -type f -path "*/.aws/*" 2>/dev/null
+      find #{file_path}/.aws -name "credentials" -type f 2>/dev/null
     name: sh
 - name: Extract Browser and System credentials with LaZagne
   auto_generated_guid: 9e507bb8-1d30-4e3b-a49b-cb5727d7ea79
@@ -189,3 +188,48 @@ atomic_tests:
       
     name: command_prompt
     elevation_required: true
+- name: Find Azure credentials
+  description: |
+    Find local Azure credentials from file, defaults to using / as the look path.
+  supported_platforms:
+  - macos
+  - linux
+  input_arguments:
+    file_path:
+      description: Path to search
+      type: string
+      default: /
+  executor:
+    command: |
+      find #{file_path}/.azure -name "msal_token_cache.json" -o -name "accessTokens.json" -type f 2>/dev/null
+    name: sh
+- name: Find GCP credentials
+  description: |
+    Find local Google Cloud Platform credentials from file, defaults to using / as the look path.
+  supported_platforms:
+  - macos
+  - linux
+  input_arguments:
+    file_path:
+      description: Path to search
+      type: string
+      default: /
+  executor:
+    command: |
+      find #{file_path}/.config/gcloud -name "credentials.db" -o -name "access_tokens.db" -type f 2>/dev/null
+    name: sh
+- name: Find OCI credentials
+  description: |
+    Find local Oracle cloud credentials from file, defaults to using / as the look path.
+  supported_platforms:
+  - macos
+  - linux
+  input_arguments:
+    file_path:
+      description: Path to search
+      type: string
+      default: /
+  executor:
+    command: |
+      find #{file_path}/.oci/sessions -name "token" -type f 2>/dev/null
+    name: sh


### PR DESCRIPTION
Adding support for Azure, GCP, and OCI
Also fixed AWS check

**Details:**
Added file system searches for Azure, GCP, and OCI credentials:
- Azure: `#{file_path}/.azure` with files named either `msal_token_cache.json` or `accessTokens.json`
- GCP: `#{file_path}/.config/gcloud` with files named either `credentials.db` or `access_tokens.json`
- OCI: `#{file_path}/.oci/sessions` with files named `token`

Also adjusted the `find` command for the AWS credential search as it would look outside of expected locations

**Testing:**
Here is the output of me performing all four searches on my local system (macOS):
- AWS

     ```powershell
     Invoke-AtomicTest T1552.001 -TestNames "Find AWS credentials" -InputArgs @{"file_path" = "/Users/nicholsr"}
    ```

    ```text
    PathToAtomicsFolder = /Users/nicholsr/AtomicRedTeam/atomics
    
    Executing test: T1552.001-1 Find AWS credentials                                
    /Users/nicholsr/.aws/credentials                                                
    Exit code: 0                                                                    
    Done executing test: T1552.001-1 Find AWS credentials
    ```

- Azure

    ```powershell
    Invoke-AtomicTest T1552.001 -TestNames "Find Azure credentials" -InputArgs @{"file_path" = "/Users/nicholsr"}
    ```

    ```text
    PathToAtomicsFolder = /Users/nicholsr/AtomicRedTeam/atomics
    
    Executing test: T1552.001-15 Find Azure credentials                             
    /Users/nicholsr/.azure/msal_token_cache.json                                    
    Exit code: 0                                                                    
    Done executing test: T1552.001-15 Find Azure credentials
    ```

- GCP

    ```powershell
    Invoke-AtomicTest T1552.001 -TestNames "Find GCP credentials" -InputArgs @{"file_path" = "/Users/nicholsr"}
    ```

    ```text
    PathToAtomicsFolder = /Users/nicholsr/AtomicRedTeam/atomics
    
    Executing test: T1552.001-16 Find GCP credentials                               
    /Users/nicholsr/.config/gcloud/access_tokens.db                                 
    /Users/nicholsr/.config/gcloud/credentials.db
    Exit code: 0                                                                    
    Done executing test: T1552.001-16 Find GCP credentials
    ```

- OCI

    ```powershell
    Invoke-AtomicTest T1552.001 -TestNames "Find OCI credentials" -InputArgs @{"file_path" = "/Users/nicholsr"}
    ```

    ```text
    PathToAtomicsFolder = /Users/nicholsr/AtomicRedTeam/atomics
    
    Executing test: T1552.001-17 Find OCI credentials                               
    /Users/nicholsr/.oci/sessions/DEFAULT/token                                     
    Exit code: 0
    ```

**Associated Issues:**
Previous version of T1552.001-1 exits with code `1` even if credentials are present. This PR fixes the `find` command to return `0`.