### PR TITLE
Enhance T1546.018: Add Python Hooking variations and venv isolation

### DIFF
--- a/atomics/T1546.018/T1546.018.yaml
+++ b/atomics/T1546.018/T1546.018.yaml
@@ -1,77 +1,124 @@
 attack_technique: T1546.018
-display_name: "Event Triggered Execution: Python Startup Hooks"
+display_name: 'Event Triggered Execution: Python Startup Hooks'
 atomic_tests:
-  - name: "Python Startup Hook Execution via .pth (Windows)"
+  - name: Python Startup Hook - atomic_hook.pth (Windows)
     description: |
-      Creates a Python startup hook using a .pth file inside a virtual environment on Windows.
+      Executes code by placing a .pth file in the site-packages directory. 
+      Supports python.exe and python3.exe via input arguments.
     supported_platforms:
       - windows
     input_arguments:
-      exe_name:
-        description: Executable to launch
-        type: string
-        default: calc.exe
-      python_path:
-        description: Path to Python interpreter
-        type: path
+      python_exe:
+        description: The python binary name to test.
+        type: String
         default: python.exe
     dependency_executor_name: powershell
     dependencies:
-      - description: Ensure Python is installed
+      - description: |
+          Python must be installed and the specified binary (#{python_exe}) must be in the PATH.
         prereq_command: |
-          if (Get-Command #{python_path} -ErrorAction SilentlyContinue) { exit 0 } else { exit 1 }
+          if (Get-Command @("#{python_exe}", 'python3.exe') -ErrorAction SilentlyContinue) { exit 0 } else { exit 1 }
         get_prereq_command: |
-          Write-Host "Python not found. Please install it from https://www.python.org/downloads/windows/ or via 'winget install Python.Python.3'"
+          Write-Host "[!] Python3 not found. Please install Python3 (e.g., winget install python3 or winget install python or https://www.python.org/downloads/windows/) or ensure it is in your PATH."
     executor:
       name: powershell
       elevation_required: false
       command: |
-        $TempDir = Join-Path $env:TEMP ("atomic_python_hook_" + [guid]::NewGuid())
-        New-Item -ItemType Directory -Path $TempDir | Out-Null
-        Set-Location $TempDir
-        Set-Content -Path "$env:TEMP\atomic_python_hook_path.txt" -Value $TempDir
-        & "#{python_path}" -m venv env
+        $TempDir = Join-Path $env:TEMP "atomic_pth_win"
+        New-Item -ItemType Directory -Path $TempDir -Force
+        & "#{python_exe}" -m venv "$TempDir\env"
         $SitePackages = & "$TempDir\env\Scripts\python.exe" -c "import site; print(site.getsitepackages()[1])"
-        "import os, subprocess; os.environ.get('CALC_SPAWNED') or (os.environ.update({'CALC_SPAWNED':'1'}) or subprocess.Popen(['#{exe_name}']))" | Out-File -Encoding ASCII "$SitePackages\atomic_hook.pth"
-        & "$TempDir\env\Scripts\python.exe" -c "print('Interpreter started')"
+        "import os, subprocess; os.environ.get('CALC_SPAWNED') or (os.environ.update({'CALC_SPAWNED':'1'}) or subprocess.Popen(['calc.exe']))" | Out-File -Encoding ASCII "$SitePackages\atomic_hook.pth"
+        Get-ChildItem -Path "$SitePackages" | Where-Object { $_.Name -like "*.pth" }
+        & "$TempDir\env\Scripts\python.exe" -c "print('Triggering Hook via atomic_hook...')"
       cleanup_command: |
-        Get-Process CalculatorApp -ErrorAction SilentlyContinue | Stop-Process -Force
-        if (Test-Path "$env:TEMP\atomic_python_hook_path.txt") {
-          $TempDir = Get-Content "$env:TEMP\atomic_python_hook_path.txt"
-          Remove-Item -Recurse -Force $TempDir -ErrorAction SilentlyContinue
-          Remove-Item "$env:TEMP\atomic_python_hook_path.txt" -Force }
+        if (-not (Get-ChildItem -Path $env:TEMP -ErrorAction SilentlyContinue | Where-Object Name -like 'atomic_pth_win')) { Write-Host "[!] Artifact missing: $env:Temp\atomic_pth_win Folder - [-] Please Run : Invoke-AtomicTest T1546.018"; exit 1 };
+        Remove-Item -Path "$env:TEMP\atomic_pth_win" -Recurse -Force
+        Write-Host "[+] Successfully Removed atomic_pth_win folder and atomic_hook.pth from Temp Directory"
+        Get-Process -Name "Calc*" -ErrorAction SilentlyContinue | Stop-Process -Force
+        Get-Process -Name "calc*" -ErrorAction SilentlyContinue | Stop-Process -Force
+        Write-Host "[+] Successfully Terminated Calculator"
 
-  - name: "Python Startup Hook Execution via .pth (Linux)"
+  - name: Python Startup Hook - usercustomize.py (Windows)
     description: |
-      Creates a Python startup hook using a .pth file inside a virtual environment on Linux.
+      Executes code via usercustomize.py. This is a per-user persistence mechanism 
+      that does not require Administrative privileges.
+    supported_platforms:
+      - windows
+    input_arguments:
+      python_exe:
+        description: The python binary name to test
+        type: String
+        default: python.exe
+    dependency_executor_name: powershell
+    dependencies:
+      - description: |
+          Python must be installed and the specified binary (#{python_exe}) must be in the PATH.
+        prereq_command: |
+          if (Get-Command @("#{python_exe}", 'python3.exe') -ErrorAction SilentlyContinue) { exit 0 } else { exit 1 }
+        get_prereq_command: |
+          Write-Host "[!] Python3 not found. Please install Python3 (e.g., winget install python3 or winget install python or https://www.python.org/downloads/windows/) or ensure it is in your PATH."
+    executor:
+      name: powershell
+      elevation_required: false
+      command: |
+        $UserDir = & "#{python_exe}" -c "import site; print(site.getusersitepackages())"
+        if (!(Test-Path $UserDir)) { New-Item -ItemType Directory -Path $UserDir -Force }
+        "import os; os.system('calc.exe')" | Out-File -FilePath "$UserDir\usercustomize.py" -Encoding ASCII
+        Get-ChildItem -Path "$UserDir"
+        & "#{python_exe}" -c "print('Triggering Hook via usercustomize...')"
+      cleanup_command: |
+        $PyBin = if (Get-Command "#{python_exe}" -ErrorAction SilentlyContinue) { "#{python_exe}" } elseif (Get-Command "python3.exe" -ErrorAction SilentlyContinue) { "python3.exe" } else { "python.exe" }; 
+        $UserDir = & $PyBin -S -c "import site; print(site.getusersitepackages())"
+        if (-not (Get-ChildItem -Path $UserDir -Recurse -ErrorAction SilentlyContinue | Where-Object Name -like 'usercustomize*')) { Write-Host "[!] Artifact missing: $UserDir\usercustomize.py - [-] Please Run : Invoke-AtomicTest T1546.018"; exit 1 };
+        Get-ChildItem -Path "$UserDir" -Recurse -Force |
+        Where-Object { $_.Name -like "usercustomize*" } |
+        Remove-Item -Force 
+        Write-Host "[+] Successfully Removed usercustomize.py under $UserDir"
+        Get-Process -Name "Calc*", "calc*" -ErrorAction SilentlyContinue | Stop-Process -Force
+        Write-Host "[+] Successfully Terminated Calculator"
+
+  - name: Python Startup Hook - atomic_hook.pth (Linux)
+    description: |
+      Executes code by creating atomic_hook.pth in the site-packages directory. 
+      This script runs automatically for every user on the system when Python starts.
     supported_platforms:
       - linux
     input_arguments:
-      python_path:
-        description: Path to Python interpreter
-        type: path
+      python_exe:
+        description: The python binary name to test
+        type: String
         default: python3
-    dependency_executor_name: bash
+    dependency_executor_name: sh
     dependencies:
-      - description: Ensure Python is installed
-        prereq_command: command -v #{python_path} >/dev/null 2>&1
+      - description: |
+          Python must be installed and the specified binary (#{python_exe}) must be in the PATH.
+        prereq_command: |
+          PYTHON_CMD=$(command -v #{python_exe} || command -v python)
+          if [ -z "$PYTHON_CMD" ]; then exit 1; fi
+          $PYTHON_CMD -m venv --help >/dev/null 2>&1
         get_prereq_command: |
-          echo "Python3 not found. Please install it using your package manager (e.g., 'sudo apt install python3' or 'sudo yum install python3')."
+          echo "Python not found. Please install Python using your package manager (e.g., Debian Based 'sudo apt-get update && sudo apt-get install -y python3 python3-venv', RedHat / CentOS Based 'sudo yum install -y python3 python3-venv || sudo dnf install -y python3 python3-venv')."
     executor:
-      name: bash
+      name: sh
       elevation_required: false
       command: |
-        PYTHON_EXE=$(command -v #{python_path})
-        TEMPDIR=$(mktemp -d /tmp/atomic_python_hook_XXXXXX)
-        echo "$TEMPDIR" > /tmp/atomic_python_hook_path.txt
-        $PYTHON_EXE -m venv "$TEMPDIR/env"
-        SITE_PACKAGES=$("$TEMPDIR/env/bin/python" -c "import site; print(site.getsitepackages()[0])")
-        echo "import sys, os; (not hasattr(sys, 'hook_run')) and (setattr(sys, 'hook_run', True) or os.system('cat /etc/passwd'))" > "$SITE_PACKAGES/atomic_hook.pth"
-        "$TEMPDIR/env/bin/python" -c "print('Interpreter started')"
+        TEMPDIR="/tmp/atomic_sitecust_posix"
+        mkdir -p "$TEMPDIR"
+        "#{python_exe}" -m venv "$TEMPDIR/env"
+        SITE_PACKAGES=$("$TEMPDIR/env/bin/#{python_exe}" -c "import site; print(site.getsitepackages()[0])")
+        echo "import os; os.system('cat /etc/passwd 1> /tmp/atomic_hook_poc.txt')" > "$SITE_PACKAGES/atomic_hook.pth"
+        ls -la "$SITE_PACKAGES/atomic_hook.pth"
+        "$TEMPDIR/env/bin/python" -c "print('Triggering Hook via atomic_hook...')"
+        if [ -f /tmp/atomic_hook_poc.txt ]; then echo "[+] Success: atomic_hook_poc.txt created under /tmp \n" $(ls -la /tmp/ | grep -w atomic_hook_poc.txt); else echo "Failed: /tmp/atomic_hook_poc.txt not found"; fi
       cleanup_command: |
-        rm -rf $(cat /tmp/atomic_python_hook_path.txt) && rm -f /tmp/atomic_python_hook_path.txt
+        if [ ! -f /tmp/atomic_hook_poc.txt ] || [ ! -d /tmp/atomic_sitecust_posix ]; then echo "[!] Missing artifact or folder: /tmp/atomic_hook_poc.txt or /tmp/atomic_sitecust_posix — [-] Please Run : Invoke-AtomicTest T1546.018"; exit 0; fi
+        rm -rf /tmp/atomic_sitecust_posix
+        echo "[+] Successful Removed atomic_hook.pth"
+        rm -rf /tmp/atomic_hook_poc.txt
+        echo "[+] Successful Removed atomic_hook_poc.txt under /tmp"
 
-  - name: "Python Startup Hook Execution via .pth (macOS)"
+  - name: Python Startup Hook - atomic_hook.pth (macOS)
     description: |
       Creates a Python startup hook using a .pth file inside a virtual environment on macOS.
     supported_platforms:
@@ -81,27 +128,73 @@ atomic_tests:
         description: App to launch
         type: string
         default: Calculator
-      python_path:
-        description: Path to Python interpreter
-        type: path
+      python_exe:
+        description: The python binary name to test
+        type: string
         default: python3
-    dependency_executor_name: bash
+    dependency_executor_name: sh
     dependencies:
-      - description: Ensure Python is installed
-        prereq_command: command -v #{python_path} >/dev/null 2>&1
+      - description: Python must be installed and the specified binary (#{python_exe}) must be in the PATH.
+        prereq_command: |
+          PYTHON_CMD=$(command -v python || command -v #{python_exe})
+          if [ -z "$PYTHON_CMD" ]; then exit 1; fi
+          $PYTHON_CMD -m venv --help >/dev/null 2>&1
         get_prereq_command: |
-          echo "Python3 not found. Please install it using Homebrew ('brew install python') or the macOS developer tools ('xcode-select --install')."
+          echo "Python3 not found. Please install it using Homebrew ('brew install python' or 'brew install python3 or brew install python@3.X') or the macOS developer tools ('xcode-select --install')."
     executor:
-      name: bash
+      name: sh
       elevation_required: false
       command: |
-        PYTHON_EXE=$(command -v #{python_path})
-        TEMPDIR=$(mktemp -d /tmp/atomic_python_hook_XXXXXX)
+        PYTHON_EXE=$(command -v #{python_exe} || command -v python)
+        TEMPDIR=$(mktemp -d /tmp/atomic_python_hook_XX)
         echo "$TEMPDIR" > /tmp/atomic_python_hook_path.txt
         $PYTHON_EXE -m venv "$TEMPDIR/env"
-        SITE_PACKAGES=$("$TEMPDIR/env/bin/python" -c "import site; print(site.getsitepackages()[0])")
+        SITE_PACKAGES=$("$TEMPDIR/env/bin/#{python_exe}" -c "import site; print(site.getsitepackages()[0])")
         echo "import subprocess; subprocess.Popen(['open', '-a', '#{exe_name}'])" > "$SITE_PACKAGES/atomic_hook.pth"
-        "$TEMPDIR/env/bin/python" -c "print('Interpreter started')"
+        "$TEMPDIR/env/bin/python" -c "print('Triggering Hook via atomic_hook...')"
       cleanup_command: |
+        if [ ! -f /tmp/atomic_python_hook_path.txt ] || [ ! -d $(cat /tmp/atomic_python_hook_path.txt) ]; then echo "[!] Artifact missing: /tmp/atomic_python_hook_path.txt — [-] Please Run : Invoke-AtomicTest T1546.018"; exit 0; fi
         pkill "#{exe_name}" || true
         [ -f /tmp/atomic_python_hook_path.txt ] && rm -rf $(cat /tmp/atomic_python_hook_path.txt) && rm -f /tmp/atomic_python_hook_path.txt
+        echo "[+] Successful Removed atomic_hook.pth and terminated #{exe_name}"
+        
+  - name: Python Startup Hook - usercustomize.py (Linux / MacOS)
+    description: |
+      Executes code via usercustomize.py. This is a per-user persistence mechanism 
+      that does not require root privileges.
+    supported_platforms:
+      - linux
+      - macos
+    input_arguments:
+      python_exe:
+        description: The python binary name to test
+        type: String
+        default: python3
+    dependency_executor_name: sh
+    dependencies:
+      - description: |
+          Python must be installed and the specified binary (#{python_exe}) must be in the PATH.
+        prereq_command: |
+          PYTHON_CMD=$(command -v #{python_exe} || command -v python)
+          if [ -z "$PYTHON_CMD" ]; then exit 1; fi
+          $PYTHON_CMD -m venv --help >/dev/null 2>&1
+        get_prereq_command: |
+          echo "Python not found. Please install Python using your package manager (e.g., Debian Based 'sudo apt-get update && sudo apt-get install -y python3 python3-venv', RedHat / CentOS Based 'sudo yum install -y python3 python3-venv || sudo dnf install -y python3 python3-venv', MacOS brew install python3 or brew install python@3.x or the macOS developer tools ('xcode-select --install'))."
+    executor:
+      name: sh
+      elevation_required: false
+      command: |
+        PYTHON_EXE=$(command -v #{python_exe} || command -v python)
+        USER_PACKAGES=$($PYTHON_EXE -c "import site; print(site.getusersitepackages())")
+        mkdir -p "$USER_PACKAGES"
+        echo "import os; os.system('date > /tmp/poc.txt')" > "$USER_PACKAGES/usercustomize.py"
+        if [ -f "$USER_PACKAGES/usercustomize.py" ]; then echo "Success: usercustomize.py created under $USER_PACKAGES\n" $(ls -la "$USER_PACKAGES" | grep usercustomize*); else echo "Failed: usercustomize.py not found under $USER_PACKAGES"; fi
+        $PYTHON_EXE -c "print('Triggering Hook via usercustomize.py...')"
+        if [ -f /tmp/poc.txt ]; then echo "Success: poc.txt created under /tmp\n" $(ls -la /tmp/ | grep -w poc.txt); else echo "Failed: /tmp/poc.txt not found"; fi
+      cleanup_command: |
+        PYTHON_CMD=$(command -v #{python_exe} || command -v python)
+        USER_PACKAGES=$($PYTHON_CMD -S -c "import site; print(site.getusersitepackages())")
+        if [ ! -f /tmp/poc.txt ] || [ ! -f $USER_PACKAGES/usercustomize.py ]; then echo "[!] Artifact missing: /tmp/poc.txt and $USER_PACKAGES/usercustomize.py — [-] Please Run : Invoke-AtomicTest T1546.018"; exit 0; fi
+        if [ -e "$USER_PACKAGES"/usercustomize* ]; then echo "[+] Successful remove $USER_PACKAGES/usercustomize.py\n" $(rm -rf "$USER_PACKAGES"/usercustomize*); else echo "usercustomize.py not found under $USER_PACKAGES"; fi
+        rm -rf /tmp/poc.txt
+        echo "[+] Successful remove poc.txt under /tmp"


### PR DESCRIPTION
### Description
This PR improves the Atomic Red Team coverage for T1546.018 (Event Triggered Execution: PowerShell Profile) specifically focusing on Python-based hooking. These updates reflect real-world adversary behavior (as seen in recent research) and ensure reliable testing across Windows, Linux, and macOS.

### Key Changes
Expanded Coverage: Increased tests from three to five, adding validation for execution via .pth files and Python files placed directly within the site-packages directory.

Flexible Interpreter Support: Added logic to handle various Python binary names (python, python3, or python3.x). This ensures the test doesn't fail simply because of local naming conventions.

Environment Isolation: All tests now leverage the venv module to create isolated virtual environments. This prevents modification of the host's global Python environment and ensures a clean, non-persistent state.

Cross-Platform Fidelity: Validated on Windows, Linux, and macOS to ensure consistent detection triggers regardless of the OS.

### Requirements & Usage
Python 3.x Required: These tests utilize Python 3 syntax and modules (like venv). Python 2 is not supported due to significant scripting format differences.

Binary Path: The tests look for python or python3. If your environment uses a specific version (e.g., python3.11), use the following: Invoke-AtomicTest T1546.018 -InputArgs @{python_exe="python3.11"}

Module Dependency: Ensure the venv module is installed (standard in most Python 3 distributions).

### Technical Reference
The logic aligns with research regarding Python .pth extension persistence, which allows code execution during Python initialization.

Reference: [DFIR.ch - Python .pth extension](https://dfir.ch/posts/publish_python_pth_extension/)


### Screenshot

<img width="1800" height="1033" alt="Screenshot 2026-01-13 at 12 10 24 AM" src="https://github.com/user-attachments/assets/7da32350-1ce1-440f-b84c-09234a47d5b7" />
<img width="1799" height="1015" alt="Screenshot 2026-01-13 at 12 17 40 AM" src="https://github.com/user-attachments/assets/41db532a-3080-48fc-8576-69fa7fde1a32" />
<img width="1800" height="1032" alt="Screenshot 2026-01-13 at 12 18 36 AM" src="https://github.com/user-attachments/assets/bca1e82f-bebd-4ec9-ac16-1d4238c3ebfb" />
<img width="1800" height="1031" alt="Screenshot 2026-01-13 at 12 20 35 AM" src="https://github.com/user-attachments/assets/b00b75cd-9a5c-4826-ba70-db95bfffec12" />
<img width="1800" height="1034" alt="Screenshot 2026-01-13 at 12 22 30 AM" src="https://github.com/user-attachments/assets/1db0fcba-5664-4485-aa8b-90ec5d4cd9c3" />
<img width="1614" height="687" alt="Screenshot 2026-01-13 at 12 35 24 AM" src="https://github.com/user-attachments/assets/f070ebc2-a60c-48bc-a63d-67f2a5b514c2" />
<img width="1785" height="942" alt="Screenshot 2026-01-13 at 12 36 58 AM" src="https://github.com/user-attachments/assets/af86b16d-fe41-4304-91ec-3217680a6e97" />
<img width="1787" height="673" alt="Screenshot 2026-01-13 at 12 40 40 AM" src="https://github.com/user-attachments/assets/7832a094-494e-4ecd-a09e-9d13a0d6f223" />
<img width="1794" height="1126" alt="Screenshot 2026-01-13 at 12 41 42 AM" src="https://github.com/user-attachments/assets/794bc8ed-622a-4d25-b378-77a24c79e198" />
<img width="1798" height="1123" alt="Screenshot 2026-01-13 at 12 42 51 AM" src="https://github.com/user-attachments/assets/1c51487a-7d1e-4386-baaf-51626b19dcde" />
<img width="1789" height="1124" alt="Screenshot 2026-01-13 at 12 43 41 AM" src="https://github.com/user-attachments/assets/14f19a53-c4cb-497e-b900-998410394e41" />
<img width="1796" height="1163" alt="Screenshot 2026-01-13 at 12 43 56 AM" src="https://github.com/user-attachments/assets/0c0b00f6-85b0-4db6-b385-f33ce7a27942" />

### Prereq and Getreq

**For Linux**
<img width="1918" height="1077" alt="27" src="https://github.com/user-attachments/assets/667640c3-f2b7-4a34-b892-dd27d6de7e0c" />

**For Windows**
<img width="1916" height="1074" alt="26" src="https://github.com/user-attachments/assets/b772e83c-77dc-4b89-8e81-476040d88ec7" />

**For MacOS**
Removing the default python3 on macOS is difficult because it’s protected by SIP and treated as part of the OS toolchain. Attempting to remove it can break system utilities, Homebrew, Xcode Command Line Tools, and future OS updates.

I installed python3 via Homebrew and tried renaming it, but that approach doesn’t work because of default python3. My YAML file detects the python and python3 commands before spawning the TTP.
