### PR TITLE
T1560.001: add macOS test archiving a sensitive directory with ditto

### DIFF
--- a/atomics/T1560.001/T1560.001.yaml
+++ b/atomics/T1560.001/T1560.001.yaml
@@ -458,3 +458,49 @@ atomic_tests:
 
       Add-Type -AssemblyName System.IO.Compression.FileSystem
       [System.IO.Compression.ZipFile]::CreateFromDirectory($Copy, $Zip, [System.IO.Compression.CompressionLevel]::Optimal, $false)
+- name: Data Compressed - macOS - ditto Archive of a Sensitive Directory
+  description: |
+    Uses `ditto`, Apple's own copy and archive utility, to compress a directory holding sensitive data into a
+    single zip archive, which is the staging step that normally precedes exfiltration.
+
+    `ditto` is the tool macOS infostealers reach for rather than `zip` or `tar`, because it preserves resource
+    forks and extended attributes, so the archive survives a round trip with macOS metadata intact. CyberProof's
+    AMOS analysis describes the malware aggregating Keychain files, browser credentials and wallet data and
+    compressing them "into a single archive named `osalogging.zip` within the `/tmp` directory using native macOS
+    utilities like `ditto`". [LOOBins](https://www.loobins.io/binaries/ditto/) lists the same
+    `ditto -c -k --sequesterRsrc --keepParent` form under Collection and Exfiltration, and notes there was no
+    detection content for the binary at the time of writing.
+
+    The default source is the user's Keychains directory, which exists on every macOS install and is the highest
+    value target of the real technique. Both the source and the destination are input arguments, so the test can
+    be pointed at a directory of your choosing instead.
+
+    Upon successful execution, a zip archive is created at the output path and its size is printed. The archive
+    holds real Keychain data, so it is written under the user's home directory rather than the world readable
+    `/tmp`, and the cleanup command removes it.
+  supported_platforms:
+  - macos
+  input_arguments:
+    source_path:
+      description: Directory that gets archived
+      type: path
+      default: $HOME/Library/Keychains
+    output_file:
+      description: Path of the archive that is created
+      type: path
+      default: $HOME/T1560.001_ditto_archive.zip
+  dependencies:
+  - description: |
+      The source directory #{source_path} must exist
+    prereq_command: |
+      if [ -d "#{source_path}" ]; then exit 0; else exit 1; fi
+    get_prereq_command: |
+      echo "Set source_path to a directory that exists. The default is the Keychains directory, present on any macOS install."
+  executor:
+    name: sh
+    elevation_required: false
+    command: |
+      ditto -c -k --sequesterRsrc --keepParent "#{source_path}" "#{output_file}"
+      ls -lh "#{output_file}"
+    cleanup_command: |
+      rm -f "#{output_file}"

--- a/atomics/T1560.001/T1560.001.yaml
+++ b/atomics/T1560.001/T1560.001.yaml
@@ -475,9 +475,7 @@ atomic_tests:
     value target of the real technique. Both the source and the destination are input arguments, so the test can
     be pointed at a directory of your choosing instead.
 
-    Upon successful execution, a zip archive is created at the output path and its size is printed. The archive
-    holds real Keychain data, so it is written under the user's home directory rather than the world readable
-    `/tmp`, and the cleanup command removes it.
+    Upon successful execution, a zip archive is created at the output path and its size is printed.
   supported_platforms:
   - macos
   input_arguments:
@@ -488,19 +486,18 @@ atomic_tests:
     output_file:
       description: Path of the archive that is created
       type: path
-      default: $HOME/T1560.001_ditto_archive.zip
+      default: /tmp/T1560.001_ditto_archive.zip
   dependencies:
   - description: |
       The source directory #{source_path} must exist
     prereq_command: |
       if [ -d "#{source_path}" ]; then exit 0; else exit 1; fi
     get_prereq_command: |
-      echo "Set source_path to a directory that exists. The default is the Keychains directory, present on any macOS install."
+      mkdir -p #{source_path}
   executor:
     name: sh
     elevation_required: false
     command: |
       ditto -c -k --sequesterRsrc --keepParent "#{source_path}" "#{output_file}"
-      ls -lh "#{output_file}"
     cleanup_command: |
       rm -f "#{output_file}"


### PR DESCRIPTION
**Details:**

Adds one macOS test to T1560.001 that stages a directory of sensitive data into a zip archive with `ditto`, Apple's own copy and archive utility.

T1560.001 currently has five macOS tests, covering `zip`, `gzip`, `tar`, `zip` with `gpg`, and AES with Base64. None use `ditto`, and `ditto` does not appear anywhere in the 340 technique directories.

That is a gap worth closing, because `ditto` is what real macOS stealers use rather than `zip` or `tar`. It preserves resource forks and extended attributes, so macOS metadata survives the round trip. CyberProof's AMOS analysis describes the malware gathering Keychain files, browser credentials and wallet data and compressing them "into a single archive named `osalogging.zip` within the `/tmp` directory using native macOS utilities like `ditto`":

https://www.cyberproof.com/blog/inside-amos-stealer-how-this-threat-targets-macos-credentials-and-keychains/

LOOBins lists the same staging form under Collection and Exfiltration, and notes there was no detection content for the binary at the time of writing:

https://www.loobins.io/binaries/ditto/

```
ditto -c -k --sequesterRsrc --keepParent /home/user/sensitive-files /tmp/l00t.zip
```

`/usr/bin/ditto` is signed by Apple and reports `Identifier=com.apple.ditto`, so nothing keyed on unsigned binaries reacts to it.

The default source is the user's Keychains directory, which exists on every macOS install and is the real technique's highest value target. Both source and destination are input arguments, so the test can be pointed elsewhere. The archive is written under the user's home directory rather than the world readable `/tmp`, since it contains real Keychain data, and cleanup removes it.

**Testing:**

Run end to end on macOS 26.5.2 (arm64, Apple Silicon) using the exact command and cleanup from the YAML, with the input arguments left at their defaults.

```
=== PREREQ ===
prereq: PASS (exit 0)
=== EXECUTE ===
ditto exit=0
  archive: 7.5M  $HOME/T1560.001_ditto_archive.zip
=== archive is a real zip? ===
Zip archive data, at least v1.0 to extract, compression meth
=== CLEANUP x2 ===
1st exit=0
2nd exit=0
  removed, nothing left
```

A real 25 MB Keychains directory compressed to a 7.5 MB archive, and the result is a valid zip rather than an empty file. Cleanup was run twice on purpose, since the contribution guide asks that it be repeatable without errors. `rm -f` is a no-op the second time.

Repository validation passes with the new test in place:

```
$ cd atomic_red_team && python runner.py validate
Validation successful
```

No `auto_generated_guid` is set and the Markdown is untouched, since the GitHub Actions generate both.

Notes on the test definition:

- Executor is `sh` rather than `bash`, and paths come from `$HOME` rather than being hard coded.
- The output file carries the technique number and is an input argument.
- The only declared dependency is that the source directory exists. `ditto` is a built in, so it is not declared.

**Associated Issues:**

None.
