### PR TITLE
Add T1213.005 - Data from Information Repositories: Messaging Applications (Slack & Teams API collection)

### DIFF
--- a/atomics/T1213.005/T1213.005.yaml
+++ b/atomics/T1213.005/T1213.005.yaml
@@ -1,0 +1,187 @@
+attack_technique: T1213.005
+display_name: 'Data from Information Repositories: Messaging Applications'
+atomic_tests:
+- name: Slack - Dump channel message history via conversations.history API (sh)
+  auto_generated_guid: 6998cd96-06d0-45f9-80bc-ced040d714da
+  description: |
+    Uses a Slack API token (user or bot token, e.g. `xoxp-`/`xoxb-`) to call the `conversations.history`
+    Web API method and dump the message history of a target channel to a local file.
+
+    Adversaries who obtain a Slack token from a compromised host, leaked CI/CD secret, or OAuth grant can
+    read sensitive conversations, shared credentials, and links to internal information repositories without
+    ever logging into the Slack web client. Mapped to MITRE ATT&CK T1213.005.
+
+    Upon successful execution the channel history is written to the file defined in `output_file` and printed
+    to the console. The token requires the `channels:history` (or `groups:history`) OAuth scope.
+  supported_platforms:
+  - saas
+  input_arguments:
+    slack_token:
+      description: Slack API token with the channels:history (or groups:history) scope (xoxp-/xoxb-)
+      type: string
+      default:
+    slack_channel_id:
+      description: Target Slack channel ID (e.g. C0123456789), not the channel name
+      type: string
+      default: C0123456789
+    message_limit:
+      description: Maximum number of messages to retrieve
+      type: integer
+      default: 200
+    output_file:
+      description: Path to write the dumped channel history to
+      type: path
+      default: /tmp/T1213.005_slack_messages.json
+  dependencies:
+  - description: |
+      curl must be installed.
+    prereq_command: |
+      which curl
+    get_prereq_command: |
+      echo "Install curl using your package manager, e.g. 'sudo apt-get install -y curl' or 'brew install curl'"
+  dependency_executor_name: sh
+  executor:
+    command: |
+      curl -s -H "Authorization: Bearer #{slack_token}" \
+        "https://slack.com/api/conversations.history?channel=#{slack_channel_id}&limit=#{message_limit}" \
+        -o "#{output_file}"
+      cat "#{output_file}"
+    cleanup_command: |
+      rm -f "#{output_file}"
+    name: sh
+    elevation_required: false
+- name: Slack - Dump channel message history via conversations.history API (PowerShell)
+  auto_generated_guid: 1ddc8f8c-204c-4b47-b3b9-557f08e39921
+  description: |
+    Uses a Slack API token to call the `conversations.history` Web API method from PowerShell and dump the
+    message history of a target channel to a local file.
+
+    This is the cross-platform PowerShell equivalent of the sh-based Slack collection test. An adversary in
+    possession of a leaked Slack token can stage this from any Windows, macOS, or Linux host with PowerShell.
+    Mapped to MITRE ATT&CK T1213.005.
+
+    Upon successful execution the channel history is written to the file defined in `output_file` and printed
+    to the console. The token requires the `channels:history` (or `groups:history`) OAuth scope.
+  supported_platforms:
+  - saas
+  input_arguments:
+    slack_token:
+      description: Slack API token with the channels:history (or groups:history) scope (xoxp-/xoxb-)
+      type: string
+      default:
+    slack_channel_id:
+      description: Target Slack channel ID (e.g. C0123456789), not the channel name
+      type: string
+      default: C0123456789
+    message_limit:
+      description: Maximum number of messages to retrieve
+      type: integer
+      default: 200
+    output_file:
+      description: Path to write the dumped channel history to
+      type: path
+      default: $env:TEMP\T1213.005_slack_messages.json
+  executor:
+    command: |
+      $headers = @{ Authorization = "Bearer #{slack_token}" }
+      $uri = "https://slack.com/api/conversations.history?channel=#{slack_channel_id}&limit=#{message_limit}"
+      $response = Invoke-RestMethod -Uri $uri -Headers $headers -Method Get
+      $response | ConvertTo-Json -Depth 10 | Out-File -FilePath "#{output_file}" -Encoding utf8
+      Get-Content "#{output_file}"
+    cleanup_command: |
+      Remove-Item -Path "#{output_file}" -ErrorAction Ignore
+    name: powershell
+    elevation_required: false
+- name: Microsoft Teams - Dump channel messages via Microsoft Graph API (sh)
+  auto_generated_guid: e16e2398-187d-4b31-814c-2e8c0db0587a
+  description: |
+    Uses a Microsoft Graph OAuth access token to call the
+    `/teams/{team-id}/channels/{channel-id}/messages` endpoint and dump the message history of a target
+    Microsoft Teams channel to a local file.
+
+    An adversary holding a Graph token with the `ChannelMessage.Read.All` scope (for example obtained via an
+    over-permissioned application registration or a phished delegated grant) can read Teams conversations and
+    the sensitive data shared within them. Mapped to MITRE ATT&CK T1213.005.
+
+    Upon successful execution the channel messages are written to the file defined in `output_file` and printed
+    to the console.
+  supported_platforms:
+  - office-365
+  input_arguments:
+    graph_token:
+      description: Microsoft Graph access token with the ChannelMessage.Read.All scope
+      type: string
+      default:
+    team_id:
+      description: Target Microsoft Teams team (group) ID
+      type: string
+      default: 00000000-0000-0000-0000-000000000000
+    channel_id:
+      description: Target Teams channel ID (e.g. 19:abc...@thread.tacv2)
+      type: string
+      default: 19:00000000000000000000000000000000@thread.tacv2
+    output_file:
+      description: Path to write the dumped channel messages to
+      type: path
+      default: /tmp/T1213.005_teams_messages.json
+  dependencies:
+  - description: |
+      curl must be installed.
+    prereq_command: |
+      which curl
+    get_prereq_command: |
+      echo "Install curl using your package manager, e.g. 'sudo apt-get install -y curl' or 'brew install curl'"
+  dependency_executor_name: sh
+  executor:
+    command: |
+      curl -s -H "Authorization: Bearer #{graph_token}" \
+        "https://graph.microsoft.com/v1.0/teams/#{team_id}/channels/#{channel_id}/messages" \
+        -o "#{output_file}"
+      cat "#{output_file}"
+    cleanup_command: |
+      rm -f "#{output_file}"
+    name: sh
+    elevation_required: false
+- name: Microsoft Teams - Dump channel messages via Microsoft Graph API (PowerShell)
+  auto_generated_guid: 00aff48d-3dfd-4c6b-823e-03ffdab7e652
+  description: |
+    Uses a Microsoft Graph OAuth access token to call the
+    `/teams/{team-id}/channels/{channel-id}/messages` endpoint from PowerShell and dump the message history of
+    a target Microsoft Teams channel to a local file.
+
+    This is the cross-platform PowerShell equivalent of the sh-based Teams collection test. An adversary holding
+    a Graph token with the `ChannelMessage.Read.All` scope can stage this from any host with PowerShell.
+    Mapped to MITRE ATT&CK T1213.005.
+
+    Upon successful execution the channel messages are written to the file defined in `output_file` and printed
+    to the console.
+  supported_platforms:
+  - office-365
+  input_arguments:
+    graph_token:
+      description: Microsoft Graph access token with the ChannelMessage.Read.All scope
+      type: string
+      default:
+    team_id:
+      description: Target Microsoft Teams team (group) ID
+      type: string
+      default: 00000000-0000-0000-0000-000000000000
+    channel_id:
+      description: Target Teams channel ID (e.g. 19:abc...@thread.tacv2)
+      type: string
+      default: 19:00000000000000000000000000000000@thread.tacv2
+    output_file:
+      description: Path to write the dumped channel messages to
+      type: path
+      default: $env:TEMP\T1213.005_teams_messages.json
+  executor:
+    command: |
+      $headers = @{ Authorization = "Bearer #{graph_token}" }
+      $uri = "https://graph.microsoft.com/v1.0/teams/#{team_id}/channels/#{channel_id}/messages"
+      $response = Invoke-RestMethod -Uri $uri -Headers $headers -Method Get
+      $response | ConvertTo-Json -Depth 10 | Out-File -FilePath "#{output_file}" -Encoding utf8
+      Get-Content "#{output_file}"
+    cleanup_command: |
+      Remove-Item -Path "#{output_file}" -ErrorAction Ignore
+    name: powershell
+    elevation_required: false


### PR DESCRIPTION
# Add T1213.005 Data from Information Repositories: Messaging Applications (Slack & Teams API collection)

**Details:**

This PR adds a new technique directory `atomics/T1213.005/` covering **T1213.005 — Data from Information Repositories: Messaging Applications**, which currently has no atomic coverage in the repository.

The technique models an adversary using a stolen or over-permissioned API token to read message history directly from collaboration platforms (Slack, Microsoft Teams) via their REST APIs — bypassing the desktop/web client and the controls layered around interactive sign-in.

Four atomic tests are included, each pairing a SaaS data source with a cross-platform executor:

| # | Test | Platform | Executor | API |
|---|------|----------|----------|-----|
| 1 | Slack — Dump channel message history | `saas` | `sh` (curl) | `conversations.history` |
| 2 | Slack — Dump channel message history | `saas` | `powershell` | `conversations.history` |
| 3 | Microsoft Teams — Dump channel messages | `office-365` | `sh` (curl) | Graph `/teams/{id}/channels/{id}/messages` |
| 4 | Microsoft Teams — Dump channel messages | `office-365` | `powershell` | Graph `/teams/{id}/channels/{id}/messages` |

Each test:
- Takes the access token and target channel as `input_arguments` (token defaults left blank so the operator must supply their own), plus a `message_limit` and an `output_file`.
- Writes the retrieved messages to a local dump file and echoes them to the console on success.
- Includes a `cleanup_command` that deletes the dump file (`rm -f` / `Remove-Item -ErrorAction Ignore`).
- The `sh` tests declare a `curl` dependency with a `get_prereq_command`; the PowerShell tests use the built-in `Invoke-RestMethod`.

GUIDs were pre-generated and checked for uniqueness against `atomics/used_guids.txt`. The generated `T1213.005.md` and index entries are intentionally **not** included, as they are produced by the `generate-docs` workflow on merge to `master`.

**Security rationale:**

- **MITRE ATT&CK:** Directly implements the Collection sub-technique T1213.005, which had zero atomics. This closes a defensive testing gap for token-based SaaS messaging exfiltration.
- **Real-world relevance:** Slack/Graph tokens routinely leak through compromised endpoints, committed `.env` files, CI/CD secrets, and over-scoped OAuth/app registrations (CWE-522 Insufficiently Protected Credentials, CWE-798 Use of Hard-coded Credentials, CWE-200 Exposure of Sensitive Information). A token alone — no interactive auth, no MFA prompt — is sufficient to read entire channel histories, which frequently contain secrets, links to internal repositories, and PII.
- **Detection value:** The atomics generate observable, attributable telemetry — outbound requests to `slack.com/api/conversations.history` and `graph.microsoft.com/.../messages` carrying a `Bearer` token, followed by a local JSON dump — letting defenders validate detections for anomalous API-driven message collection (Slack audit logs / `ChannelMessage.Read.All` Graph access) rather than only client-side activity.

**Testing:**

Validated locally against the repository's own tooling (no live Slack/Teams tenant required to validate the spec):

- Parsed `atomics/T1213.005/T1213.005.yaml` through the repo's `atomic_red_team.models.Technique` pydantic model — all 4 tests parse, `test_number`s assigned correctly.
- Ran the repo's `atomic_red_team.validator.Validator` over the new directory (the same class invoked by `runner.py validate` in the `validate-atomics` CI workflow) — **no errors**.
- Confirmed every `input_arguments` key is referenced in a command/cleanup and every mustache key is defined (enforced by the model).
- Confirmed all four `auto_generated_guid` values are unique against `atomics/used_guids.txt`.

**Associated Issues:**

<!-- None; net-new coverage for T1213.005. -->
