### PR TITLE
abuse of Linux Magic System Request Key for shutdown

### DIFF
--- a/atomics/T1529/T1529.md
+++ b/atomics/T1529/T1529.md
@@ -42,7 +42,7 @@ Adversaries may attempt to shutdown/reboot a system after impacting it in other 
 
 - [Atomic Test #15 - ESXi - vim-cmd Used to Power Off VMs](#atomic-test-15---esxi---vim-cmd-used-to-power-off-vms)
 
-- [Atomic Test #16 - abuse of linux magic system request key for shutdown](#atomic-test-18---abuse-of-linux-magic-system-request-key-for-shutdown)
+- [Atomic Test #16 - abuse of linux magic system request key for reboot](#atomic-test-18---abuse-of-linux-magic-system-request-key-for-reboot)
 
 
 <br/>
@@ -537,8 +537,8 @@ echo "" | "#{plink_file}" -batch "#{vm_host}" -ssh -l #{vm_user} -pw "#{vm_pass}
 <br/>
 <br/>
 
-## Atomic Test #16 - abuse of linux magic system request key for shutdown
-adversaries with root or sufficient privileges to silently manipulate or destabilize a system. By writing to /proc/sysrq-trigger, they can shutdown.
+## Atomic Test #16 - abuse of linux magic system request key for reboot
+adversaries with root or sufficient privileges to silently manipulate or destabilize a system. By writing to /proc/sysrq-trigger, they can forced systemo to reboot.
 [Reference](https://www.kernel.org/doc/html/v4.10/_sources/admin-guide/sysrq.txt)
 
 **Supported Platforms:** Linux

--- a/atomics/T1529/T1529.md
+++ b/atomics/T1529/T1529.md
@@ -42,6 +42,8 @@ Adversaries may attempt to shutdown/reboot a system after impacting it in other 
 
 - [Atomic Test #15 - ESXi - vim-cmd Used to Power Off VMs](#atomic-test-15---esxi---vim-cmd-used-to-power-off-vms)
 
+- [Atomic Test #16 - abuse of linux magic system request key for shutdown](#atomic-test-18---abuse-of-linux-magic-system-request-key-for-shutdown)
+
 
 <br/>
 
@@ -532,8 +534,26 @@ Adversaries may power off VMs to facilitate the deployment of ransomware payload
 echo "" | "#{plink_file}" -batch "#{vm_host}" -ssh -l #{vm_user} -pw "#{vm_pass}" "for i in `vim-cmd vmsvc/getallvms | awk 'NR>1 {print $1}'`; do vim-cmd vmsvc/power.off $i & done"
 ```
 
+<br/>
+<br/>
+
+## Atomic Test #16 - abuse of linux magic system request key for shutdown
+adversaries with root or sufficient privileges to silently manipulate or destabilize a system. By writing to /proc/sysrq-trigger, they can shutdown.
+[Reference](https://www.kernel.org/doc/html/v4.10/_sources/admin-guide/sysrq.txt)
+
+**Supported Platforms:** Linux
 
 
+
+#### Attack Commands: Run with `sh`!  Elevation Required (e.g. root or admin) 
+
+
+```sh
+echo "b" > /proc/sys/kernel/sysrq
+```
+
+<br/>
+<br/>
 
 #### Dependencies:  Run with `powershell`!
 ##### Description: Check if we have plink

--- a/atomics/T1529/T1529.yaml
+++ b/atomics/T1529/T1529.yaml
@@ -278,3 +278,14 @@ atomic_tests:
       echo "" | "#{plink_file}" -batch "#{vm_host}" -ssh -l #{vm_user} -pw "#{vm_pass}" "for i in `vim-cmd vmsvc/getallvms | awk 'NR>1 {print $1}'`; do vim-cmd vmsvc/power.off $i & done"
     name: command_prompt
     elevation_required: false
+- name: abuse of linux magic system request key for shutdown
+  description: |
+    adversaries with root or sufficient privileges to silently manipulate or destabilize a system. By writing to /proc/sysrq-trigger, they can shutdown.
+  supported_platforms:
+  - linux
+  dependency_executor_name: bash
+  executor:
+    command: |
+      echo "b" > /proc/sys/kernel/sysrq
+    name: bash
+    elevation_required: true

--- a/atomics/T1529/T1529.yaml
+++ b/atomics/T1529/T1529.yaml
@@ -278,9 +278,9 @@ atomic_tests:
       echo "" | "#{plink_file}" -batch "#{vm_host}" -ssh -l #{vm_user} -pw "#{vm_pass}" "for i in `vim-cmd vmsvc/getallvms | awk 'NR>1 {print $1}'`; do vim-cmd vmsvc/power.off $i & done"
     name: command_prompt
     elevation_required: false
-- name: abuse of linux magic system request key for shutdown
+- name: abuse of linux magic system request key for reboot
   description: |
-    adversaries with root or sufficient privileges to silently manipulate or destabilize a system. By writing to /proc/sysrq-trigger, they can shutdown.
+    adversaries with root or sufficient privileges to silently manipulate or destabilize a system. By writing to /proc/sysrq-trigger, they can forced to reboot.
   supported_platforms:
   - linux
   dependency_executor_name: bash


### PR DESCRIPTION
**Details:**
<!-- Insert details about this change here. Please include as much detail as possible -->
Summary

This PR adds a new atomic test simulating a forced system reboot on Linux by writing "b" to /proc/sys/kernel/sysrq, corresponding to the MITRE ATT&CK technique T1529 – System Shutdown/Reboot.

The test mimics a kernel-level forced reboot triggered via the SysRq interface, causing immediate system restart without a clean shutdown. This technique reflects attacker behavior to disrupt system availability or evade detection.

Atomic Test Details

    Technique ID: T1529

    Technique Name: System Shutdown/Reboot

    Platforms: Linux

    Author: Milad Cheraghi

    Status: ⚠️ Dangerous – will immediately reboot the system, use with caution

    Cleanup: N/A (System reboot clears transient state)

Use Case

This atomic test can be used for:

    Validating detection of kernel-level disruptive commands

    Testing blue team monitoring of system availability attacks

    Training analysts on shutdown and reboot persistence and disruption techniques
**Testing:**
<!-- Note any testing done, local or automated here. -->
Sample Test:

echo "b" > /proc/sys/kernel/sysrq

Atomic Test Details

Technique ID: T1529
Technique Name: System Shutdown/Reboot
Platforms: Linux
Author: Milad Cheraghi
Status: ⚠️ Dangerous – will immediately reboot the system, use with caution
Cleanup: N/A (System reboot clears transient state)
Use Case

This atomic test can be used for:

    Validating detection of kernel-level disruptive commands

    Testing blue team monitoring of system availability attacks

    Training analysts on shutdown and reboot persistence and disruption techniques
**Associated Issues:**
<!-- Please link any issues that this pull request impacts or fixes. -->