### PR TITLE
New Test for AWS Config

### DIFF
--- a/atomics/T1562.008/T1562.008.yaml
+++ b/atomics/T1562.008/T1562.008.yaml
@@ -478,7 +478,6 @@ atomic_tests:
     get_prereq_command: |
       gcloud auth login --no-launch-browser
 - name: AWS - Config Logs Disabled
-  auto_generated_guid: 9c10dc6b-20bd-403a-8e67-50ef7d07ed4e
   description: |
     Disables AWS Config by stopping the configuration recorder, deleting the delivery channel, and deleting the configuration recorder. An attacker with sufficient permissions can use this to stop configuration change recording and avoid detection of subsequent activity.
   supported_platforms:


### PR DESCRIPTION
**Details:**
<!-- Insert details about this change here. Please include as much detail as possible -->

Test #11 for the Technique of 'Impair Defenses: Disable Cloud Logs'

**Testing:**
<!-- Note any testing done, local or automated here. -->
Enable AWS Config in your account 
Then as noted, run the following
```
aws configservice stop-configuration-recorder --configuration-recorder-name #{configuration_recorder_name} --region #{region}

aws configservice delete-delivery-channel --delivery-channel-name #{delivery_channel_name} --region #{region}

aws configservice delete-configuration-recorder --configuration-recorder-name #{configuration_recorder_name} --region #{region}
```
Testing:

T1562.008 Test 11 
`Invoke-AtomicTest -PathToAtomicsFolder /Users/User/atomic-red-team/atomics T1562.008 -TestNumbers 11`
<img width="932" height="210" alt="T1562_008_Before copy" src="https://github.com/user-attachments/assets/b8085c6d-61a0-4852-ac67-576020448cb9" />

Success exit code after running the test
<img width="1316" height="200" alt="T1562_008_Success copy" src="https://github.com/user-attachments/assets/65bd60a7-d201-49bd-84aa-29892b7267bf" />


Confirm with the following command as shown
`aws configservice list-configuration-recorders --region us-west-2  `

Reference
https://attack.mitre.org/techniques/T1562/008/

**Associated Issues:**
<!-- Please link any issues that this pull request impacts or fixes. -->