### PR TITLE
Add T1546.017 - Udev Rules persistence (Event Triggered Execution)

### DIFF
--- a/atomics/T1546.017/T1546.017.yaml
+++ b/atomics/T1546.017/T1546.017.yaml
@@ -1,0 +1,51 @@
+attack_technique: T1546.017
+display_name: 'Event Triggered Execution: Udev Rules'
+atomic_tests:
+- name: Persistence via Udev Rule RUN+= Action
+  auto_generated_guid: 9de07d08-c099-4da7-a9f8-3ab4a626b764
+  description: |
+    Establishes persistence by writing a udev rule with a `RUN+=` action to `/etc/udev/rules.d/`.
+    The rule matches the always-present `/dev/null` device (`SUBSYSTEM=="mem", KERNEL=="null"`) on an
+    `add` event, so reloading the udev rules and re-triggering the device causes systemd-udevd to run
+    the payload as root. The payload writes the current user context to a marker file to demonstrate
+    execution. This mirrors the in-the-wild `sedexp` malware, which abused udev rules for stealthy
+    persistence. Requires a running systemd-udevd, which is standard on Linux.
+    See https://www.levelblue.com/blogs/spiderlabs-blog/unveiling-sedexp
+  supported_platforms:
+  - linux
+  input_arguments:
+    rule_file:
+      description: Path to the udev rule file that is created
+      type: path
+      default: /etc/udev/rules.d/70-art-udev-persistence.rules
+    marker_file:
+      description: Marker file written by the udev RUN+= payload to demonstrate execution
+      type: path
+      default: /tmp/art-udev-persistence.txt
+  dependency_executor_name: bash
+  dependencies:
+  - description: |
+      udevadm (systemd-udev) must be installed and systemd-udevd must be running.
+    prereq_command: |
+      if [ -x "$(command -v udevadm)" ]; then exit 0; else exit 1; fi
+    get_prereq_command: |
+      echo "Install udev (systemd-udev) and ensure the systemd-udevd service is running."; exit 1
+  executor:
+    command: |
+      mkdir -p "$(dirname #{rule_file})"
+      cat > "#{rule_file}" <<'EOF'
+      ACTION=="add", SUBSYSTEM=="mem", KERNEL=="null", RUN+="/bin/sh -c 'id > #{marker_file} 2>&1'"
+      EOF
+      udevadm control --reload-rules
+      udevadm trigger --action=add --subsystem-match=mem --sysname-match=null
+      udevadm settle
+      echo "Udev rule installed at #{rule_file}:"
+      cat "#{rule_file}"
+      echo "Marker file (proves the RUN+= payload executed):"
+      cat "#{marker_file}" 2>/dev/null || echo "Marker not created - is systemd-udevd running?"
+    cleanup_command: |
+      rm -f "#{rule_file}"
+      rm -f "#{marker_file}"
+      udevadm control --reload-rules 2>/dev/null
+    name: bash
+    elevation_required: true


### PR DESCRIPTION
**Details:**

This adds the first atomic test for **T1546.017 – Event Triggered Execution: Udev Rules**, a Linux persistence sub-technique added to ATT&CK in 2024 that currently has no coverage in the repo (no `atomics/T1546.017/` folder).

The atomic ("Persistence via Udev Rule RUN+= Action") establishes persistence the way the in-the-wild *sedexp* malware did:

- Writes a udev rule with a `RUN+=` action to `/etc/udev/rules.d/`.
- The rule matches the always-present `/dev/null` device (`SUBSYSTEM=="mem", KERNEL=="null"`) on an `add` event.
- `udevadm control --reload-rules` + `udevadm trigger --action=add --sysname-match=null` reload and re-fire the event, so `systemd-udevd` runs the payload **as root**.
- The payload writes the current user context (`id`) to a marker file so execution can be confirmed.

Rule path and marker file are parameterized via `input_arguments`; `elevation_required: true`; a `dependencies` block checks `udevadm` is present. `cleanup_command` removes the rule and marker and reloads the udev rules so the malicious rule no longer exists in the live ruleset.

**ATT&CK:** [T1546.017 – Event Triggered Execution: Udev Rules](https://attack.mitre.org/techniques/T1546/017/)

**Novelty / dedup:** No `atomics/T1546.017/` folder existed; grepping `atomics/` for `udevadm` / `RUN+=` / `rules.d` matched only auto-generated `Indexes/*` — no atomic exercised udev rules. No open or closed PR referenced udev or T1546.017.

**Source:** LevelBlue/Stroz Friedberg, ["Unveiling sedexp"](https://www.levelblue.com/blogs/spiderlabs-blog/unveiling-sedexp) (Aug 2024), documenting real-world udev-rule persistence.

**Testing:**

Runtime-tested end to end in Docker on two systemd/udev versions — **Debian 12 (udev 252)** and **Ubuntu 24.04 (udev 255)**. `systemd-udevd` was started, then the atomic's command and cleanup were run with default inputs:

```
===== RUN ATOMIC COMMAND (as root) =====
Udev rule installed at /etc/udev/rules.d/70-art-udev-persistence.rules:
ACTION=="add", SUBSYSTEM=="mem", KERNEL=="null", RUN+="/bin/sh -c 'id > /tmp/art-udev-persistence.txt 2>&1'"
Marker file (proves the RUN+= payload executed):
uid=0(root) gid=0(root) groups=0(root)
===== VERIFY CLEANUP (both should be GONE) =====
rule file:  GONE
marker file: GONE
```

- **Side effect observed:** marker created by `systemd-udevd` executing the `RUN+=` payload as root.
- **Cleanup verified:** rule + marker removed, udev rules reloaded.
- **Schema validation:** `python runner.py validate` → `Validation successful`.

On a normal Linux host `systemd-udevd` is already running, so the test runs natively; in a container it must be started first (`--privileged` + `systemd-udevd --daemon`), which the description and `dependencies` check call out.

**Associated Issues:**

N/A — new sub-technique coverage.
