### PR TITLE
feat: Add T1046-12

### DIFF
--- a/atomics/T1046/T1046.yaml
+++ b/atomics/T1046/T1046.yaml
@@ -277,3 +277,31 @@ atomic_tests:
        Get-Service -Name "Remote Desktop Services", "Remote Desktop Configuration"
     name: powershell
     elevation_required: true
+- name: Port Scan using nmap (Port range)
+  description: |
+    Scan multiple ports to check for listening ports with nmap
+  supported_platforms:
+  - linux
+  - macos
+  input_arguments:
+    host:
+      description: Host(s) to scan.
+      type: string
+      default: "127.0.0.1"
+    port_range:
+      description: Port range(s) to scan.
+      type: string
+      default: "0-65535"
+  dependency_executor_name: sh
+  dependencies:
+  - description: |
+      Check if nmap command exists on the machine
+    prereq_command: |
+      if [ -x "$(command -v nmap)" ]; then exit 0; else exit 1; fi;
+    get_prereq_command: |
+      (which yum && yum -y install epel-release nmap)||(which apt-get && DEBIAN_FRONTEND=noninteractive apt-get install -y nmap)||(which pkg && pkg install -y nmap)||(which brew && brew install nmap)
+  executor:
+    command: |
+      nmap -Pn -sV -p #{port_range} #{host}
+    elevation_required: true
+    name: powershell

--- a/atomics/T1046/T1046.yaml
+++ b/atomics/T1046/T1046.yaml
@@ -304,4 +304,4 @@ atomic_tests:
     command: |
       nmap -Pn -sV -p #{port_range} #{host}
     elevation_required: true
-    name: powershell
+    name: sh


### PR DESCRIPTION
**Details:**
Added one more atomic test similar to test number 2, but scans a range of ports on a remote host.

**Testing:**
Executed with the command `Invoke-AtomicTest T1046-12 -PathToAtomicsFolder ./atomics -InputArgs @{"host" = "IP_REDACTED"; "port_range" = "0-1024,54122"}` from a macOS system. Results shown below.

<img width="1141" alt="image" src="https://github.com/user-attachments/assets/8dfa2a79-f96c-4b4f-a9ca-8b7923017bd7" />


**Associated Issues:**
No issues corrected with this PR.