### PR TITLE
Update T1547.001.yaml

### DIFF
--- a/atomics/T1547.001/T1547.001.yaml
+++ b/atomics/T1547.001/T1547.001.yaml
@@ -248,6 +248,9 @@ atomic_tests:
       default: C:\Windows\System32\calc.exe
   executor:
     command: |
+      if (!(Test-Path -Path "HKCU:\Software\Microsoft\Windows\CurrentVersion\Policies\Explorer")){
+        New-Item -ItemType Key -Path  "HKCU:\Software\Microsoft\Windows\CurrentVersion\Policies\Explorer"
+      }
       if (!(Test-Path -Path "HKCU:\Software\Microsoft\Windows\CurrentVersion\Policies\Explorer\Run")){
         New-Item -ItemType Key -Path  "HKCU:\Software\Microsoft\Windows\CurrentVersion\Policies\Explorer\Run"
       }


### PR DESCRIPTION
**Details:**
Adding an existence check and key creation for 1 level higher. The "explorer" key doesn't exist on my fresh Win11 install, so this patch is required

**Testing:**
Tested locally

**Associated Issues:**
N/A