### PR TITLE
fix(atomics): Fix T1562.008-8 - add region in aws CLI call

### DIFF
--- a/atomics/T1562.008/T1562.008.yaml
+++ b/atomics/T1562.008/T1562.008.yaml
@@ -388,9 +388,9 @@ atomic_tests:
     command: |
       aws logs create-log-group --log-group-name #{cloudwatch_log_group_name} --region #{region} --output json
       echo "*** Log Group Created ***"
-      aws logs create-log-stream --log-group-name #{cloudwatch_log_group_name} --log-stream-name #{cloudwatch_log_stream_name}
+      aws logs create-log-stream --log-group-name #{cloudwatch_log_group_name} --log-stream-name #{cloudwatch_log_stream_name} --region #{region}
       echo "*** Log Stream Created ***"
-      aws logs delete-log-stream --log-group-name #{cloudwatch_log_group_name} --log-stream-name #{cloudwatch_log_stream_name}
+      aws logs delete-log-stream --log-group-name #{cloudwatch_log_group_name} --log-stream-name #{cloudwatch_log_stream_name} --region #{region}
       echo "*** Log Stream Deleted ***"
       aws logs delete-log-group --log-group-name #{cloudwatch_log_group_name} --region #{region} --output json
       echo "*** Log Group Deleted ***"


### PR DESCRIPTION
**Details:**
<!-- Insert details about this change here. Please include as much detail as possible -->

The test T1562.008-8 "AWS CloudWatch Log Stream Deletes" fails to execute completely because the log stream is not created if the default AWS profile region is different from the region provided in the test.

| Before | After |
|--------|--------|
| <img width="917" alt="image" src="https://github.com/user-attachments/assets/fe5e1028-1d83-4335-a46b-182bac3f605e" /> | <img width="770" alt="image" src="https://github.com/user-attachments/assets/636b24fd-48a8-4c28-8fa8-4735b50c8592" /> |

**Testing:**
<!-- Note any testing done, local or automated here. -->

See screenshot above for the testing with Invoke-AtomicTest.

You can also manually test directly with the AWS CLI:
```shell
$ aws configure list
[...]
region     : us-east-1                : config-file      : ~/.aws/config

$ aws logs create-log-group --log-group-name test-logs --region us-west-2 --output json
$ aws logs create-log-stream --log-group-name test-logs --log-stream-name 20150601
An error occurred (ResourceNotFoundException) when calling the CreateLogStream operation: The specified log group does not exist.

$ aws logs create-log-stream --log-group-name test-logs --log-stream-name 20150601 --region us-west-2
$ aws logs delete-log-stream --log-group-name test-logs --log-stream-name 20150601 --region us-west-2
$ aws logs delete-log-group --log-group-name test-logs --region us-west-2 --output json
```

**Associated Issues:**
<!-- Please link any issues that this pull request impacts or fixes. -->