### PR TITLE
T1137 Office Application Startup fix

### DIFF
--- a/atomics/T1137/T1137.md
+++ b/atomics/T1137/T1137.md
@@ -19,7 +19,7 @@ A variety of features have been discovered in Outlook that can be abused to obta
 As outlined in MDSEC's Blog post https://www.mdsec.co.uk/2020/11/a-fresh-outlook-on-mail-based-persistence/ 
 it is possible to use Outlook Macro as a way to achieve persistance and execute arbitrary commands. This transform Outlook into a C2.
 Too achieve this two things must happened on the syste
-- The macro security registry value must be set to '4'
+- The macro security registry value must be set to '1'
 - A file called VbaProject.OTM must be created in the Outlook Folder.
 
 **Supported Platforms:** Windows
@@ -36,14 +36,14 @@ Too achieve this two things must happened on the syste
 
 
 ```cmd
-reg add "HKEY_CURRENT_USER\Software\Microsoft\Office\16.0\Outlook\Security\Level" /t REG_DWORD /d 1 /f
+reg add "HKEY_CURRENT_USER\Software\Microsoft\Office\16.0\Outlook\Security" /v Level /t REG_DWORD /d 1 /f
 mkdir  %APPDATA%\Microsoft\Outlook\ >nul 2>&1
 echo "Atomic Red Team TEST" > %APPDATA%\Microsoft\Outlook\VbaProject.OTM
 ```
 
 #### Cleanup Commands:
 ```cmd
-reg delete "HKEY_CURRENT_USER\Software\Microsoft\Office\16.0\Outlook\Security\Level" /f >nul 2>&1
+reg delete "HKEY_CURRENT_USER\Software\Microsoft\Office\16.0\Outlook\Security" /v Level /f >nul 2>&1
 del %APPDATA%\Microsoft\Outlook\VbaProject.OTM >nul 2>&1
 ```
 

--- a/atomics/T1137/T1137.yaml
+++ b/atomics/T1137/T1137.yaml
@@ -7,16 +7,16 @@ atomic_tests:
     As outlined in MDSEC's Blog post https://www.mdsec.co.uk/2020/11/a-fresh-outlook-on-mail-based-persistence/ 
     it is possible to use Outlook Macro as a way to achieve persistance and execute arbitrary commands. This transform Outlook into a C2.
     Too achieve this two things must happened on the syste
-    - The macro security registry value must be set to '4'
+    - The macro security registry value must be set to '1'
     - A file called VbaProject.OTM must be created in the Outlook Folder.
   supported_platforms:
   - windows
   executor:
     command: |
-      reg add "HKEY_CURRENT_USER\Software\Microsoft\Office\16.0\Outlook\Security\Level" /t REG_DWORD /d 1 /f
+      reg add "HKEY_CURRENT_USER\Software\Microsoft\Office\16.0\Outlook\Security" /v Level /t REG_DWORD /d 1 /f
       mkdir  %APPDATA%\Microsoft\Outlook\ >nul 2>&1
       echo "Atomic Red Team TEST" > %APPDATA%\Microsoft\Outlook\VbaProject.OTM
     cleanup_command: |
-      reg delete "HKEY_CURRENT_USER\Software\Microsoft\Office\16.0\Outlook\Security\Level" /f >nul 2>&1
+      reg delete "HKEY_CURRENT_USER\Software\Microsoft\Office\16.0\Outlook\Security" /v Level /f >nul 2>&1
       del %APPDATA%\Microsoft\Outlook\VbaProject.OTM >nul 2>&1
     name: command_prompt


### PR DESCRIPTION
**Details:**
Based on the referenced report, we should add the Level registry value as a REG_DWORD set to 1.
The previous command only created the Security key path and did not create the Level value.
