### PR TITLE
Enhance T1496(Resource Hijacking): Add Windows CPU Load Simulation

### DIFF
--- a/atomics/T1496/T1496.yaml
+++ b/atomics/T1496/T1496.yaml
@@ -14,3 +14,24 @@ atomic_tests:
       yes > /dev/null
     name: sh
 
+- name: Windows - Simulate CPU Load with PowerShell
+  description: |
+    This test simulates high CPU load using PowerShell, commonly seen in resource hijacking.
+    Spawns background jobs to stress CPU cores for a specified duration.
+  supported_platforms:
+  - windows
+  input_arguments:
+    duration_seconds:
+      description: Duration in seconds to run the CPU stress test
+      type: integer
+      default: 30
+    cpu_threads:
+      description: Number of threads to stress (default 4)
+      type: integer
+      default: 4
+  executor:
+    command: |
+      $end = (Get-Date).AddSeconds(#{duration_seconds})
+      1..#{cpu_threads} | ForEach-Object { Start-Job { param($t) while((Get-Date) -lt $t) { $i=0; while($i -lt 200000){$i++} } } -ArgumentList $end }
+      Get-Job | Wait-Job | Remove-Job
+    name: powershell


### PR DESCRIPTION
**Details:**
<!-- Insert details about this change here. Please include as much detail as possible -->
This PR introduces a new atomic test for T1496 (Resource Hijacking) on Windows, which utilizes the powershell "Start-Job" to spawn background threads. These threads execute tight arithmetic loops to simulate high resource usage in order to stress CPU cores for a configurable duration. (background jobs are automatically terminated upon completion).

**Testing:**
<!-- Note any testing done, local or automated here. -->
I have tested this addition with a Github-Workflow, with the following result:
<img width="911" height="412" alt="image" src="https://github.com/user-attachments/assets/c1f84cc7-fac7-477b-a819-b1eb8b7dc8bf" />

If needed, the exact workflow can be found here: 
https://github.com/vl43den/atomic-red-team/actions/runs/21114494382/job/60717966349

The test successfully triggered a significant CPU load. Metrics show a spike from a baseline of ~11.6% to an average of ~85.2% during execution.

**Associated Issues:**
<!-- Please link any issues that this pull request impacts or fixes. -->
N/A