### PR TITLE
T1546.018: Python Startup Hooks - Universal Compatibility Update

### DIFF
--- a/atomics/T1546.018/T1546.018.yaml
+++ b/atomics/T1546.018/T1546.018.yaml
@@ -32,10 +32,9 @@ atomic_tests:
         Get-ChildItem -Path "$SitePackages" | Where-Object { $_.Name -like "*.pth" }
         & "$TempDir\env\Scripts\python.exe" -c "print('Triggering Hook via atomic_hook...')"
       cleanup_command: |
-        if (-not (Get-ChildItem -Path $env:Temp -ErrorAction SilentlyContinue | Where-Object Name -like 'atomic_pth_win')) { Write-Host "[!] Artifact missing: $env:Temp\atomic_pth_win Folder - [-] Please Run : Invoke-AtomicTest T1546.018"; exit 1 };
-        Remove-Item -Path "$env:Temp\atomic_pth_win" -Recurse -Force
-        Write-Host "[+] Successfully Removed atomic_pth_win folder from Temp Directory"
-        if (-not (Test-Path "$SitePackages\atomic_hook.pth")) { Write-Host "[+] Successfully Removed atomic_hook.pth" } else { Write-Host "File still exists" } 
+        if (-not (Get-ChildItem -Path $env:TEMP -ErrorAction SilentlyContinue | Where-Object Name -like 'atomic_pth_win')) { Write-Host "[!] Artifact missing: $env:Temp\atomic_pth_win Folder - [-] Please Run : Invoke-AtomicTest T1546.018"; exit 1 };
+        Remove-Item -Path "$env:TEMP\atomic_pth_win" -Recurse -Force
+        Write-Host "[+] Successfully Removed atomic_pth_win folder and atomic_hook.pth from Temp Directory"
         Get-Process -Name "Calc*" -ErrorAction SilentlyContinue | Stop-Process -Force
         Get-Process -Name "calc*" -ErrorAction SilentlyContinue | Stop-Process -Force
         Write-Host "[+] Successfully Terminated Calculator"
@@ -194,7 +193,7 @@ atomic_tests:
         if [ -f /tmp/poc.txt ]; then echo "Success: poc.txt created under /tmp\n" $(ls -la /tmp/ | grep -w poc.txt); else echo "Failed: /tmp/poc.txt not found"; fi
       cleanup_command: |
         PYTHON_CMD=$(command -v #{python_exe} || command -v python)
-        USER_PACKAGES=$($PYTHON_CMD -c "import site; print(site.getusersitepackages())")
+        USER_PACKAGES=$($PYTHON_CMD -S -c "import site; print(site.getusersitepackages())")
         if [ ! -f /tmp/poc.txt ] || [ ! -f $USER_PACKAGES/usercustomize.py ]; then echo "[!] Artifact missing: /tmp/poc.txt and $USER_PACKAGES/usercustomize.py — [-] Please Run : Invoke-AtomicTest T1546.018"; exit 0; fi
         if [ -e "$USER_PACKAGES"/usercustomize* ]; then echo "[+] Successful remove $USER_PACKAGES/usercustomize.py\n" $(rm -rf "$USER_PACKAGES"/usercustomize*); else echo "usercustomize.py not found under $USER_PACKAGES"; fi
         rm -rf /tmp/poc.txt


### PR DESCRIPTION
This update improves the Atomic Red Team coverage for T1546.018 (Hook via Python) to better reflect real-world behavior and ensure reliable testing across platforms.

Because Python invocation varies by operating system and environment—sometimes defaulting to python, other times to python3—the tests now account for both cases to ensure consistent detection on Windows, Linux, and macOS. This avoids assumptions about interpreter naming and improves portability.

In alignment with recent research from https://dfir.ch/posts/publish_python_pth_extension/, the test logic has been expanded to more accurately exercise this technique. Coverage now includes execution via .pth files as well as Python files placed directly within the site-packages directory.

To support this expanded coverage, the total number of tests has been increased from three to five, with the newly added tests specifically validating site-packages–based Python file execution across all supported operating systems.

The goal of these changes is to advance the fidelity and completeness of Atomic Red Team’s coverage for this technique, while ensuring testing remains safe and non-persistent. All tests are executed in isolated environments, with careful cleanup to avoid impacting the host system.

Requirements:
	•	Python 3 (If you don't have python3 and python command in your binary path, please use with -InputArgs @{python_exe="input"})
	•	venv module installed (required to create isolated virtual environments for testing)

I acknowledge that this pull request has gone through multiple iterations, and I appreciate the maintainers’ patience. This version reflects thorough validation of both success and failure cases and represents my most complete and carefully tested implementation to date.