### PR TITLE
T1046 - added csv option to ip_address parameter to test number 10

### DIFF
--- a/atomics/T1046/T1046.yaml
+++ b/atomics/T1046/T1046.yaml
@@ -200,7 +200,7 @@ atomic_tests:
   - windows
   input_arguments:
     ip_address:
-      description: IP-Address within the target subnet. Default is empty and script tries to determine local IP address of attacking machine.
+      description: IP-Address within the target subnet. Default is empty and script tries to determine local IP address of attacking machine. A comma separated list of targe IPs is also accepted (useful to simulate a wider scan while only scanning key host e.g., honeypots)
       type: string
       default: ""
     port_list:
@@ -212,57 +212,59 @@ atomic_tests:
       type: string
       default: "200"
   executor:
-    command: |
+    command: |-
       $ipAddr = "#{ip_address}"
-	  if(ipAddr -eq "" -or ipAddr -Match ","){
-		  if ($ipAddr -eq "") {
-			  # Assumes the "primary" interface is shown at the top
-			  $interface = Get-NetIPInterface -AddressFamily IPv4 -ConnectionState Connected | Select-Object -ExpandProperty InterfaceAlias -First 1
-			  Write-Host "[i] Using Interface $interface"
-			  $ipAddr = Get-NetIPAddress -AddressFamily IPv4 -InterfaceAlias $interface | Select-Object -ExpandProperty IPAddress
-		  }
-		  Write-Host "[i] Base IP-Address for Subnet: $ipAddr"
-		  $subnetSubstring = $ipAddr.Substring(0, $ipAddr.LastIndexOf('.') + 1)
-		  # Always assumes /24 subnet
-		  Write-Host "[i] Assuming /24 subnet. scanning $subnetSubstring'1' to $subnetSubstring'254'"
-
-		  $ports = #{port_list}
-		  $subnetIPs = 1..254 | ForEach-Object { "$subnetSubstring$_" }
-
-		  foreach ($ip in $subnetIPs) {
-			  foreach ($port in $ports) {
-				try {
-					$tcp = New-Object Net.Sockets.TcpClient
-					$tcp.ConnectAsync($ip, $port).Wait(#{timeout_ms}) | Out-Null
-				} catch {}
-				if ($tcp.Connected) {
-					$tcp.Close()
-					Write-Host "Port $port is open on $ip"
-				}
-			  }
-		  }
-	}elseif(ipAddr -Match ","){
-		Write-Host "[i] IP Address List: $ipAddr"
-
-		$ports = #{port_list}
-		$targetList = 1..254 | ForEach-Object { "$ipAddr$_" }
-
-		foreach ($ip in $targetList) {
-			foreach ($port in $ports) {
-			try {
-				$tcp = New-Object Net.Sockets.TcpClient
-				$tcp.ConnectAsync($ip, $port).Wait(#{timeout_ms}) | Out-Null
-			} catch {}
-			if ($tcp.Connected) {
-				$tcp.Close()
-				Write-Host "Port $port is open on $ip"
-			}
-			}
-		  }
-	}else{
-		Write-Host "[Error] Invalid Inputs"
-		exit 1
-		}
+      if ($ipAddr -like "*,*") {
+          $ip_list = $ipAddr -split ","
+          $ip_list = $ip_list.ForEach({ $_.Trim() })
+          Write-Host "[i] IP Address List: $ip_list"
+  
+          $ports = #{port_list}
+  
+          foreach ($ip in $ip_list) {
+              foreach ($port in $ports) {
+                  Write-Host "[i] Establishing connection to: $ip : $port"
+                  try {
+                      $tcp = New-Object Net.Sockets.TcpClient
+                      $tcp.ConnectAsync($ip, $port).Wait(#{timeout_ms}) | Out-Null
+                  } catch {}
+                  if ($tcp.Connected) {
+                      $tcp.Close()
+                      Write-Host "Port $port is open on $ip"
+                  }
+              }
+          }
+      } elseif ($ipAddr -notlike "*,*") {
+          if ($ipAddr -eq "") {
+              # Assumes the "primary" interface is shown at the top
+              $interface = Get-NetIPInterface -AddressFamily IPv4 -ConnectionState Connected | Select-Object -ExpandProperty InterfaceAlias -First 1
+              Write-Host "[i] Using Interface $interface"
+              $ipAddr = Get-NetIPAddress -AddressFamily IPv4 -InterfaceAlias $interface | Select-Object -ExpandProperty IPAddress
+          }
+          Write-Host "[i] Base IP-Address for Subnet: $ipAddr"
+          $subnetSubstring = $ipAddr.Substring(0, $ipAddr.LastIndexOf('.') + 1)
+          # Always assumes /24 subnet
+          Write-Host "[i] Assuming /24 subnet. scanning $subnetSubstring'1' to $subnetSubstring'254'"
+  
+          $ports = #{port_list}
+          $subnetIPs = 1..254 | ForEach-Object { "$subnetSubstring$_" }
+  
+          foreach ($ip in $subnetIPs) {
+              foreach ($port in $ports) {
+                  try {
+                      $tcp = New-Object Net.Sockets.TcpClient
+                      $tcp.ConnectAsync($ip, $port).Wait(#{timeout_ms}) | Out-Null
+                  } catch {}
+                  if ($tcp.Connected) {
+                      $tcp.Close()
+                      Write-Host "Port $port is open on $ip"
+                  }
+              }
+          }
+      } else {
+          Write-Host "[Error] Invalid Inputs"
+          exit 1
+      }
     name: powershell
 - name: Remote Desktop Services Discovery via PowerShell 
   auto_generated_guid: 9e55750e-4cbf-4013-9627-e9a045b541bf

--- a/atomics/T1046/T1046.yaml
+++ b/atomics/T1046/T1046.yaml
@@ -214,32 +214,55 @@ atomic_tests:
   executor:
     command: |
       $ipAddr = "#{ip_address}"
-      if ($ipAddr -eq "") {
-          # Assumes the "primary" interface is shown at the top
-          $interface = Get-NetIPInterface -AddressFamily IPv4 -ConnectionState Connected | Select-Object -ExpandProperty InterfaceAlias -First 1
-          Write-Host "[i] Using Interface $interface"
-          $ipAddr = Get-NetIPAddress -AddressFamily IPv4 -InterfaceAlias $interface | Select-Object -ExpandProperty IPAddress
-      }
-      Write-Host "[i] Base IP-Address for Subnet: $ipAddr"
-      $subnetSubstring = $ipAddr.Substring(0, $ipAddr.LastIndexOf('.') + 1)
-      # Always assumes /24 subnet
-      Write-Host "[i] Assuming /24 subnet. scanning $subnetSubstring'1' to $subnetSubstring'254'"
+	  if(ipAddr -eq "" -or ipAddr -Match ","){
+		  if ($ipAddr -eq "") {
+			  # Assumes the "primary" interface is shown at the top
+			  $interface = Get-NetIPInterface -AddressFamily IPv4 -ConnectionState Connected | Select-Object -ExpandProperty InterfaceAlias -First 1
+			  Write-Host "[i] Using Interface $interface"
+			  $ipAddr = Get-NetIPAddress -AddressFamily IPv4 -InterfaceAlias $interface | Select-Object -ExpandProperty IPAddress
+		  }
+		  Write-Host "[i] Base IP-Address for Subnet: $ipAddr"
+		  $subnetSubstring = $ipAddr.Substring(0, $ipAddr.LastIndexOf('.') + 1)
+		  # Always assumes /24 subnet
+		  Write-Host "[i] Assuming /24 subnet. scanning $subnetSubstring'1' to $subnetSubstring'254'"
 
-      $ports = #{port_list}
-      $subnetIPs = 1..254 | ForEach-Object { "$subnetSubstring$_" }
+		  $ports = #{port_list}
+		  $subnetIPs = 1..254 | ForEach-Object { "$subnetSubstring$_" }
 
-      foreach ($ip in $subnetIPs) {
-          foreach ($port in $ports) {
-            try {
-                $tcp = New-Object Net.Sockets.TcpClient
-                $tcp.ConnectAsync($ip, $port).Wait(#{timeout_ms}) | Out-Null
-            } catch {}
-            if ($tcp.Connected) {
-                $tcp.Close()
-                Write-Host "Port $port is open on $ip"
-            }
-          }
-      }
+		  foreach ($ip in $subnetIPs) {
+			  foreach ($port in $ports) {
+				try {
+					$tcp = New-Object Net.Sockets.TcpClient
+					$tcp.ConnectAsync($ip, $port).Wait(#{timeout_ms}) | Out-Null
+				} catch {}
+				if ($tcp.Connected) {
+					$tcp.Close()
+					Write-Host "Port $port is open on $ip"
+				}
+			  }
+		  }
+	}elseif(ipAddr -Match ","){
+		Write-Host "[i] IP Address List: $ipAddr"
+
+		$ports = #{port_list}
+		$targetList = 1..254 | ForEach-Object { "$ipAddr$_" }
+
+		foreach ($ip in $targetList) {
+			foreach ($port in $ports) {
+			try {
+				$tcp = New-Object Net.Sockets.TcpClient
+				$tcp.ConnectAsync($ip, $port).Wait(#{timeout_ms}) | Out-Null
+			} catch {}
+			if ($tcp.Connected) {
+				$tcp.Close()
+				Write-Host "Port $port is open on $ip"
+			}
+			}
+		  }
+	}else{
+		Write-Host "[Error] Invalid Inputs"
+		exit 1
+		}
     name: powershell
 - name: Remote Desktop Services Discovery via PowerShell 
   auto_generated_guid: 9e55750e-4cbf-4013-9627-e9a045b541bf


### PR DESCRIPTION
**Details:**
Modified test GUID 05df2a79-dba6-4088-a804-9ca0802ca8e4 - name: "Port-Scanning /24 Subnet with PowerShell"
to add an option to pass a CSV list of IP addresses to the ip_address parameter in order to support simulating a wider scan, by scanning specific hosts e.g., honeypots, and avoid a noisier scan to the full subnet. 

**Testing:**
Tested with a IP list, port list, and without any parameters. all tests completed successfully 

**Associated Issues:**
n/a