### PR TITLE
Added new Atomic: T1027 Obfuscated Command in Windows Command Prompt

### DIFF
--- a/atomics/T1027/T1027.yaml
+++ b/atomics/T1027/T1027.yaml
@@ -249,7 +249,7 @@ atomic_tests:
 - name: Obfuscated Command in Windows Command Prompt
   auto_generated_guid: 
   description: |
-    This is an obfuscated Windows Command Prompt command which when executed prints "Hello, from the Windows Command Prompt!". Example is generated using the Invoke-DOSfuscation framework by Daniel Bohannon. More info: https://github.com/danielbohannon/Invoke-DOSfuscation.
+    This is an obfuscated Windows Command Prompt command which when executed prints "Hello from the Windows Command Prompt!". Example is generated using the Invoke-DOSfuscation framework by Daniel Bohannon. More info: https://github.com/danielbohannon/Invoke-DOSfuscation.
   supported_platforms:
   - windows
   executor:

--- a/atomics/T1027/T1027.yaml
+++ b/atomics/T1027/T1027.yaml
@@ -246,3 +246,13 @@ atomic_tests:
     cleanup_command: |
       taskkill /f /im calculator.exe >nul 2>nul
     name: command_prompt
+- name: Obfuscated Command in Windows Command Prompt
+  auto_generated_guid: 
+  description: |
+    This is an obfuscated Windows Command Prompt command which when executed prints "Hello, from the Windows Command Prompt!". Example is generated using the Invoke-DOSfuscation framework by Daniel Bohannon. More info: https://github.com/danielbohannon/Invoke-DOSfuscation.
+  supported_platforms:
+  - windows
+  executor:
+    command: |
+      cmd.exe /V:ON/C"set W9m=llo&&set Sje0=e Windows Comm&&set Fq9=echo ""He&&set Gg=""&&set BonT=and Prompt!""&&set 6dQ= f&&set pHW=rom&&set cP= th&&call set dM=%Fq9%%W9m%%6dQ%%pHW%%cP%%Sje0%%BonT%&&call %dM:""=!Gg:~-1,52!%"
+    name: command_prompt


### PR DESCRIPTION
**Details:**
Added a new atomic which executes a lightly obfuscated command in Windows Command Prompt. The command was generated using the Invoke-DOSfuscation toolkit. This test is similar in functionality to Atomic `8b3f4ed6-077b-4bdd-891c-2d237f19410f` (Obfuscated Command in PowerShell), but allows for basic detection coverage checking on obfuscation in the Windows Command Prompt.

**Testing:**
```
PS C:\Users\xxx> Invoke-AtomicTest T1027 -ShowDetails
{{{SNIP}}}
[********BEGIN TEST*******]
Technique: Obfuscated Files or Information T1027
Atomic Test Name: Obfuscated Command in Windows Command Prompt                                                                                                    Atomic Test Number: 3
Description: This is an obfuscated Windows Command Prompt command which when executed prints "Hello from the Windows Command Prompt!". Example is generated using the Invoke-DOSfuscation framework by Daniel Bohannon. More info: https://github.com/danielbohannon/Invoke-DOSfuscation.

Attack Commands:
Executor: command_prompt
ElevationRequired: False
Command:
cmd.exe /V:ON/C"set W9m=llo&&set Sje0=e Windows Comm&&set Fq9=echo ""He&&set Gg=""&&set BonT=and Prompt!""&&set 6dQ= f&&set pHW=rom&&set cP= th&&call set dM=%Fq9%%W9m%%6dQ%%pHW%%cP%%Sje0%%BonT%&&call %dM:""=!Gg:~-1,52!%"
[!!!!!!!!END TEST!!!!!!!]
```
```
PS C:\Users\xxx> Invoke-AtomicTest T1027 -TestNames "Obfuscated Command in Windows Command Prompt"
PathToAtomicsFolder = C:\AtomicRedTeam\atomics

Executing test: T1027-3 Obfuscated Command in Windows Command Prompt
/c cmd.exe /V:ON/C"set W9m=llo&&set Sje0=e Windows Comm&&set Fq9=echo ""He&&set Gg=""&&set BonT=and Prompt!""&&set 6dQ= f&&set pHW=rom&&set cP= th&&call set dM=%Fq9%%W9m%%6dQ%%pHW%%cP%%Sje0%%BonT%&&call %dM:""=!Gg:~-1,52!%"
"Hello from the Windows Command Prompt!"
Exit code: 0
Done executing test: T1027-3 Obfuscated Command in Windows Command Prompt
```