### PR TITLE
Fix T1003.001 Mimikatz command quoting

### DIFF
--- a/atomics/T1003.001/T1003.001.yaml
+++ b/atomics/T1003.001/T1003.001.yaml
@@ -175,7 +175,7 @@ atomic_tests:
       Write-Host "Create the lsass dump manually using the steps in the previous test (Dump LSASS.exe Memory using Windows Task Manager)"
   executor:
     command: |
-      "#{mimikatz_exe}" "sekurlsa::minidump #{input_file}" "sekurlsa::logonpasswords full" exit
+      #{mimikatz_exe} "sekurlsa::minidump #{input_file}" "sekurlsa::logonpasswords full" exit
     name: command_prompt
     elevation_required: true
 - name: LSASS read with pypykatz


### PR DESCRIPTION
## Details
Fixes the T1003.001-6 command emitted for the Offline Credential Theft With Mimikatz atomic.

The current command wraps the executable input in quotes, which has been reported to fail through Invoke-AtomicTest with the error: The filename, directory name, or volume label syntax is incorrect.

The default executable path does not contain spaces, and the reporter confirmed the unquoted executable form runs successfully while keeping the Mimikatz arguments quoted.

## Validation
- Parsed the updated YAML successfully
- Confirmed T1003.001 test 6 still resolves to Offline Credential Theft With Mimikatz
- Confirmed the executor command now starts with the unquoted executable input and preserves quoted Mimikatz arguments

Fixes #3347