### PR TITLE
Add atomic test for T1036.002 - Masquerading: Right-to-Left Override

### DIFF
--- a/atomics/T1036.002/T1036.002.yaml
+++ b/atomics/T1036.002/T1036.002.yaml
@@ -1,0 +1,20 @@
+- name: Masquerading - Right-to-Left Override (RTLO) File Creation
+  description: |
+    Adversaries abuse the right-to-left override (RTLO / U+202E) Unicode character to reverse the display order of characters in a filename. 
+    This makes a malicious file (e.g. ending in .scr or .exe) appear as a benign document (e.g. .docx or .txt) in Windows Explorer.
+    Example: The real filename "March_25_[RTLO]xcod.scr" displays as "March_25_rcs.docx".
+    Reference: https://attack.mitre.org/techniques/T1036/002/
+  supported_platforms:
+  - windows
+  executor:
+    name: powershell
+    command: |
+      $rtlo = [char]0x202E
+      $filename = "March_25_$($rtlo)xcod.scr"
+      New-Item -Path $filename -ItemType File -Force | Out-Null
+      Write-Output "Created masqueraded file: $filename"
+      Write-Output "→ In Windows Explorer this displays as: March_25_rcs.docx"
+    cleanup_command: |
+      $rtlo = [char]0x202E
+      $filename = "March_25_$($rtlo)xcod.scr"
+      Remove-Item -Path $filename -Force -ErrorAction SilentlyContinue


### PR DESCRIPTION
## Description
Adds a new atomic test for the missing sub-technique **T1036.002** (Masquerading: Right-to-Left Override).

### Test Details
- **Technique**: T1036.002
- **Platform**: Windows
- **Executor**: PowerShell
- Creates a file with RTLO character (U+202E) so it masquerades as a harmless .docx document in Explorer.
- Includes proper cleanup command.

Reference: https://attack.mitre.org/techniques/T1036/002/