### PR TITLE
Update  T1007 to enhance service discovery methods across platforms

### DIFF
--- a/atomics/T1007/T1007.yaml
+++ b/atomics/T1007/T1007.yaml
@@ -54,7 +54,6 @@ atomic_tests:
     name: command_prompt
     command: powershell.exe Get-Service
 - name: System Service Discovery - macOS launchctl
-  auto_generated_guid: 91311179-9d2f-40ae-a80a-d3c30c5dc638
   description: |
     Enumerates services on macOS using launchctl. Used by adversaries for
     identifying daemons, background services, and persistence mechanisms.
@@ -64,7 +63,6 @@ atomic_tests:
     name: sh
     command: launchctl list
 - name: System Service Discovery - Windows Scheduled Tasks (schtasks)
-  auto_generated_guid: 3df87928-cb07-4f1b-b711-c655b5ae8abd
   description: |
     Enumerates scheduled tasks on Windows using schtasks.exe.
   supported_platforms:
@@ -74,7 +72,6 @@ atomic_tests:
     command: schtasks /query /fo LIST /v
 
 - name: System Service Discovery - Services Registry Enumeration
-  auto_generated_guid: 4cde1f2b-d3d1-4850-9c81-9a91007c1bba
   description: |
     Enumerates Windows services by reading the Services registry key
     (HKLM\SYSTEM\CurrentControlSet\Services) instead of using Service Control
@@ -96,7 +93,6 @@ atomic_tests:
         }
 
 - name: System Service Discovery - Linux init scripts
-  auto_generated_guid: 37a8ef14-c86a-44e8-aa70-38ccdec0f0b6
   description: |
     Enumerates system services by listing SysV init scripts and runlevel
     symlinks under /etc/init.d and /etc/rc*.d.


### PR DESCRIPTION
**Details:**
<!-- Insert details about this change here. Please include as much detail as possible -->

This PR broadens T1007 – System Service Discovery with additional enumeration methods across Windows/Linux/macOS. It adds macOS service discovery via "launchctl", Windows scheduled task discovery via "schtasks", and a registry-based method for reading Windows services, plus Linux coverage for traditional SysV init scripts mentioned in AN1326, while lightly refining the existing Windows service discovery tests.

The goal is to better reflect how adversaries enumerate services and related mechanisms across different OS. If any of these additions feel redundant or could be improved, I'm happy to adjust.

Update:
1. **System Service Discovery** 

   - Updated to use  `tasklist.exe /svc` more clearly ties processes to services while remaining low impact:

     ```cmd
     tasklist.exe /svc
     sc query
     sc query state= all
     ```
New:
5. **System Service Discovery – macOS launchctl**

   - Adds a macOS-specific discovery test using:

     ```sh
     launchctl list
     ```

   Models enumeration of launch daemons/agents and background services on macOS.

New:
6. **System Service Discovery – Windows Scheduled Tasks (schtasks)**

   - Adds scheduled task discovery under T1007 using:

     ```cmd
     schtasks /query /fo LIST /v
     ```

    Models the use of `schtasks.exe` to enumerate scheduled tasks, which are often treated as
    service-like persistence.
    
New:
7. **System Service Discovery – Services Registry Enumeration**

   - Adds registry-based service discovery via:

     ```powershell
     Get-ChildItem -Path 'HKLM:\SYSTEM\CurrentControlSet\Services' |
       ForEach-Object {
         $p = Get-ItemProperty -Path $_.PSPath -ErrorAction SilentlyContinue
         [PSCustomObject]@{
           Name        = $_.PSChildName
           DisplayName = $p.DisplayName
           ImagePath   = $p.ImagePath
           StartType   = $p.Start
         }
       }
     ```

   Exercises registry telemetry for service discovery and can reveal services not visible via SCM-based enumeration.

New:
8. **System Service Discovery – Linux init scripts**

   - Enumerates traditional SysV init scripts and runlevel symlinks:

     ```sh
     echo "[*] Listing SysV init scripts (/etc/init.d):"
     if [ -d /etc/init.d ]; then
       ls -l /etc/init.d
     else
       echo "/etc/init.d not present on this system"
     fi

     echo
     echo "[*] Listing runlevel directories (/etc/rc*.d):"
     ls -ld /etc/rc*.d 2>/dev/null || echo "No /etc/rc*.d directories found"
     ```

   Reflects behavior seen on systems that still rely on or retain SysV-style init and runlevels.



**Testing:**
<!-- Note any testing done, local or automated here. -->
I validated the new/updated atomics using `Invoke-AtomicTest` from a fork:

- **Windows (GitHub Actions: `windows-latest`):**
  - `Invoke-AtomicTest T1007 -TestNames "System Service Discovery"`

  Captured execution logs with `-ExecutionLogPath` for each.

<img width="578" height="448" alt="image" src="https://github.com/user-attachments/assets/c2bd2c6b-3cea-49ee-97ab-4eb6c660bff0" />

- `Invoke-AtomicTest T1007 -TestNames "System Service Discovery - Windows Scheduled Tasks (schtasks)"`

<img width="748" height="607" alt="image" src="https://github.com/user-attachments/assets/9cd1c7e5-df9e-48d4-b65c-66cbee2135d3" />


 - `Invoke-AtomicTest T1007 -TestNames "System Service Discovery - Services Registry Enumeration"`

<img width="792" height="480" alt="image" src="https://github.com/user-attachments/assets/16c1091d-0f96-427e-962c-3c25b384e914" />


- **Linux (GitHub Actions: `ubuntu-latest`):**
  - `Invoke-AtomicTest T1007 -TestNames "System Service Discovery - Linux init scripts"`

<img width="692" height="542" alt="image" src="https://github.com/user-attachments/assets/956c5082-a310-42f6-805d-5ba95ef85199" />


- **macOS (GitHub Actions: `macos-latest`):**
  - `Invoke-AtomicTest T1007 -TestNames "System Service Discovery - macOS launchctl"`
 
<img width="652" height="463" alt="image" src="https://github.com/user-attachments/assets/f8cf3b8e-ffec-45dd-af56-4bc02cb421b1" />


**Associated Issues:**
<!-- Please link any issues that this pull request impacts or fixes. -->

N/A