### PR TITLE
update slack link

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -29,7 +29,7 @@ If you see anything that you believe breaks our community guidelines, no matter 
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the Community Manager. Unacceptable behavior will not be tolerated by community members, maintainers, and Red Canary team members.  The Atomic Red Team Community Manager and maintainers will review and investigate all complaints. 
 
-Anyone asked to stop unacceptable behavior is expected to comply immediately. If an Atomic Red Team community member (anyone contributing to our [GitHub Repo](https://github.com/redcanaryco/atomic-red-team) or [Community Slack](https://redcanaryco.github.io/atomic-red-team-slack/) engages in unacceptable behavior, the Community Manager may take any temporary or permanent action they deem appropriate, up to and including immediate expulsion from the Atomic Red Team community without warning.
+Anyone asked to stop unacceptable behavior is expected to comply immediately. If an Atomic Red Team community member (anyone contributing to our [GitHub Repo](https://github.com/redcanaryco/atomic-red-team) or [Community Slack](https://atomicredteam.io/slack)) engages in unacceptable behavior, the Community Manager may take any temporary or permanent action they deem appropriate, up to and including immediate expulsion from the Atomic Red Team community without warning.
 
 Atomic Red Team maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
 
@@ -45,7 +45,7 @@ This Code of Conduct applies to all of the Atomic Red Team, and “Atomic Family
 
 * [Atomic Red Team Website](https://atomicredteam.io/)
 
-* [Atomic Red Team Slack](https://redcanaryco.github.io/atomic-red-team-slack/)
+* [Atomic Red Team Slack](https://atomicredteam.io/slack)
 
 * [Atomic Red Team GitHub](https://github.com/redcanaryco/atomic-red-team)
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ To stay up to date on all things Atomic Red Team, sign up for the Atomic Newslet
 Atomic Red Team is open source and community developed. If you're interested in
 becoming a contributor, check out these resources:
 
-- Join our [Slack workspace](https://redcanaryco.github.io/atomic-red-team-slack/) and get involved
+- Join our [Slack workspace](https://atomicredteam.io/slack) and get involved
   with the community. Don't forget to review the [code of conduct](CODE_OF_CONDUCT.md)
   before you join.
 - Report bugs and request new features by [submitting an issue](https://github.com/redcanaryco/atomic-red-team/issues/new/choose).


### PR DESCRIPTION
**Details:**
the DNS CNAME we used to use is not working, so I updated the invite URL to `https://redcanaryco.github.io/atomic-red-team-slack/`