### PR TITLE
Update T1491.001.yaml

### DIFF
--- a/atomics/T1491.001/T1491.001.yaml
+++ b/atomics/T1491.001/T1491.001.yaml
@@ -153,3 +153,67 @@ atomic_tests:
     name: command_prompt
     elevation_required: false
 
+- name: Windows - Display a simulated ransom note via Notepad (non-destructive)
+  authors: bak3n3k0
+  description: |
+    Creates a temporary ransom-note text file and opens it in Notepad to simulate
+    ransomware "note display" behavior without making destructive changes.
+    SAFE and non-destructive. Uses only %TEMP% paths (no user-specific paths).
+  supported_platforms:
+    - windows
+  input_arguments:
+    note_path:
+      description: Full path for the simulated ransom note
+      type: path
+      default: '%TEMP%\ART-T1491-ransom-note.txt'
+    note_title:
+      description: Title at the top of the ransom note
+      type: string
+      default: '!!! READ_ME_NOW !!!'
+    note_body:
+      description: The body of the ransom note (plain text)
+      type: string
+      default: |
+        Your files are SAFE. This is a TEST note for detection validation by bak3n3k0.
+        No data has been encrypted. This simulation exercises detections for:
+          - notepad.exe launched with a ransom-themed text file
+          - creation of a ransom-themed text file in %TEMP%
+        If seen in production, investigate process lineage and recent file writes.
+        NON-DESTRUCTIVE Atomic Red Team test.
+    note_pid_path:
+      description: Path to store Notepad PID for cleanup
+      type: path
+      default: '%TEMP%\ART-T1491-notepad.pid'
+  dependencies:
+    - description: Notepad must be present on the system
+      prereq_command: 'where notepad'
+      get_prereq_command: ''
+  executor:
+    name: powershell
+    elevation_required: false
+    command: |
+      $Path  = "#{note_path}"
+      $Title = "#{note_title}"
+      $Body  = @"
+#{note_body}
+"@
+
+      $header  = $Title + "`r`n" + ('=' * $Title.Length) + "`r`n`r`n"
+      $content = $header + $Body
+
+      $dir = Split-Path $Path
+      if ($dir -and -not (Test-Path $dir)) { New-Item -ItemType Directory -Path $dir -Force | Out-Null }
+
+      [System.IO.File]::WriteAllText($Path, $content, [System.Text.Encoding]::ASCII)
+      $proc = Start-Process notepad.exe -ArgumentList "`"$Path`"" -PassThru
+      $proc.Id | Out-File -FilePath "#{note_pid_path}" -Encoding ascii -Force
+    cleanup_command: |
+      if (Test-Path "#{note_pid_path}") {
+        try {
+          $pid = Get-Content "#{note_pid_path}" | Select-Object -First 1
+          if ($pid) { Stop-Process -Id $pid -ErrorAction SilentlyContinue }
+        } catch {}
+        Remove-Item "#{note_pid_path}" -Force -ErrorAction SilentlyContinue
+      }
+      Remove-Item -Path "#{note_path}" -Force -ErrorAction SilentlyContinue
+

--- a/atomics/T1491.001/T1491.001.yaml
+++ b/atomics/T1491.001/T1491.001.yaml
@@ -154,66 +154,82 @@ atomic_tests:
     elevation_required: false
 
 - name: Windows - Display a simulated ransom note via Notepad (non-destructive)
-  authors: bak3n3k0
+  authors:
+    - bak3n3k0
   description: |
-    Creates a temporary ransom-note text file and opens it in Notepad to simulate
-    ransomware "note display" behavior without making destructive changes.
-    SAFE and non-destructive. Uses only %TEMP% paths (no user-specific paths).
+    Creates a temporary ransom-note text file and opens it in Notepad to
+    simulate ransomware "note display" behavior without making destructive
+    changes. SAFE and non-destructive.
   supported_platforms:
     - windows
   input_arguments:
-    note_path:
-      description: Full path for the simulated ransom note
-      type: path
-      default: '%TEMP%\ART-T1491-ransom-note.txt'
+    note_filename:
+      description: File name for the simulated ransom note
+      type: string
+      default: "ART-T1491-ransom-note.txt"
+    pid_filename:
+      description: File name for storing Notepad PID
+      type: string
+      default: "ART-T1491-notepad.pid"
     note_title:
       description: Title at the top of the ransom note
       type: string
-      default: '!!! READ_ME_NOW !!!'
+      default: "!!! READ_ME_NOW !!!"
     note_body:
       description: The body of the ransom note (plain text)
       type: string
       default: |
-        Your files are SAFE. This is a TEST note for detection validation by bak3n3k0.
-        No data has been encrypted. This simulation exercises detections for:
+        Your files are SAFE. This is a TEST note for detection validation
+        by bak3n3k0. No data has been encrypted. This simulation exercises
+        detections for:
           - notepad.exe launched with a ransom-themed text file
           - creation of a ransom-themed text file in %TEMP%
-        If seen in production, investigate process lineage and recent file writes.
         NON-DESTRUCTIVE Atomic Red Team test.
-    note_pid_path:
-      description: Path to store Notepad PID for cleanup
-      type: path
-      default: '%TEMP%\ART-T1491-notepad.pid'
   dependencies:
     - description: Notepad must be present on the system
-      prereq_command: 'where notepad'
-      get_prereq_command: ''
+      dependency_executor_name: command_prompt
+      prereq_command: "where notepad"
+      get_prereq_command: ""
   executor:
     name: powershell
     elevation_required: false
     command: |
-      $Path  = "#{note_path}"
+      $notePath = Join-Path $env:TEMP "#{note_filename}"
+      $pidPath  = Join-Path $env:TEMP "#{pid_filename}"
+
       $Title = "#{note_title}"
-      $Body  = @"
-#{note_body}
-"@
+      $Body  = "#{note_body}"
 
       $header  = $Title + "`r`n" + ('=' * $Title.Length) + "`r`n`r`n"
       $content = $header + $Body
 
-      $dir = Split-Path $Path
-      if ($dir -and -not (Test-Path $dir)) { New-Item -ItemType Directory -Path $dir -Force | Out-Null }
+      [System.IO.File]::WriteAllText($notePath, $content, [System.Text.Encoding]::UTF8)
 
-      [System.IO.File]::WriteAllText($Path, $content, [System.Text.Encoding]::ASCII)
-      $proc = Start-Process notepad.exe -ArgumentList "`"$Path`"" -PassThru
-      $proc.Id | Out-File -FilePath "#{note_pid_path}" -Encoding ascii -Force
+      $p = Start-Process notepad.exe -ArgumentList "`"$notePath`"" -PassThru
+      $p.Id | Out-File -FilePath $pidPath -Encoding ascii -Force
     cleanup_command: |
-      if (Test-Path "#{note_pid_path}") {
-        try {
-          $pid = Get-Content "#{note_pid_path}" | Select-Object -First 1
-          if ($pid) { Stop-Process -Id $pid -ErrorAction SilentlyContinue }
-        } catch {}
-        Remove-Item "#{note_pid_path}" -Force -ErrorAction SilentlyContinue
+      try {
+        # 1. Kill all Notepad processes
+        Get-Process notepad -ErrorAction SilentlyContinue |
+          ForEach-Object {
+            Stop-Process -Id $_.Id -Force -ErrorAction SilentlyContinue
+          }
+
+        # 2. Wait briefly for Windows to release file handles
+        Start-Sleep -Seconds 1
+
+        # 3. Force delete ransom note + PID file
+        $notePath = Join-Path $env:TEMP "ART-T1491-ransom-note.txt"
+        $pidPath  = Join-Path $env:TEMP "ART-T1491-notepad.pid"
+
+        if (Test-Path $notePath) {
+          Remove-Item $notePath -Force -ErrorAction Stop
+        }
+        if (Test-Path $pidPath) {
+          Remove-Item $pidPath -Force -ErrorAction Stop
+        }
       }
-      Remove-Item -Path "#{note_path}" -Force -ErrorAction SilentlyContinue
+      catch {
+        Write-Warning "Cleanup failed with error: $_"
+      }
 

--- a/atomics/T1491.001/T1491.001.yaml
+++ b/atomics/T1491.001/T1491.001.yaml
@@ -154,8 +154,6 @@ atomic_tests:
     elevation_required: false
 
 - name: Windows - Display a simulated ransom note via Notepad (non-destructive)
-  authors:
-    - bak3n3k0
   description: |
     Creates a temporary ransom-note text file and opens it in Notepad to
     simulate ransomware "note display" behavior without making destructive


### PR DESCRIPTION
Added Test #3:
"Windows - Display a simulated ransom note via Notepad (non-destructive)"

**Details:**
Added new Test #3 - "Windows - Display a simulated ransom note via Notepad (non-destructive)"

**Testing:**
This is an automatic non destructive writing of ransom note, then popping it up in notepad to display the mock note.

**Associated Issues:**
<!-- Please link any issues that this pull request impacts or fixes. -->