### PR TITLE
Add atomic test "Decrypt to file" to T1027.013.yaml

### DIFF
--- a/atomics/T1027.013/T1027.013.yaml
+++ b/atomics/T1027.013/T1027.013.yaml
@@ -1,7 +1,7 @@
 attack_technique: T1027.013
 display_name: 'Obfuscated Files or Information: Encrypted/Encoded File'
 atomic_tests:
-- name: T1027.013 Encrypted/Encoded File
+- name: T1027.013 Encoded File
   auto_generated_guid: 7693ccaa-8d64-4043-92a5-a2eb70359535
   description: Decode the eicar value, and write it to file, for AV/EDR to try to catch.
   supported_platforms:
@@ -17,5 +17,24 @@ atomic_tests:
       #write the decoded eicar string to file
       $decodedString | Out-File T1027.013_decodedEicar.txt
     cleanup_command: Just delete the resulting T1027.013_decodedEicar.txt file.
+    name: powershell
+    elevation_required: false
+- name: T1027.013 Encrypted File
+  description: Decrypt the eicar value, and write it to file, for AV/EDR to try to catch.
+  supported_platforms:
+    - windows
+    - macos
+    - linux
+  executor:
+    command: |-
+      $encryptedString = "76492d1116743f0423413b16050a5345MgB8AGkASwA0AHMAbwBXAFoAagBkAFoATABXAGIAdAA5AFcAWAB1AFMANABVAEEAPQA9AHwAZQBjAGMANgAwADQAZAA0AGQAMQAwADUAYgA4ADAAMgBmADkAZgBjADEANQBjAGMANQBiAGMANwA2AGYANQBmADUANABhAGIAYgAyAGMANQA1AGQAMgA5ADEANABkADUAMgBiAGMANgA2AGMAMAAxADUAZABjADAAOABjAGIANAA1ADUANwBjADcAZQBlAGQAYgAxADEAOQA4AGIAMwAwADMANwAwADAANQA2ADQAOAA4ADkAZgA4ADMAZQA4ADgAOQBiAGEAMAA2ADMAMQAyADYAMwBiAGUAMAAxADgANAA0ADYAOAAxADQANQAwAGUANwBkADkANABjADcANQAxADgAYQA2ADMANQA4AGIAYgA1ADkANQAzAGIAMwAxADYAOAAwADQAMgBmADcAZQBjADYANQA5AGIANwBkADUAOAAyAGEAMgBiADEAMQAzAGQANABkADkAZgA3ADMAMABiADgAOQAxADAANAA4ADcAOQA5ADEAYQA1ADYAZAAzADQANwA3AGYANgAyADcAMAAwADEAMQA4ADEAZgA5ADUAYgBmAGYANQA3ADQAZQA4AGUAMAAxADUANwAwAGQANABiADMAMwA2ADgANwA0AGIANwAyADMAMQBhADkAZABhADEANQAzADQAMgAzADEANwAxADAAZgAxADkAYQA1ADEAMQA="
+      $key = [byte]1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32
+
+      $decrypt = ConvertTo-SecureString -String $encryptedString -Key $key
+      $decryptedString = [Runtime.InteropServices.Marshal]::PtrToStringBSTR([Runtime.InteropServices.Marshal]::SecureStringToBSTR($decrypt))
+
+      #Write the decrypted eicar string to a file
+      $decryptedString | out-file T1027.013_decryptedEicar.txt
+    cleanup_command: Just delete the resulting T1027.013_decryptedEicar.txt file.
     name: powershell
     elevation_required: false

--- a/atomics/T1027.013/T1027.013.yaml
+++ b/atomics/T1027.013/T1027.013.yaml
@@ -1,7 +1,7 @@
 attack_technique: T1027.013
 display_name: 'Obfuscated Files or Information: Encrypted/Encoded File'
 atomic_tests:
-- name: T1027.013 Encoded File
+- name: Decode Eicar File and Write to File
   auto_generated_guid: 7693ccaa-8d64-4043-92a5-a2eb70359535
   description: Decode the eicar value, and write it to file, for AV/EDR to try to catch.
   supported_platforms:
@@ -19,7 +19,7 @@ atomic_tests:
     cleanup_command: Just delete the resulting T1027.013_decodedEicar.txt file.
     name: powershell
     elevation_required: false
-- name: T1027.013 Encrypted File
+- name: Decrypt Eicar File and Write to File
   description: Decrypt the eicar value, and write it to file, for AV/EDR to try to catch.
   supported_platforms:
     - windows


### PR DESCRIPTION
Added an atomic to decrypt an encrypted eicar value to file.

**Details:**
<!-- Previously, I had accidentally submitted 2 yaml files for T1027.013 - one for the decoding atomic, and one for the decryption atomic. I now added the decryption atomic to the existing yaml file that was created when I submitted the decoding atomic. -->

**Testing:**
<!-- Tested on Windows 11, and Mac Sonoma. -->

**Associated Issues:**
<!-- No known issues. -->