### PR TITLE
fix MD->HTML render for .io site

### DIFF
--- a/atomic_red_team/atomic_doc_template.md.erb
+++ b/atomic_red_team/atomic_doc_template.md.erb
@@ -1,7 +1,11 @@
 # <%= technique['identifier'] %> - <%= technique['name'] -%>
 
 ## [Description from ATT&CK](https://attack.mitre.org/techniques/<%= technique['identifier'].gsub(/\./, '/') %>)
-<blockquote><%= technique['description'].gsub("%\\<", "%<") %></blockquote>
+<blockquote>
+
+<%= technique['description'].gsub("%\\<", "%<") %>
+
+</blockquote>
 
 ## Atomic Tests
 <% atomic_yaml['atomic_tests'].each_with_index do |test, test_number| -%>


### PR DESCRIPTION
Simple fix to correct html rendering of markdown content such as links. See description paragraph here: <img width="1512" alt="396270449-22374f00-48d3-4d50-bdf6-7f9fee5832e4" src="https://github.com/user-attachments/assets/f0e95b6f-65ad-4fe3-a01d-c465fd374d38" />

Thanks to @cyberbuff for the confirmation of a viable fix!!

**Details:**
Whitespace around the `<blockquote>` and `</blockquote>` tags seems to cause unpredictable behavior when converting a test's markdown file to html.  This should address that error.

**Testing:**
Tested with manually-edited html in a sandbox.

**Associated Issues:**
Should fix this: https://github.com/redcanaryco/atomicredteam.io/issues/230 (only visible to .io site folks)