### PR TITLE
Update T1070.002.md

### DIFF
--- a/atomics/T1070.002/T1070.002.md
+++ b/atomics/T1070.002/T1070.002.md
@@ -4,7 +4,7 @@
 
 Adversaries may clear system logs to hide evidence of an intrusion. macOS and Linux both keep track of system or user-initiated actions via system logs. The majority of native system logging is stored under the <code>/var/log/</code> directory. Subfolders in this directory categorize logs by their related functions, such as:(Citation: Linux Logs)
 
-* <code>/var/log/messages:</code>: General and system-related messages
+* <code>/var/log/messages</code>: General and system-related messages
 * <code>/var/log/secure</code> or <code>/var/log/auth.log</code>: Authentication logs
 * <code>/var/log/utmp</code> or <code>/var/log/wtmp</code>: Login records
 * <code>/var/log/kern.log</code>: Kernel logs
@@ -782,8 +782,13 @@ This test overwrites the Linux mail spool of a specified user. This technique wa
 ```bash
 echo 0> /var/spool/mail/#{username}
 ```
+or
 
+```
+: > /var/spool/mail/#{username}
+```
 
+(Using : as a no-op to truncate the file)
 
 
 #### Dependencies:  Run with `sh`!

--- a/atomics/T1070.002/T1070.002.md
+++ b/atomics/T1070.002/T1070.002.md
@@ -304,7 +304,7 @@ The first sub-test truncates the log file to zero bytes via /dev/null and the se
 
 ```sh
 cat /dev/null > /var/log/messages #truncating the file to zero bytes
-cat /dev/zero > /var/lol/messages #log file filled with null bytes(zeros)
+cat /dev/zero > /var/log/messages #log file filled with null bytes(zeros)
 ```
 
 

--- a/atomics/T1070.002/T1070.002.yaml
+++ b/atomics/T1070.002/T1070.002.yaml
@@ -127,7 +127,7 @@ atomic_tests:
   executor:
     command: |
       cat /dev/null > /var/log/messages #truncating the file to zero bytes
-      cat /dev/zero > /var/lol/messages #log file filled with null bytes(zeros)
+      cat /dev/zero > /var/log/messages #log file filled with null bytes(zeros)
     name: sh
     elevation_required: true
 


### PR DESCRIPTION
**Details:**
- removed a typo 'lol' > 'log'
- removed extra colon in `/var/log/messages:`
- additional example usage (no-op to truncate a file)
 
**Testing:**
<!-- Note any testing done, local or automated here. -->

**Associated Issues:**
<!-- Please link any issues that this pull request impacts or fixes. -->