### PR TITLE
Fix: Get prereq T1562.004

### DIFF
--- a/atomics/T1562.004/T1562.004.yaml
+++ b/atomics/T1562.004/T1562.004.yaml
@@ -363,7 +363,7 @@ atomic_tests:
     prereq_command: |
       if [ ! -x "$(command -v iptables)" ]; then echo -e "\n***** iptables NOT installed *****\n"; exit 1; fi
     get_prereq_command: |
-      echo ""
+      sudo apt-get install iptables
   executor:
     name: sh
     elevation_required: true


### PR DESCRIPTION
**Details:**
Added get prereq command to install iptables for T1562.004
**Testing:**
Tested on Ubuntu machine