### PR TITLE
Update T1490 to include Diskshadow.exe test

### DIFF
--- a/atomics/T1490/T1490.yaml
+++ b/atomics/T1490/T1490.yaml
@@ -186,7 +186,7 @@ atomic_tests:
     elevation_required: true
 - name: Windows - Delete Volume Shadow Copies via Diskshadow
   description: |
-    Deletes Windows Volume Shadow Copies via Diskshadow binary. This technique is used by numerous ransomware families such as Crytox. The binary is present by default in Windows Server operating systems (since Windows Server 2008). Upon execution, it will delete all shadows copies of the server.
+    Deletes Windows Volume Shadow Copies via Diskshadow binary. This technique is used by numerous ransomware families such as Crytox. The binary is present by default in Windows Server operating systems (since Windows Server 2008). Upon execution, it will delete all shadow copies of the server.
   supported_platforms:
   - windows
   dependency_executor_name: powershell


### PR DESCRIPTION
**Details:**
<!Diskshadow.exe is a native Windows Server binary that also be used to delete volume shadow copies.>

**Testing:**
<!--The command was tested in the lab env and successfully executed and performed the deletion. -->