### PR TITLE
Add Acronis Cyber Protect enumeration test to T1518.001

### DIFF
--- a/atomics/T1518.001/T1518.001.yaml
+++ b/atomics/T1518.001/T1518.001.yaml
@@ -152,6 +152,24 @@ atomic_tests:
       Get-NetFirewallRule | select DisplayName, Enabled, Description
     name: powershell 
     elevation_required: true
+- name: Security Software Discovery - Acronis Cyber Protect Enumeration
+  auto_generated_guid: 92da0596-bfa0-4088-a70d-09cb3523da5d
+  description: |
+    Enumerates processes and services associated with Acronis Cyber Protect (EDR/XDR + backup agent).
+
+    when sucessfully executed, the test displays whether the Acronis Cyber Protection Service, the
+    Cyber Protect agent (aakore), and the Active Protection anti-ransomware component are installed
+    and/or running.
+  supported_platforms:
+  - windows
+  executor:
+    command: |
+      tasklist.exe | findstr /i "cyber-protect-service aakore anti_ransomware_service"
+      sc.exe query AcronisCyberProtectionService
+      sc.exe query AcronisActiveProtectionService
+      powershell.exe -c "Get-Service | Where-Object {$_.DisplayName -like '*Acronis*'}"
+    name: command_prompt
+    elevation_required: true
 - name: Get Windows Defender exclusion settings using WMIC
   auto_generated_guid: e31564c8-4c60-40cd-a8f4-9261307e8336
   description: |


### PR DESCRIPTION
## Summary
`T1518.001` (Security Software Discovery) already includes vendor-specific enumeration for several EDR/AV products (Cylance, CrowdStrike `falcond`, Carbon Black, Sysmon, Windows Defender, etc.) but had no test for Acronis Cyber Protect. This adds one Windows test following the same style as the existing "AV Discovery via WMI" / "Windows Defender Enumeration" entries — checking for the Acronis Cyber Protection Service, the Cyber Protect agent (`aakore`), and the Active Protection anti-ransomware component via `tasklist`, `sc query`, and `Get-Service`.

This is pure discovery/enumeration (matching the technique's scope), not tampering.

## Test plan
- [x] YAML parses cleanly with PyYAML and the new entry's `auto_generated_guid` is unique within the file (checked against all existing GUIDs in `atomics/`)
- [x] Verified via `git diff upstream/master HEAD --stat` that only `atomics/T1518.001/T1518.001.yaml` is touched (this environment lacks `git-lfs`, which locally shows unrelated binary payloads elsewhere in the repo as deleted in the working tree — confirmed those are not part of this commit)
- [ ] Not run through the full `poetry`-based validation suite locally (no Python/poetry toolchain in this environment); command syntax matches the existing entries in this same file