### PR TITLE
Add atomic test for T1059.012 (Command and Scripting Interpreter: Hypervisor CLI)

### DIFF
--- a/atomics/T1059.012/T1059.012.yaml
+++ b/atomics/T1059.012/T1059.012.yaml
@@ -1,0 +1,51 @@
+attack_technique: T1059.012
+display_name: 'Command and Scripting Interpreter: Hypervisor CLI'
+atomic_tests:
+- name: Run a read only esxcli command over SSH
+  auto_generated_guid: 3d7a9e2b-6c4f-4e1a-8b3d-2a9f7c5e1d4b
+  description: |
+    ESXi servers have their own command line tools, like esxcli and vim-cmd.
+    Attackers can connect to an ESXi server over SSH and run these tools directly.
+    This is how real ransomware groups (like the ones behind the ESXiArgs attacks) find and stop virtual machines before they encrypt them.
+
+    This test only runs a read only command. It does not stop, delete, or change any virtual machine.
+    It just asks the ESXi server for its version number, the same way an attacker would check what they are working with.
+
+    You need a real ESXi server for this test, and SSH must be turned on for it.
+    This test will not work without one.
+
+    After the test runs, you should see the ESXi version printed on the screen.
+  supported_platforms:
+  - windows
+  dependencies:
+  - description: |
+      The SSH client built into Windows must be available.
+    prereq_command: |
+      if (Get-Command ssh.exe -ErrorAction SilentlyContinue) {
+          exit 0
+      } else {
+          exit 1
+      }
+    get_prereq_command: |
+      Write-Host "The Windows OpenSSH Client feature is missing. Turn it on with: Add-WindowsCapability -Online -Name OpenSSH.Client~~~~0.0.1.0"
+  input_arguments:
+    esxi_host:
+      description: IP address or hostname of the ESXi server used for this test
+      type: string
+      default: 192.168.1.10
+    esxi_user:
+      description: Username used to log in to the ESXi server
+      type: string
+      default: root
+    ssh_key_path:
+      description: Path to the SSH private key used to log in to the ESXi server
+      type: path
+      default: $env:USERPROFILE\.ssh\esxi_test_key
+    esxi_command:
+      description: The read only hypervisor CLI command that will be run on the ESXi server
+      type: string
+      default: esxcli system version get
+  executor:
+    command: |
+      ssh -o StrictHostKeyChecking=no -i "#{ssh_key_path}" #{esxi_user}@#{esxi_host} "#{esxi_command}"
+    name: powershell


### PR DESCRIPTION
## Summary
Adds a new atomic test for T1059.012 (Command and Scripting Interpreter: Hypervisor CLI). There was no existing test for this technique.

The test connects to a real ESXi host over SSH and runs one read only command (`esxcli system version get` by default, can be changed via input argument). It does not stop, delete, or change any virtual machine. This mirrors how real attacks (for example the ESXiArgs ransomware cases) use esxcli and vim-cmd over SSH to look at and later act on virtual machines, but this test only covers the read only recon step.

Requires a real ESXi host with SSH turned on. Host, user, SSH key path, and the command itself are all input arguments so it can point at a test lab host.

## Test plan
- [x] Validated the YAML loads correctly and matches the schema style used by other T1059.0xx tests.
- [ ] Not yet executed end to end against a live ESXi host. Testing and feedback welcome before merge.