### PR TITLE
T1555.001 Copy Keychain via cat

### DIFF
--- a/atomics/T1555.001/T1555.001.yaml
+++ b/atomics/T1555.001/T1555.001.yaml
@@ -56,23 +56,6 @@ atomic_tests:
     name: sh
     elevation_required: false
 
-- name: Import Certificate Item(s) into Keychain
-  auto_generated_guid: e544bbcb-c4e0-4bd0-b614-b92131635f59
-  description: |
-    This command will import a certificate pem file into a keychain.
-  supported_platforms:
-  - macos
-  input_arguments:
-    cert_export:
-      description: Specify the path of the pem certificate file to import.
-      type: path
-      default: /tmp/certs.pem
-  executor:
-    command: |
-      security import #{cert_export} -k
-    name: sh
-    elevation_required: false
-
 - name: Copy Keychain using cat utility
   description: |
     This command will copy the keychain using the cat utility in a manner similar to Atomic Stealer.

--- a/atomics/T1555.001/T1555.001.yaml
+++ b/atomics/T1555.001/T1555.001.yaml
@@ -55,3 +55,37 @@ atomic_tests:
       security import #{cert_export} -k
     name: sh
     elevation_required: false
+
+- name: Import Certificate Item(s) into Keychain
+  auto_generated_guid: e544bbcb-c4e0-4bd0-b614-b92131635f59
+  description: |
+    This command will import a certificate pem file into a keychain.
+  supported_platforms:
+  - macos
+  input_arguments:
+    cert_export:
+      description: Specify the path of the pem certificate file to import.
+      type: path
+      default: /tmp/certs.pem
+  executor:
+    command: |
+      security import #{cert_export} -k
+    name: sh
+    elevation_required: false
+
+- name: Copy Keychain using cat utility
+  description: |
+    This command will copy the keychain using the cat utility in a manner similar to Atomic Stealer.
+  supported_platforms:
+  - macos
+  input_arguments:
+    keychain_export:
+      description: Specify the path to copy they keychain into.
+      type: path
+      default: /tmp/keychain
+  executor:
+    command: |
+      cat ~/Library/Keychains/login.keychain-db > #{keychain_export}
+    cleanup_command: 'rm #{keychain_export}'
+    name: sh
+    elevation_required: false


### PR DESCRIPTION
**Details:**
Adding test for T1555.001 keychain copying that has been seen with Atomic Stealer

**Testing:**
Tested on macOS 14.6.1

**Associated Issues:**
No associated issues